### PR TITLE
jj: Updated completions to v0.18.0

### DIFF
--- a/completers/jj_completer/cmd/branch_list.go
+++ b/completers/jj_completer/cmd/branch_list.go
@@ -20,6 +20,7 @@ func init() {
 	branch_listCmd.Flags().BoolP("conflicted", "c", false, "Show only conflicted branches")
 	branch_listCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	branch_listCmd.Flags().StringSliceP("revisions", "r", []string{}, "Show branches whose local targets are in the given revisions")
+	branch_listCmd.Flags().StringP("template", "T", "", "Render each branch using the given template")
 
 	branch_listCmd.MarkFlagsMutuallyExclusive("all-remotes", "conflicted")
 

--- a/completers/jj_completer/cmd/fix.go
+++ b/completers/jj_completer/cmd/fix.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var fixCmd = &cobra.Command{
+	Use:   "fix [OPTIONS]",
+	Short: "Update files with formatting fixes or other changes",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(fixCmd).Standalone()
+
+	fixCmd.Flags().StringSliceP("source", "s", nil, "Fix files in specified revision(s) and their descendants")
+	rootCmd.AddCommand(fixCmd)
+
+	carapace.Gen(fixCmd).FlagCompletion(carapace.ActionMap{
+		"source": jj.ActionRevSets(jj.RevOption{}.Default()),
+	})
+}

--- a/completers/jj_completer/cmd/git_push.go
+++ b/completers/jj_completer/cmd/git_push.go
@@ -16,6 +16,7 @@ func init() {
 	carapace.Gen(git_pushCmd).Standalone()
 
 	git_pushCmd.Flags().Bool("all", false, "Push all branches (including deleted branches)")
+	git_pushCmd.Flags().Bool("allow-empty-description", false, "Allow commits with empty description messages to be pushed")
 	git_pushCmd.Flags().StringSliceP("branch", "b", []string{}, "Push only this branch (can be repeated)")
 	git_pushCmd.Flags().StringSliceP("change", "c", []string{}, "Push this commit by creating a branch based on its change ID (can be repeated)")
 	git_pushCmd.Flags().Bool("deleted", false, "Push all deleted branches")

--- a/completers/jj_completer/cmd/new.go
+++ b/completers/jj_completer/cmd/new.go
@@ -16,11 +16,15 @@ func init() {
 	carapace.Gen(newCmd).Standalone()
 
 	newCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	newCmd.Flags().BoolP("insert-after", "A", false, "Insert the new change between the target commit(s) and their children")
-	newCmd.Flags().BoolP("insert-before", "B", false, "Insert the new change between the target commit(s) and their parents")
+	newCmd.Flags().StringP("insert-after", "A", "", "Insert the new change between the target commit(s) and their children")
+	newCmd.Flags().StringP("insert-before", "B", "", "Insert the new change between the target commit(s) and their parents")
 	newCmd.Flags().StringSliceP("message", "m", []string{}, "The change description to use")
 	rootCmd.AddCommand(newCmd)
 
+	carapace.Gen(newCmd).FlagCompletion(carapace.ActionMap{
+		"insert-after":  jj.ActionRevs(jj.RevOption{}.Default()).FilterArgs(),
+		"insert-before": jj.ActionRevs(jj.RevOption{}.Default()).FilterArgs(),
+	})
 	carapace.Gen(newCmd).PositionalAnyCompletion(
 		jj.ActionRevs(jj.RevOption{}.Default()).FilterArgs(),
 	)

--- a/completers/jj_completer/cmd/tag.go
+++ b/completers/jj_completer/cmd/tag.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var tagCmd = &cobra.Command{
+	Use:   "tag [OPTIONS] <COMMAND>",
+	Short: "Manage Tags",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(tagCmd).Standalone()
+
+	rootCmd.AddCommand(tagCmd)
+}

--- a/completers/jj_completer/cmd/tag_help.go
+++ b/completers/jj_completer/cmd/tag_help.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var tag_helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Print this message or the help of given subcommand(s)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(tag_helpCmd).Standalone()
+
+	tagCmd.AddCommand(tag_helpCmd)
+}

--- a/completers/jj_completer/cmd/tag_list.go
+++ b/completers/jj_completer/cmd/tag_list.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var tag_listCmd = &cobra.Command{
+	Use:   "list [OPTIONS] [NAMES]...",
+	Short: "List tags",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(tag_listCmd).Standalone()
+
+	tag_listCmd.Flags().StringP("template", "T", "", "Render each tag using the given template")
+	tagCmd.AddCommand(tag_listCmd)
+
+	carapace.Gen(tag_listCmd).PositionalAnyCompletion(
+		jj.ActionTags(),
+	)
+}

--- a/pkg/actions/tools/jj/rev.go
+++ b/pkg/actions/tools/jj/rev.go
@@ -101,5 +101,8 @@ func ActionRevSetFunctions() carapace.Action {
 		"file", "Commits modifying one of the paths specified",
 		"conflict", "Commits with conflicts",
 		"present", "Same as x, but evaluated to none() if any of the commits in x doesn't exist",
+		"reachable", "All commits reachable from srcs within domain",
+		"mutable", "All commits that jj does not treat as immutable (same as ~immutable())",
+		"immutable", "All commits that jj treats as immutable (same as (immutable_heads() | root()))",
 	).Tag("revset functions")
 }


### PR DESCRIPTION
	- Added ``-T/--template` flags to `jj branch list`
	- Added completions for `jj tag`
	- `--insert-after` and `--insert-before` on `jj new` now take revisions
	- Added `--allow-empty-description` flag to `jj git push`
	- Added new revsets `mutable()`, `immutable()`, and `reachable(srcs, domain)`