### PR TITLE
jj_completer: Updated completer for v0.17.0

### DIFF
--- a/completers/jj_completer/cmd/rebase.go
+++ b/completers/jj_completer/cmd/rebase.go
@@ -15,10 +15,14 @@ var rebaseCmd = &cobra.Command{
 func init() {
 	carapace.Gen(rebaseCmd).Standalone()
 
+	rebaseCmd.Flags().StringArray("after", []string{}, "Alias for `--insert-after`")
+	rebaseCmd.Flags().StringArray("before", []string{}, "Alias for `--insert-before`")
 	rebaseCmd.Flags().StringSliceP("branch", "b", []string{}, "Rebase the whole branch relative to destination's ancestors (can be repeated)")
 	rebaseCmd.Flags().StringSliceP("destination", "d", []string{}, "The revision(s) to rebase onto (can be repeated to create a merge commit)")
 	rebaseCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	rebaseCmd.Flags().StringP("revision", "r", "", "Rebase only this revision, rebasing descendants onto this revision's parent(s)")
+	rebaseCmd.Flags().StringArrayP("insert-after", "A", []string{}, "Revision(s) to insert after")
+	rebaseCmd.Flags().StringArrayP("insert-before", "B", []string{}, "Revision(s) to insert before")
+	rebaseCmd.Flags().StringP("revisions", "r", "", "Rebase only this revision, rebasing descendants onto this revision's parent(s)")
 	rebaseCmd.Flags().StringSliceP("source", "s", []string{}, "Rebase specified revision(s) together their tree of descendants (can be repeated)")
 	rebaseCmd.MarkFlagRequired("destination")
 	rootCmd.AddCommand(rebaseCmd)
@@ -26,7 +30,7 @@ func init() {
 	carapace.Gen(rebaseCmd).FlagCompletion(carapace.ActionMap{
 		"branch":      jj.ActionRevs(jj.RevOption{LocalBranches: true, RemoteBranches: true, Tags: true}),
 		"destination": jj.ActionRevs(jj.RevOption{}.Default()),
-		"revision":    jj.ActionRevs(jj.RevOption{}.Default()),
+		"revisions":   jj.ActionRevs(jj.RevOption{}.Default()),
 		"source":      jj.ActionRevs(jj.RevOption{}.Default()),
 	})
 }

--- a/completers/jj_completer/cmd/root.go
+++ b/completers/jj_completer/cmd/root.go
@@ -26,6 +26,7 @@ func init() {
 	rootCmd.PersistentFlags().String("color", "", "When to colorize output (always, never, auto)")
 	rootCmd.PersistentFlags().StringSlice("config-toml", []string{}, "Additional configuration options (can be repeated)")
 	rootCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	rootCmd.PersistentFlags().Bool("ignore-immutable", false, "Allow rewriting of immutable commits")
 	rootCmd.PersistentFlags().Bool("ignore-working-copy", false, "Don't snapshot the working copy, and don't update it")
 	rootCmd.PersistentFlags().Bool("no-pager", false, "Disable the pager")
 	rootCmd.PersistentFlags().Bool("quiet", false, "Silence non-primary output")

--- a/completers/jj_completer/cmd/squash.go
+++ b/completers/jj_completer/cmd/squash.go
@@ -24,6 +24,7 @@ func init() {
 	squashCmd.Flags().StringP("revision", "r", "@", "Revision to squash into its parent")
 	squashCmd.Flags().String("to", "@", "Revision to squash into (alias for --into)")
 	squashCmd.Flags().String("tool", "", "Specify diff editor to use (implies --interactive)")
+	squashCmd.Flags().BoolP("use-destination-message", "u", false, "Use the description of the destination revision for the new squashed revision")
 
 	squashCmd.MarkFlagsMutuallyExclusive("revision", "into", "to")
 	squashCmd.MarkFlagsMutuallyExclusive("revision", "from")

--- a/completers/jj_completer/cmd/status.go
+++ b/completers/jj_completer/cmd/status.go
@@ -16,5 +16,8 @@ func init() {
 	carapace.Gen(statusCmd).Standalone()
 
 	statusCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+
+	carapace.Gen(statusCmd).PositionalAnyCompletion(carapace.ActionFiles())
+
 	rootCmd.AddCommand(statusCmd)
 }


### PR DESCRIPTION
	- added `--insert-after` and `--insert-before` to `jj rebase`
	- renamed `--revision` to `--revisions` in `jj rebase`
	- Added global flag `--ignore-immutable`
	- `jj status` now accepts any number of paths as positional arguments
	- added `--use-destination-message` to `jj squash`