### PR TITLE
jj: Updated completer to v0.20.0

### DIFF
--- a/completers/jj_completer/cmd/backout.go
+++ b/completers/jj_completer/cmd/backout.go
@@ -17,11 +17,11 @@ func init() {
 
 	backoutCmd.Flags().StringSliceP("destination", "d", []string{}, "The revision to apply the reverse changes on top of")
 	backoutCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	backoutCmd.Flags().StringP("revision", "r", "", "The revision to apply the reverse of")
+	backoutCmd.Flags().StringP("revisions", "r", "", "The revision to apply the reverse of")
 	rootCmd.AddCommand(backoutCmd)
 
 	carapace.Gen(backoutCmd).FlagCompletion(carapace.ActionMap{
 		"destination": jj.ActionRevs(jj.RevOption{}.Default()),
-		"revision":    jj.ActionRevs(jj.RevOption{}.Default()),
+		"revisions":   jj.ActionRevs(jj.RevOption{}.Default()),
 	})
 }

--- a/completers/jj_completer/cmd/operation_diff.go
+++ b/completers/jj_completer/cmd/operation_diff.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var operation_diffCmd = &cobra.Command{
+	Use:   "diff [OPTIONS]",
+	Short: "Compare changes to the repository between two operations",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(operation_diffCmd).Standalone()
+
+	// Options
+	operation_diffCmd.Flags().String("from", "", "Show repository changes from this operation")
+	operation_diffCmd.Flags().Bool("no-graph", false, "Don't show the graph, show a flat list of operations")
+	operation_diffCmd.Flags().String("operation", "", "Show repository changes in this operation, compared to its parent")
+	operation_diffCmd.Flags().String("to", "", "Show repository changes to this operation")
+
+	// Diff formatting options
+	operation_diffCmd.Flags().Int("context", 3, "Number of lines of context to show")
+	operation_diffCmd.Flags().Bool("color-words", false, "Show a word-level diff with changes indicated only by color")
+	operation_diffCmd.Flags().Bool("git", false, "Show a Git-format diff")
+	operation_diffCmd.Flags().Bool("name-only", false, "For each path, show only its path")
+	operation_diffCmd.Flags().StringP("revision", "r", "", "Show changes in this revision, compared to its parent(s)")
+	operation_diffCmd.Flags().Bool("stat", false, "Show a histogram of the changes")
+	operation_diffCmd.Flags().BoolP("summary", "s", false, "For each path, show only whether it was modified, added, or removed")
+	operation_diffCmd.Flags().String("tool", "", "Generate diff by external command")
+	operation_diffCmd.Flags().Bool("types", false, "For each path, show only its type before and after")
+
+	operationCmd.AddCommand(operation_diffCmd)
+
+	operation_diffCmd.MarkFlagsMutuallyExclusive("from", "to")
+
+	carapace.Gen(operation_diffCmd).FlagCompletion(carapace.ActionMap{
+		"from":      jj.ActionRevs(jj.RevOption{}.Default()),
+		"operation": jj.ActionOperations(100),
+		"to":        jj.ActionRevs(jj.RevOption{}.Default()),
+		"tool":      bridge.ActionCarapaceBin().Split(),
+	})
+}

--- a/completers/jj_completer/cmd/operation_show.go
+++ b/completers/jj_completer/cmd/operation_show.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/jj"
+	"github.com/spf13/cobra"
+)
+
+var operation_showCmd = &cobra.Command{
+	Use:   "show [OPTIONS] [OPERATION]",
+	Short: "Show changes to the repository in an operation",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(operation_showCmd).Standalone()
+
+	// Options
+	operation_showCmd.Flags().Bool("no-graph", false, "Don't show the graph, show a flat list of operations")
+	operation_showCmd.Flags().BoolP("patch", "p", false, "Show patch of modifications to changes")
+
+	// Diff formatting options
+	operation_showCmd.Flags().Int("context", 3, "Number of lines of context to show")
+	operation_showCmd.Flags().Bool("color-words", false, "Show a word-level diff with changes indicated only by color")
+	operation_showCmd.Flags().Bool("git", false, "Show a Git-format diff")
+	operation_showCmd.Flags().Bool("name-only", false, "For each path, show only its path")
+	operation_showCmd.Flags().StringP("revision", "r", "", "Show changes in this revision, compared to its parent(s)")
+	operation_showCmd.Flags().Bool("stat", false, "Show a histogram of the changes")
+	operation_showCmd.Flags().BoolP("summary", "s", false, "For each path, show only whether it was modified, added, or removed")
+	operation_showCmd.Flags().String("tool", "", "Generate diff by external command")
+	operation_showCmd.Flags().Bool("types", false, "For each path, show only its type before and after")
+
+	operationCmd.AddCommand(operation_showCmd)
+
+	carapace.Gen(operation_showCmd).PositionalCompletion(
+		jj.ActionOperations(100),
+	)
+}

--- a/completers/jj_completer/cmd/rebase.go
+++ b/completers/jj_completer/cmd/rebase.go
@@ -23,6 +23,7 @@ func init() {
 	rebaseCmd.Flags().StringArrayP("insert-after", "A", []string{}, "Revision(s) to insert after")
 	rebaseCmd.Flags().StringArrayP("insert-before", "B", []string{}, "Revision(s) to insert before")
 	rebaseCmd.Flags().StringP("revisions", "r", "", "Rebase only this revision, rebasing descendants onto this revision's parent(s)")
+	rebaseCmd.Flags().Bool("skip-emptied", false, "Abandon empty commits created by the rebase")
 	rebaseCmd.Flags().StringSliceP("source", "s", []string{}, "Rebase specified revision(s) together their tree of descendants (can be repeated)")
 	rebaseCmd.MarkFlagRequired("destination")
 	rootCmd.AddCommand(rebaseCmd)

--- a/pkg/actions/tools/jj/rev.go
+++ b/pkg/actions/tools/jj/rev.go
@@ -97,12 +97,16 @@ func ActionRevSetFunctions() carapace.Action {
 		"mine", "Commits where the author's email matches the email of the current user",
 		"committer", "Commits with the committer's name or email matching the given string pattern",
 		"empty", "Commits modifying no files. This also includes merges() without user modifications and root()",
-		"file", "Commits modifying one of the paths specified",
-		"file", "Commits modifying one of the paths specified",
+		"file", "Commits modifying paths matching the given fileset expression",
 		"conflict", "Commits with conflicts",
 		"present", "Same as x, but evaluated to none() if any of the commits in x doesn't exist",
 		"reachable", "All commits reachable from srcs within domain",
 		"mutable", "All commits that jj does not treat as immutable (same as ~immutable())",
 		"immutable", "All commits that jj treats as immutable (same as (immutable_heads() | root()))",
+		"diff_contains", "Commits containing diffs matching the given text pattern line by line",
+		"author_date", "Commits with author dates matching the specified date pattern",
+		"committer_date", "Commits with committer dates matching the specified date pattern",
+		"tracked_remote_branches", "All targets of tracked remote branches",
+		"untracked_remote_branches", "All targets of untracked remote branches",
 	).Tag("revset functions")
 }


### PR DESCRIPTION
	- Added `--skip-emptied` flag to `jj rebase`
	- Renamed `jj backout --revision` to `jj backout --revisions`
	- Added new revset functions
		* tracked_remote_branches
		* untracked_remote_branches
		* diff_contains
		* author_date
		* committer_date
	- Changed description of file revset function
	- Added `jj operation show` command
	- Added `jj operation diff` command