### PR TITLE
Updated jj completer for jj v0.15.1

### DIFF
--- a/completers/jj_completer/cmd/config_list.go
+++ b/completers/jj_completer/cmd/config_list.go
@@ -18,6 +18,7 @@ func init() {
 
 	config_listCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	config_listCmd.Flags().Bool("include-defaults", false, "Whether to explicitly include built-in default values in the list")
+	config_listCmd.Flags().StringP("template", "T", "", "Render each variable using the given template")
 	configCmd.AddCommand(config_listCmd)
 
 	carapace.Gen(config_listCmd).PositionalCompletion(

--- a/completers/jj_completer/cmd/diff.go
+++ b/completers/jj_completer/cmd/diff.go
@@ -16,6 +16,7 @@ var diffCmd = &cobra.Command{
 func init() {
 	carapace.Gen(diffCmd).Standalone()
 
+	diffCmd.Flags().Int("context", 3, "Number of lines of context to show")
 	diffCmd.Flags().Bool("color-words", false, "Show a word-level diff with changes indicated only by color")
 	diffCmd.Flags().String("from", "", "Show changes from this revision")
 	diffCmd.Flags().Bool("git", false, "Show a Git-format diff")

--- a/completers/jj_completer/cmd/git_init.go
+++ b/completers/jj_completer/cmd/git_init.go
@@ -19,6 +19,10 @@ func init() {
 	git_initCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	gitCmd.AddCommand(git_initCmd)
 
+	carapace.Gen(git_initCmd).FlagCompletion(carapace.ActionMap{
+		"git-repo": carapace.ActionFiles(),
+	})
+
 	carapace.Gen(git_initCmd).PositionalCompletion(
 		carapace.ActionDirectories(),
 	)

--- a/completers/jj_completer/cmd/git_init.go
+++ b/completers/jj_completer/cmd/git_init.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var git_initCmd = &cobra.Command{
+	Use:   "init [OPTIONS] [DESTINATION]",
+	Short: "Create a new Git backed repo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(git_initCmd).Standalone()
+
+	git_initCmd.Flags().Bool("colocate", false, "Specifies that the `jj` repo should also be a valid `git` repo")
+	git_initCmd.Flags().String("git-repo", "", "Specifies a path to an existing git repository to be used to back the new `jj` repo")
+	git_initCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	gitCmd.AddCommand(git_initCmd)
+
+	carapace.Gen(git_initCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/jj_completer/cmd/interdiff.go
+++ b/completers/jj_completer/cmd/interdiff.go
@@ -16,6 +16,7 @@ var interdiffCmd = &cobra.Command{
 func init() {
 	carapace.Gen(interdiffCmd).Standalone()
 
+	interdiffCmd.Flags().Int("context", 3, "Number of lines of context to show")
 	interdiffCmd.Flags().Bool("color-words", false, "Show a word-level diff with changes indicated only by color")
 	interdiffCmd.Flags().String("from", "@", "Show changes from this revision")
 	interdiffCmd.Flags().Bool("git", false, "Show a Git-format diff")


### PR DESCRIPTION
# Changes
* added subcommand for `jj git init`
* added --template/-T for `jj config list`
* added --context for `jj diff` and `jj interdiff`

I did not add actions for completing the template language since it seemed out-of-scope for the project (it seems to be a DSL with a much higher complexity level than the revsets grammer, more comparable to awk scripts)