### PR TITLE
improved documentation regarding macros

### DIFF
--- a/.github/macros.sh
+++ b/.github/macros.sh
@@ -3,6 +3,8 @@
 scriptdir=$(dirname $(readlink -f $0))
 
 echo "# Macros"
+echo "On top of the base [Macros](https://carapace-sh.github.io/carapace-spec/carapace-spec/macros.html) defined in [carapace-spec](https://carapace-sh.github.io/carapace-spec),"
+echo "carapace-bin also provides the following macros:"
 echo
 
 $scriptdir/../cmd/carapace/carapace --macro \

--- a/docs/src/spec.md
+++ b/docs/src/spec.md
@@ -42,4 +42,4 @@ carapace --macro color.HexColors <TAB> # test macro
 ![](./spec-macros.cast)
 
 
-[carapace-spec]:https://github.com/carapace-sh/carapace-spec
+[carapace-spec]:https://carapace-sh.github.io/carapace-spec


### PR DESCRIPTION
https://carapace-sh.github.io/carapace-bin/spec.html points to https://github.com/carapace-sh/carapace-spec, which points to https://carapace.sh/, whose "Read" section points to https://pixi.carapace.sh/, whose "Spec" section points back to https://carapace-sh.github.io/carapace-bin/spec.html

This change breaks the cycle

It also adds a link directly from https://carapace-sh.github.io/carapace-bin/spec/macros.html to https://carapace-sh.github.io/carapace-spec/carapace-spec/macros.html