### PR TITLE
jj_completer: updated for jj v0.19.0

### DIFF
--- a/completers/jj_completer/cmd/branch_move.go
+++ b/completers/jj_completer/cmd/branch_move.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var branch_moveCmd = &cobra.Command{
+	Use:     "move [OPTIONS] <--from <REVISIONS>|NAME>",
+	Short:   "Move existing branches to target revision",
+	Aliases: []string{"s"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(branch_moveCmd).Standalone()
+
+	branch_moveCmd.Flags().BoolP("allow-backwards", "B", false, "Allow moving the branch backwards or sideways")
+	branch_moveCmd.Flags().String("from", "@", "Move part of this change into the destination")
+	branch_moveCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	branch_moveCmd.Flags().String("to", "@", "Move part of the source into this change")
+	branchCmd.AddCommand(branch_moveCmd)
+
+	carapace.Gen(branch_moveCmd).FlagCompletion(carapace.ActionMap{
+		"from": jj.ActionRevs(jj.RevOption{}.Default()),
+		"to":   jj.ActionRevs(jj.RevOption{}.Default()),
+	})
+
+	carapace.Gen(branch_moveCmd).PositionalAnyCompletion(
+		jj.ActionLocalBranches().FilterArgs(),
+	)
+}

--- a/completers/jj_completer/cmd/commit.go
+++ b/completers/jj_completer/cmd/commit.go
@@ -19,6 +19,7 @@ func init() {
 	commitCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	commitCmd.Flags().BoolP("interactive", "i", false, "Interactively choose which changes to include in the first commit")
 	commitCmd.Flags().StringSliceP("message", "m", []string{}, "The change description to use (don't open editor)")
+	commitCmd.Flags().Bool("reset-author", false, "Reset the author to the configured user")
 	rootCmd.AddCommand(commitCmd)
 
 	carapace.Gen(commitCmd).PositionalAnyCompletion(

--- a/completers/jj_completer/cmd/diff.go
+++ b/completers/jj_completer/cmd/diff.go
@@ -21,6 +21,7 @@ func init() {
 	diffCmd.Flags().String("from", "", "Show changes from this revision")
 	diffCmd.Flags().Bool("git", false, "Show a Git-format diff")
 	diffCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	diffCmd.Flags().Bool("name-only", false, "For each path, show only its path")
 	diffCmd.Flags().StringP("revision", "r", "", "Show changes in this revision, compared to its parent(s)")
 	diffCmd.Flags().Bool("stat", false, "Show a histogram of the changes")
 	diffCmd.Flags().BoolP("summary", "s", false, "For each path, show only whether it was modified, added, or removed")
@@ -28,6 +29,8 @@ func init() {
 	diffCmd.Flags().String("tool", "", "Generate diff by external command")
 	diffCmd.Flags().Bool("types", false, "For each path, show only its type before and after")
 	rootCmd.AddCommand(diffCmd)
+
+	diffCmd.MarkFlagsMutuallyExclusive("name-only", "summary")
 
 	carapace.Gen(diffCmd).FlagCompletion(carapace.ActionMap{
 		"from":     jj.ActionRevs(jj.RevOption{}.Default()),

--- a/completers/jj_completer/cmd/file.go
+++ b/completers/jj_completer/cmd/file.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var fileCmd = &cobra.Command{
+	Use:   "file",
+	Short: "File operations",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(fileCmd).Standalone()
+
+	fileCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	rootCmd.AddCommand(fileCmd)
+}

--- a/completers/jj_completer/cmd/file_chmod.go
+++ b/completers/jj_completer/cmd/file_chmod.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var file_chmodCmd = &cobra.Command{
+	Use:   "chmod [OPTIONS] <MODE> <PATHS>...",
+	Short: "Sets or removes the executable bit for paths in the repo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(file_chmodCmd).Standalone()
+
+	file_chmodCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	file_chmodCmd.Flags().StringP("revision", "r", "", "The revision to update")
+	fileCmd.AddCommand(file_chmodCmd)
+
+	carapace.Gen(file_chmodCmd).FlagCompletion(carapace.ActionMap{
+		"revision": jj.ActionRevs(jj.RevOption{}.Default()),
+	})
+
+	carapace.Gen(file_chmodCmd).PositionalCompletion(
+		carapace.ActionStyledValuesDescribed(
+			"n", "normal", style.Default,
+			"x", "executable", style.Yellow,
+		),
+	)
+
+	carapace.Gen(file_chmodCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return jj.ActionRevFiles(file_chmodCmd.Flag("revision").Value.String())
+		}),
+	)
+}

--- a/completers/jj_completer/cmd/file_help.go
+++ b/completers/jj_completer/cmd/file_help.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var file_helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Print this message or the help of the given subcommand(s)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(file_helpCmd).Standalone()
+
+	fileCmd.AddCommand(file_helpCmd)
+
+	carapace.Gen(file_helpCmd).PositionalAnyCompletion(
+		carapace.ActionCommands(utilCmd),
+	)
+}

--- a/completers/jj_completer/cmd/file_list.go
+++ b/completers/jj_completer/cmd/file_list.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var file_listCmd = &cobra.Command{
+	Use:   "files [OPTIONS] [PATHS]...",
+	Short: "List files in a revision",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(file_listCmd).Standalone()
+
+	file_listCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	file_listCmd.Flags().StringP("revision", "r", "@", "The revision to list files in")
+	fileCmd.AddCommand(file_listCmd)
+
+	carapace.Gen(file_listCmd).FlagCompletion(carapace.ActionMap{
+		"revision": jj.ActionRevs(jj.RevOption{}.Default()),
+	})
+
+	carapace.Gen(file_listCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return jj.ActionRevFiles(file_listCmd.Flag("revision").Value.String())
+		}),
+	)
+}

--- a/completers/jj_completer/cmd/file_show.go
+++ b/completers/jj_completer/cmd/file_show.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var file_showCmd = &cobra.Command{
+	Use:     "show [OPTIONS] <PATH>",
+	Short:   "Print contents of a file in a revision",
+	Aliases: []string{},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(file_showCmd).Standalone()
+
+	file_showCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	file_showCmd.Flags().StringP("revision", "r", "", "The revision to get the file contents from")
+	fileCmd.AddCommand(file_showCmd)
+
+	carapace.Gen(file_showCmd).FlagCompletion(carapace.ActionMap{
+		"revision": jj.ActionRevs(jj.RevOption{}.Default()),
+	})
+
+	carapace.Gen(file_showCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return jj.ActionRevFiles(file_showCmd.Flag("revision").Value.String())
+		}),
+	)
+}

--- a/completers/jj_completer/cmd/git_remote_add.go
+++ b/completers/jj_completer/cmd/git_remote_add.go
@@ -8,7 +8,7 @@ import (
 )
 
 var git_remote_addCmd = &cobra.Command{
-	Use:   "add [OPTIONS] <REMOTE> <URL",
+	Use:   "add [OPTIONS] <REMOTE> <URL>",
 	Short: "Add a Git remote",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }

--- a/completers/jj_completer/cmd/git_remote_setUrl.go
+++ b/completers/jj_completer/cmd/git_remote_setUrl.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/git"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var git_remote_setUrlCmd = &cobra.Command{
+	Use:   "set-url [OPTIONS] <REMOTE> <URL>",
+	Short: "Set the URL of a Git remote",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(git_remote_setUrlCmd).Standalone()
+
+	git_remote_setUrlCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	git_remoteCmd.AddCommand(git_remote_setUrlCmd)
+
+	carapace.Gen(git_remote_setUrlCmd).PositionalCompletion(
+		jj.ActionRemotes(),
+		git.ActionRepositorySearch(git.SearchOpts{}.Default()),
+	)
+}

--- a/completers/jj_completer/cmd/log.go
+++ b/completers/jj_completer/cmd/log.go
@@ -19,7 +19,8 @@ func init() {
 	logCmd.Flags().Bool("color-words", false, "Show a word-level diff with changes indicated only by color")
 	logCmd.Flags().Bool("git", false, "Show a Git-format diff")
 	logCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	logCmd.Flags().StringP("limit", "l", "", "Limit number of revisions to show")
+	logCmd.Flags().StringP("limit", "n", "", "Limit number of revisions to show")
+	logCmd.Flags().StringS("limit-old-shorthand", "l", "", "Limit number of revisions to show")
 	logCmd.Flags().Bool("no-graph", false, "Don't show the graph, show a flat list of revisions")
 	logCmd.Flags().BoolP("patch", "p", false, "Show patch")
 	logCmd.Flags().Bool("reversed", false, "Show revisions in the opposite order (older revisions first)")
@@ -30,6 +31,8 @@ func init() {
 	logCmd.Flags().String("tool", "", "Generate diff by external command")
 	logCmd.Flags().Bool("types", false, "For each path, show only its type before and after")
 	rootCmd.AddCommand(logCmd)
+
+	logCmd.MarkFlagsMutuallyExclusive("limit", "limit-old-shorthand")
 
 	carapace.Gen(logCmd).FlagCompletion(carapace.ActionMap{
 		"revisions": jj.ActionRevSets(jj.RevOption{}.Default()),

--- a/completers/jj_completer/cmd/next.go
+++ b/completers/jj_completer/cmd/next.go
@@ -15,6 +15,7 @@ var nextCmd = &cobra.Command{
 func init() {
 	carapace.Gen(nextCmd).Standalone()
 
+	nextCmd.Flags().Bool("conflict", false, "Jump to the next conflicted descendant")
 	nextCmd.Flags().Bool("edit", false, "Instead of creating a new working-copy commit on top of the target commit (like `jj new`), edit the target commit directly (like `jj edit`)")
 	nextCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	rootCmd.AddCommand(nextCmd)

--- a/completers/jj_completer/cmd/obslog.go
+++ b/completers/jj_completer/cmd/obslog.go
@@ -19,7 +19,8 @@ func init() {
 	obslogCmd.Flags().Bool("color-words", false, "Show a word-level diff with changes indicated only by color")
 	obslogCmd.Flags().Bool("git", false, "Show a Git-format diff")
 	obslogCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	obslogCmd.Flags().StringP("limit", "l", "", "Limit number of revisions to show")
+	obslogCmd.Flags().StringP("limit", "n", "", "Limit number of revisions to show")
+	obslogCmd.Flags().StringS("limit-old-shorthand", "l", "", "Limit number of revisions to show")
 	obslogCmd.Flags().Bool("no-graph", false, "Don't show the graph, show a flat list of revisions")
 	obslogCmd.Flags().BoolP("patch", "p", false, "Show patch compared to the previous version of this change")
 	obslogCmd.Flags().StringP("revision", "r", "", "")
@@ -29,6 +30,8 @@ func init() {
 	obslogCmd.Flags().String("tool", "", "Generate diff by external command")
 	obslogCmd.Flags().Bool("types", false, "For each path, show only its type before and after")
 	rootCmd.AddCommand(obslogCmd)
+
+	obslogCmd.MarkFlagsMutuallyExclusive("limit", "limit-old-shorthand")
 
 	carapace.Gen(obslogCmd).FlagCompletion(carapace.ActionMap{
 		"revision": jj.ActionRevs(jj.RevOption{}.Default()),

--- a/completers/jj_completer/cmd/operation_log.go
+++ b/completers/jj_completer/cmd/operation_log.go
@@ -15,8 +15,11 @@ func init() {
 	carapace.Gen(operation_logCmd).Standalone()
 
 	operation_logCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	operation_logCmd.Flags().StringP("limit", "l", "", "Limit number of operations to show")
+	operation_logCmd.Flags().StringP("limit", "n", "", "Limit number of revisions to show")
+	operation_logCmd.Flags().StringS("limit-old-shorthand", "l", "", "Limit number of revisions to show")
 	operation_logCmd.Flags().Bool("no-graph", false, "Don't show the graph, show a flat list of operations")
 	operation_logCmd.Flags().StringP("template", "T", "", "Render each operation using the given template")
 	operationCmd.AddCommand(operation_logCmd)
+
+	operation_logCmd.MarkFlagsMutuallyExclusive("limit", "limit-old-shorthand")
 }

--- a/completers/jj_completer/cmd/prev.go
+++ b/completers/jj_completer/cmd/prev.go
@@ -15,6 +15,7 @@ var prevCmd = &cobra.Command{
 func init() {
 	carapace.Gen(prevCmd).Standalone()
 
+	prevCmd.Flags().Bool("conflict", false, "Jump to the next conflicted descendant")
 	prevCmd.Flags().Bool("edit", false, "Edit the parent directly, instead of moving the working-copy commit")
 	prevCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	rootCmd.AddCommand(prevCmd)

--- a/completers/jj_completer/cmd/split.go
+++ b/completers/jj_completer/cmd/split.go
@@ -17,9 +17,12 @@ func init() {
 
 	splitCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	splitCmd.Flags().BoolP("interactive", "i", false, "Interactively choose which parts to split. This is the default if no paths are provided")
+	splitCmd.Flags().BoolP("parallel", "p", false, "Split the revision into two siblings instead of parent and child")
 	splitCmd.Flags().StringP("revision", "r", "", "The revision to split")
-	splitCmd.Flags().BoolP("siblings", "s", false, "Split the revision into two siblings instead of parent and child")
+	splitCmd.Flags().BoolP("siblings", "s", false, "Split the revision into two siblings instead of parent and child") // deprecated in v0.19.0
 	rootCmd.AddCommand(splitCmd)
+
+	splitCmd.MarkFlagsMutuallyExclusive("parallel", "siblings")
 
 	carapace.Gen(splitCmd).FlagCompletion(carapace.ActionMap{
 		"revision": jj.ActionRevs(jj.RevOption{}.Default()),

--- a/completers/jj_completer/cmd/squash.go
+++ b/completers/jj_completer/cmd/squash.go
@@ -20,6 +20,7 @@ func init() {
 	squashCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	squashCmd.Flags().BoolP("interactive", "i", false, "Interactively choose which parts to squash")
 	squashCmd.Flags().String("into", "@", "Revision to squash into")
+	squashCmd.Flags().Bool("keep-emptied", false, "The source revision will not be abandoned")
 	squashCmd.Flags().StringSliceP("message", "m", []string{}, "The description to use for squashed revision (don't open editor)")
 	squashCmd.Flags().StringP("revision", "r", "@", "Revision to squash into its parent")
 	squashCmd.Flags().String("to", "@", "Revision to squash into (alias for --into)")


### PR DESCRIPTION
	- `jj split --siblings` deprecated for `--parallelize`
	- `jj log`, `jj obslog`, and `jj op log` alias for flag `--limit` changed from `-l` to `-n`
	- new `jj file` command to replace deprecated `jj files`, `jj cat`, and `jj chmod`
	- new command `jj branch move` added
	- new command `jj git remote set-url` added
	- new flag `--name-only` added to `jj diff`
	- new flag `--conflict` added to `jj next` and `jj prev`
	- new flag `--reset-author` added to `jj commit`
	- new flag `--keep-emptied` added to `jj squash`
	- fixed typo in `jj git remote add` usage string