### PR TITLE
helm: Add support for values files

### DIFF
--- a/completers/helm_completer/cmd/install.go
+++ b/completers/helm_completer/cmd/install.go
@@ -72,6 +72,7 @@ func init() {
 				}
 			})
 		}),
+		"values": carapace.ActionFiles(".yaml", ".yml"),
 		"version": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			if len(c.Args) > 1 {
 				if splitted := strings.Split(c.Args[1], "/"); len(splitted) == 2 {

--- a/completers/helm_completer/cmd/lint.go
+++ b/completers/helm_completer/cmd/lint.go
@@ -33,6 +33,7 @@ func init() {
 				}
 			})
 		}),
+		"values": carapace.ActionFiles(".yaml", ".yml"),
 	})
 
 	carapace.Gen(lintCmd).PositionalCompletion(

--- a/completers/helm_completer/cmd/template.go
+++ b/completers/helm_completer/cmd/template.go
@@ -76,6 +76,7 @@ func init() {
 				}
 			})
 		}),
+		"values": carapace.ActionFiles(".yaml", ".yml"),
 	})
 
 	// TODO positional completion

--- a/completers/helm_completer/cmd/upgrade.go
+++ b/completers/helm_completer/cmd/upgrade.go
@@ -84,6 +84,7 @@ func init() {
 			}
 			return carapace.ActionValues()
 		}),
+		"values": carapace.ActionFiles(".yaml", ".yml"),
 	})
 
 	carapace.Gen(upgradeCmd).PositionalCompletion(

--- a/completers/helm_completer/cmd/upgrade.go
+++ b/completers/helm_completer/cmd/upgrade.go
@@ -76,6 +76,7 @@ func init() {
 				}
 			})
 		}),
+		"values": carapace.ActionFiles(".yaml", ".yml"),
 		"version": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			if len(c.Args) > 1 {
 				if splitted := strings.Split(c.Args[1], "/"); len(splitted) == 2 {
@@ -84,7 +85,6 @@ func init() {
 			}
 			return carapace.ActionValues()
 		}),
-		"values": carapace.ActionFiles(".yaml", ".yml"),
 	})
 
 	carapace.Gen(upgradeCmd).PositionalCompletion(


### PR DESCRIPTION
Currently, running `helm install release chart -f <TAB>` doesn't autocomplete override YAML values files. This PR fixes that by completing yaml file paths after the -f (or --values) parameter.