### PR TITLE
Updated jujutsu completer to jj v0.16.0

### DIFF
--- a/completers/jj_completer/cmd/branch_list.go
+++ b/completers/jj_completer/cmd/branch_list.go
@@ -16,9 +16,13 @@ var branch_listCmd = &cobra.Command{
 func init() {
 	carapace.Gen(branch_listCmd).Standalone()
 
-	branch_listCmd.Flags().BoolP("all", "a", false, "Show all tracking and non-tracking remote branches including the ones whose targets are synchronized with the local branches")
+	branch_listCmd.Flags().BoolP("all-remotes", "a", false, "Show all tracking and non-tracking remote branches including the ones whose targets are synchronized with the local branches")
+	branch_listCmd.Flags().BoolP("conflicted", "c", false, "Show only conflicted branches")
 	branch_listCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	branch_listCmd.Flags().StringSliceP("revisions", "r", []string{}, "Show branches whose local targets are in the given revisions")
+
+	branch_listCmd.MarkFlagsMutuallyExclusive("all-remotes", "conflicted")
+
 	branchCmd.AddCommand(branch_listCmd)
 
 	carapace.Gen(branch_listCmd).FlagCompletion(carapace.ActionMap{

--- a/completers/jj_completer/cmd/root.go
+++ b/completers/jj_completer/cmd/root.go
@@ -28,9 +28,12 @@ func init() {
 	rootCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	rootCmd.PersistentFlags().Bool("ignore-working-copy", false, "Don't snapshot the working copy, and don't update it")
 	rootCmd.PersistentFlags().Bool("no-pager", false, "Disable the pager")
+	rootCmd.PersistentFlags().Bool("quiet", false, "Silence non-primary output")
 	rootCmd.PersistentFlags().StringP("repository", "R", "", "Path to repository to operate on")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose logging")
 	rootCmd.Flags().BoolP("version", "V", false, "Print version")
+
+	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"at-operation": carapace.ActionValues(), // TODO

--- a/completers/jj_completer/cmd/sparse_edit.go
+++ b/completers/jj_completer/cmd/sparse_edit.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var sparse_editCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Start an editor to update the patterns that are present in the working copy",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(sparse_editCmd).Standalone()
+
+	sparse_editCmd.Flags().BoolP("help", "h", false, "Print help (see a summary with '-h')")
+	sparseCmd.AddCommand(sparse_editCmd)
+}

--- a/completers/jj_completer/cmd/sparse_reset.go
+++ b/completers/jj_completer/cmd/sparse_reset.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var sparse_resetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset the patterns to include all files in the working copy",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(sparse_resetCmd).Standalone()
+
+	sparse_resetCmd.Flags().BoolP("help", "h", false, "Print help (see a summary with '-h')")
+	sparseCmd.AddCommand(sparse_resetCmd)
+}

--- a/completers/jj_completer/cmd/sparse_set.go
+++ b/completers/jj_completer/cmd/sparse_set.go
@@ -16,9 +16,7 @@ func init() {
 
 	sparse_setCmd.Flags().StringSlice("add", []string{}, "Patterns to add to the working copy")
 	sparse_setCmd.Flags().Bool("clear", false, "Include no files in the working copy (combine with --add)")
-	sparse_setCmd.Flags().Bool("edit", false, "Edit patterns with $EDITOR")
 	sparse_setCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	sparse_setCmd.Flags().StringSlice("remove", []string{}, "Patterns to remove from the working copy")
-	sparse_setCmd.Flags().Bool("reset", false, "Include all files in the working copy")
 	sparseCmd.AddCommand(sparse_setCmd)
 }

--- a/completers/jj_completer/cmd/split.go
+++ b/completers/jj_completer/cmd/split.go
@@ -18,6 +18,7 @@ func init() {
 	splitCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	splitCmd.Flags().BoolP("interactive", "i", false, "Interactively choose which parts to split. This is the default if no paths are provided")
 	splitCmd.Flags().StringP("revision", "r", "", "The revision to split")
+	splitCmd.Flags().BoolP("siblings", "s", false, "Split the revision into two siblings instead of parent and child")
 	rootCmd.AddCommand(splitCmd)
 
 	carapace.Gen(splitCmd).FlagCompletion(carapace.ActionMap{

--- a/completers/jj_completer/cmd/squash.go
+++ b/completers/jj_completer/cmd/squash.go
@@ -16,14 +16,25 @@ var squashCmd = &cobra.Command{
 func init() {
 	carapace.Gen(squashCmd).Standalone()
 
+	squashCmd.Flags().String("from", "@", "Revision to squash from")
 	squashCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	squashCmd.Flags().BoolP("interactive", "i", false, "Interactively choose which parts to squash")
+	squashCmd.Flags().String("into", "@", "Revision to squash into")
 	squashCmd.Flags().StringSliceP("message", "m", []string{}, "The description to use for squashed revision (don't open editor)")
-	squashCmd.Flags().StringP("revision", "r", "@", "")
+	squashCmd.Flags().StringP("revision", "r", "@", "Revision to squash into its parent")
+	squashCmd.Flags().String("to", "@", "Revision to squash into (alias for --into)")
+	squashCmd.Flags().String("tool", "", "Specify diff editor to use (implies --interactive)")
+
+	squashCmd.MarkFlagsMutuallyExclusive("revision", "into", "to")
+	squashCmd.MarkFlagsMutuallyExclusive("revision", "from")
+
 	rootCmd.AddCommand(squashCmd)
 
 	carapace.Gen(squashCmd).FlagCompletion(carapace.ActionMap{
+		"from":     jj.ActionRevs(jj.RevOption{}.Default()),
+		"into":     jj.ActionRevs(jj.RevOption{}.Default()),
 		"revision": jj.ActionRevs(jj.RevOption{}.Default()),
+		"to":       jj.ActionRevs(jj.RevOption{}.Default()),
 	})
 
 	carapace.Gen(squashCmd).PositionalAnyCompletion(


### PR DESCRIPTION
- --from, --into, and --to added to `jj squash`
- `jj sparse set [--edit/--reset]` have been moved to subcommands `jj sparse [edit|reset]`
- --conflicted added to `jj branch list`
- --all renamed --all-remotes for `jj branch list`
- --siblings added to `jj split`
- global `--quiet` flag added