### PR TITLE
fixes and improvements to FFmpeg autocompletion

### DIFF
--- a/completers/ffmpeg_completer/cmd/root.go
+++ b/completers/ffmpeg_completer/cmd/root.go
@@ -50,6 +50,8 @@ func actionFlags() carapace.Action {
 					"-acodec", "force audio codec",
 					"-af", "set audio filters",
 					"-ar", "set audio sampling rate",
+					"-c", "codec name",
+					"-codec", "codec name",
 					"-f", "force format",
 					"-h", "show help",
 					"-i", "input file",
@@ -58,6 +60,7 @@ func actionFlags() carapace.Action {
 					"-help", "show help",
 					"-loglevel", "set logging level",
 					"--help", "show help",
+					"-scodec", "force subtitle codec",
 					"-sinks", "list sinks of the output device",
 					"-sources", "list sources of the input device",
 					"-vcodec", "force video codec",
@@ -65,8 +68,6 @@ func actionFlags() carapace.Action {
 				).Style(style.Carapace.FlagArg),
 				carapace.ActionValuesDescribed(
 					"-b", "bitrate",
-					"-c", "codec name",
-					"-codec", "codec name",
 				).Style(style.Carapace.FlagOptArg),
 				carapace.ActionValuesDescribed(
 					"-L", "show license",
@@ -244,7 +245,6 @@ func actionFlags() carapace.Action {
 					"-apre", "set the audio options to the indicated preset",
 					"-s", "set frame size",
 					"-sn", "disable subtitle",
-					"-scodec", "force subtitle codec",
 					"-stag", "force subtitle tag/fourcc",
 					"-fix_sub_duration", "fix subtitles duration",
 					"-canvas_size", "set canvas size",
@@ -262,6 +262,7 @@ func actionFlags() carapace.Action {
 				return carapace.ActionValuesDescribed(
 					"a", "audio",
 					"v", "video",
+					"s", "subtitle",
 				)
 			default:
 				return carapace.ActionValues()
@@ -276,7 +277,7 @@ func actionFlagArguments(flag string) carapace.Action {
 	case "ab":
 		return carapace.ActionValues("16", "32", "64", "128", "192", "256", "320")
 	case "acodec":
-		return ffmpeg.ActionCodecs() // TODO only audio
+		return ffmpeg.ActionCodecs('A')
 	case "af":
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			return carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
@@ -304,12 +305,14 @@ func actionFlagArguments(flag string) carapace.Action {
 		if len(splitted) > 1 {
 			switch splitted[1] {
 			case "a":
-				return ffmpeg.ActionCodecs() // TODO audio codecs
+				return ffmpeg.ActionCodecs('A')
 			case "v":
-				return ffmpeg.ActionCodecs() // TODO video codecs
+				return ffmpeg.ActionCodecs('V')
+			case "s":
+				return ffmpeg.ActionCodecs('S')
 			}
 		}
-		return carapace.ActionValues("copy")
+		return ffmpeg.ActionCodecs('\u0000')
 	case "f":
 		return ffmpeg.ActionFormats()
 	case "h", "?", "help":
@@ -320,6 +323,8 @@ func actionFlagArguments(flag string) carapace.Action {
 		return carapace.ActionFiles()
 	case "loglevel":
 		return ffmpeg.ActionLogLevels()
+	case "scodec":
+		return ffmpeg.ActionCodecs('S')
 	case "sinks":
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
@@ -339,7 +344,7 @@ func actionFlagArguments(flag string) carapace.Action {
 			}
 		})
 	case "vcodec":
-		return ffmpeg.ActionCodecs() // TODO only video
+		return ffmpeg.ActionCodecs('V')
 
 	case "vf":
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {

--- a/completers/ffmpeg_completer/cmd/root.go
+++ b/completers/ffmpeg_completer/cmd/root.go
@@ -277,7 +277,10 @@ func actionFlagArguments(flag string) carapace.Action {
 	case "ab":
 		return carapace.ActionValues("16", "32", "64", "128", "192", "256", "320")
 	case "acodec":
-		return ffmpeg.ActionCodecs('A')
+		return carapace.Batch(
+			ffmpeg.ActionCodecs(ffmpeg.CodecOpts{Audio: true}),
+			ffmpeg.ActionEncoders(ffmpeg.EncoderOpts{Audio: true}),
+		).ToA()
 	case "af":
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			return carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
@@ -302,17 +305,18 @@ func actionFlagArguments(flag string) carapace.Action {
 		}
 		return carapace.ActionValues() // TODO invalid flag (missing a/v))
 	case "c", "codec":
+		audio := true
+		subtitle := true
+		video := true
 		if len(splitted) > 1 {
-			switch splitted[1] {
-			case "a":
-				return ffmpeg.ActionCodecs('A')
-			case "v":
-				return ffmpeg.ActionCodecs('V')
-			case "s":
-				return ffmpeg.ActionCodecs('S')
-			}
+			audio = splitted[1] == "a"
+			subtitle = splitted[1] == "s"
+			video = splitted[1] == "v"
 		}
-		return ffmpeg.ActionCodecs('\u0000')
+		return carapace.Batch(
+			ffmpeg.ActionCodecs(ffmpeg.CodecOpts{Audio: audio, Subtitle: subtitle, Video: video}),
+			ffmpeg.ActionEncoders(ffmpeg.EncoderOpts{Audio: audio, Subtitle: subtitle, Video: video}),
+		).ToA()
 	case "f":
 		return ffmpeg.ActionFormats()
 	case "h", "?", "help":
@@ -324,12 +328,15 @@ func actionFlagArguments(flag string) carapace.Action {
 	case "loglevel":
 		return ffmpeg.ActionLogLevels()
 	case "scodec":
-		return ffmpeg.ActionCodecs('S')
+		return carapace.Batch(
+			ffmpeg.ActionCodecs(ffmpeg.CodecOpts{Subtitle: true}),
+			ffmpeg.ActionEncoders(ffmpeg.EncoderOpts{Subtitle: true}),
+		).ToA()
 	case "sinks":
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:
-				return ffmpeg.ActionDevices('E').NoSpace()
+				return ffmpeg.ActionDevices(ffmpeg.DeviceOpts{Demuxing: true}).NoSpace()
 			default:
 				return carapace.ActionValues()
 			}
@@ -338,13 +345,16 @@ func actionFlagArguments(flag string) carapace.Action {
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:
-				return ffmpeg.ActionDevices('D').NoSpace()
+				return ffmpeg.ActionDevices(ffmpeg.DeviceOpts{Muxing: true}).NoSpace()
 			default:
 				return carapace.ActionValues()
 			}
 		})
 	case "vcodec":
-		return ffmpeg.ActionCodecs('V')
+		return carapace.Batch(
+			ffmpeg.ActionCodecs(ffmpeg.CodecOpts{Video: true}),
+			ffmpeg.ActionEncoders(ffmpeg.EncoderOpts{Video: true}),
+		).ToA()
 
 	case "vf":
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {

--- a/completers/ffmpeg_completer/cmd/root.go
+++ b/completers/ffmpeg_completer/cmd/root.go
@@ -324,7 +324,7 @@ func actionFlagArguments(flag string) carapace.Action {
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:
-				return ffmpeg.ActionDevices().NoSpace()
+				return ffmpeg.ActionDevices('E').NoSpace()
 			default:
 				return carapace.ActionValues()
 			}
@@ -333,7 +333,7 @@ func actionFlagArguments(flag string) carapace.Action {
 		return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:
-				return ffmpeg.ActionDevices().NoSpace()
+				return ffmpeg.ActionDevices('D').NoSpace()
 			default:
 				return carapace.ActionValues()
 			}

--- a/pkg/actions/tools/ffmpeg/bitstreamFilter.go
+++ b/pkg/actions/tools/ffmpeg/bitstreamFilter.go
@@ -21,5 +21,5 @@ func ActionBitstreamFilters() carapace.Action {
 			}
 		}
 		return carapace.ActionValues(vals...)
-	})
+	}).Tag("bitstream filters")
 }

--- a/pkg/actions/tools/ffmpeg/codec.go
+++ b/pkg/actions/tools/ffmpeg/codec.go
@@ -11,18 +11,48 @@ import (
 //
 //	4gv (4GV (Fourth Generation Vocoder))
 //	4xm (4X Movie)
-func ActionCodecs() carapace.Action {
-	return carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-codecs")(func(output []byte) carapace.Action {
-		lines := strings.Split(string(output), "\n")
-		r := regexp.MustCompile(`^.{7} (?P<codec>[^ ]+) +(?P<description>.*)$`)
+func ActionCodecs(codecType rune) carapace.Action {
+	return carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-codecs")(func(outputCodecs []byte) carapace.Action {
+		encodersCmd := carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-encoders")
+		return encodersCmd(func(outputEncoders []byte) carapace.Action {
+			linesCodecs := strings.Split(strings.TrimSpace(string(outputCodecs)), "\n")
+			linesEncoders := strings.Split(strings.TrimSpace(string(outputEncoders)), "\n")
 
-		vals := make([]string, 0)
-		for _, line := range lines[10 : len(lines)-1] {
-			if r.MatchString(line) {
-				matches := r.FindStringSubmatch(line)
-				vals = append(vals, matches[1], matches[2])
+			r := regexp.MustCompile(`^ (?P<prefix>.{6}) (?P<codec>\w+) +(?P<description>.*)$`)
+
+			vals := make(map[string]string)
+
+			// copy
+			vals["copy"] = "copy the codec of the input"
+
+			// Parse codecs
+			for _, line := range linesCodecs {
+				if r.MatchString(line) {
+					matches := r.FindStringSubmatch(line)
+					prefix := matches[1]
+					if (codecType == '\u0000' || byte(codecType) == prefix[2]) && prefix[1] == 'E' {
+						vals[matches[2]] = matches[3]
+					}
+				}
 			}
-		}
-		return carapace.ActionValuesDescribed(vals...)
+
+			// Parse encoders
+			for _, line := range linesEncoders {
+				if r.MatchString(line) {
+					matches := r.FindStringSubmatch(line)
+					prefix := matches[1]
+					if codecType == '\u0000' || (byte(codecType) == prefix[0]) {
+						vals[matches[2]] = matches[3]
+					}
+				}
+			}
+
+			result := []string{}
+			for codec, description := range vals {
+				result = append(result, codec, description)
+			}
+
+			return carapace.ActionValuesDescribed(result...)
+		})
 	})
 }

--- a/pkg/actions/tools/ffmpeg/demuxer.go
+++ b/pkg/actions/tools/ffmpeg/demuxer.go
@@ -13,19 +13,18 @@ import (
 //	ac3 (raw AC-3)
 func ActionDemuxers() carapace.Action {
 	return carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-demuxers")(func(output []byte) carapace.Action {
-		lines := strings.Split(string(output), "\n")
-		r := regexp.MustCompile(`^ (?P<type>.).{1} (?P<name>[^ ]+) +(?P<description>.*)$`)
+		_, content, ok := strings.Cut(string(output), " ---")
+		if !ok {
+			return carapace.ActionMessage("failed to parse demuxers")
+		}
 
-		found := false
+		lines := strings.Split(content, "\n")
+		r := regexp.MustCompile(`^.{5}(?P<name>[^ ]+) +(?P<description>.*)$`)
+
 		vals := make([]string, 0)
 		for _, line := range lines {
-			if !found {
-				found = line == " --"
-				continue
-			}
-
 			if matches := r.FindStringSubmatch(line); matches != nil {
-				vals = append(vals, matches[2], matches[3])
+				vals = append(vals, matches[1], matches[2])
 			}
 		}
 		return carapace.ActionValuesDescribed(vals...)

--- a/pkg/actions/tools/ffmpeg/device.go
+++ b/pkg/actions/tools/ffmpeg/device.go
@@ -11,16 +11,18 @@ import (
 //
 //	alsa (ALSA audio output)
 //	fbdev (Linux framebuffer)
-func ActionDevices() carapace.Action {
+func ActionDevices(deviceType rune) carapace.Action {
 	return carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-devices")(func(output []byte) carapace.Action {
 		lines := strings.Split(string(output), "\n")
-		r := regexp.MustCompile(`^.{3} (?P<devices>[^ ]+) +(?P<description>.*)$`)
+		r := regexp.MustCompile(`^ (?P<prefix>.{2}) (?P<devices>[^ ]+) +(?P<description>.*)$`)
 
 		vals := make([]string, 0)
 		for _, line := range lines[4 : len(lines)-1] {
 			if r.MatchString(line) {
 				matches := r.FindStringSubmatch(line)
-				vals = append(vals, matches[1], matches[2])
+				if deviceType == '\u0000' || strings.IndexByte(matches[1], byte(deviceType)) != -1 {
+					vals = append(vals, matches[2], matches[3])
+				}
 			}
 		}
 		return carapace.ActionValuesDescribed(vals...)

--- a/pkg/actions/tools/ffmpeg/format.go
+++ b/pkg/actions/tools/ffmpeg/format.go
@@ -14,7 +14,7 @@ import (
 func ActionFormats() carapace.Action {
 	return carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-formats")(func(output []byte) carapace.Action {
 		lines := strings.Split(string(output), "\n")
-		r := regexp.MustCompile(`^.{3} (?P<format>[^ ]+) +(?P<description>.*)$`)
+		r := regexp.MustCompile(`^.{4} (?P<format>[^ ]+) +(?P<description>.*)$`)
 
 		vals := make([]string, 0)
 		for _, line := range lines[4 : len(lines)-1] {

--- a/pkg/actions/tools/ffmpeg/format.go
+++ b/pkg/actions/tools/ffmpeg/format.go
@@ -24,5 +24,5 @@ func ActionFormats() carapace.Action {
 			}
 		}
 		return carapace.ActionValuesDescribed(vals...)
-	})
+	}).Tag("formats")
 }

--- a/pkg/actions/tools/ffmpeg/help.go
+++ b/pkg/actions/tools/ffmpeg/help.go
@@ -1,6 +1,8 @@
 package ffmpeg
 
-import "github.com/carapace-sh/carapace"
+import (
+	"github.com/carapace-sh/carapace"
+)
 
 // ActionHelpTopics completes help topics
 //
@@ -24,9 +26,9 @@ func ActionHelpTopics() carapace.Action {
 		default:
 			switch c.Parts[0] {
 			case "decoder":
-				return ActionDecoders()
+				return ActionDecoders(DecoderOpts{}.Default())
 			case "encoder":
-				return ActionEncoders()
+				return ActionEncoders(EncoderOpts{}.Default())
 			case "demuxer":
 				return ActionDemuxers()
 			case "muxer":

--- a/pkg/actions/tools/ffmpeg/hwAcceleration.go
+++ b/pkg/actions/tools/ffmpeg/hwAcceleration.go
@@ -21,5 +21,5 @@ func ActionHardwareAccelerations() carapace.Action {
 			}
 		}
 		return carapace.ActionValues(vals...)
-	})
+	}).Tag("hardware accelerators")
 }

--- a/pkg/actions/tools/ffmpeg/loglevel.go
+++ b/pkg/actions/tools/ffmpeg/loglevel.go
@@ -20,5 +20,5 @@ func ActionLogLevels() carapace.Action {
 		"verbose", "Same as \"info\", except more verbose",
 		"debug", "Show everything, including debugging information",
 		"trace", "",
-	).StyleF(style.ForLogLevel)
+	).StyleF(style.ForLogLevel).Tag("log levels")
 }

--- a/pkg/actions/tools/ffmpeg/muxer.go
+++ b/pkg/actions/tools/ffmpeg/muxer.go
@@ -13,19 +13,18 @@ import (
 //	ac3 (raw AC-3)
 func ActionMuxers() carapace.Action {
 	return carapace.ActionExecCommand("ffmpeg", "-hide_banner", "-demuxers")(func(output []byte) carapace.Action {
-		lines := strings.Split(string(output), "\n")
-		r := regexp.MustCompile(`^ .{1}(?P<type>.) (?P<name>[^ ]+) +(?P<description>.*)$`)
+		_, content, ok := strings.Cut(string(output), " ---")
+		if !ok {
+			return carapace.ActionMessage("failed to parse muxers")
+		}
 
-		found := false
+		lines := strings.Split(content, "\n")
+		r := regexp.MustCompile(`^.{5}(?P<name>[^ ]+) +(?P<description>.*)$`)
+
 		vals := make([]string, 0)
 		for _, line := range lines {
-			if !found {
-				found = line == " --"
-				continue
-			}
-
 			if matches := r.FindStringSubmatch(line); matches != nil {
-				vals = append(vals, matches[2], matches[3])
+				vals = append(vals, matches[1], matches[2])
 			}
 		}
 		return carapace.ActionValuesDescribed(vals...)


### PR DESCRIPTION
Things done in this pr:

- fixes format completion, not returning anything
- filter device type for sink and source
- filter codec type
- on codec completion also fill in encoders and copy
- handle subtitle codec
- autocomplete all codecs if codec is not specified
