### PR TITLE
jj_completer: Updated jujutsu completer to version 0.21.0 .

### DIFF
--- a/completers/jj_completer/cmd/file_untrack.go
+++ b/completers/jj_completer/cmd/file_untrack.go
@@ -5,19 +5,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var untrackCmd = &cobra.Command{
+var file_untrackCmd = &cobra.Command{
 	Use:   "untrack [OPTIONS] <PATHS>...",
 	Short: "Stop tracking specified paths in the working copy",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {
-	carapace.Gen(untrackCmd).Standalone()
+	carapace.Gen(file_untrackCmd).Standalone()
 
-	untrackCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	rootCmd.AddCommand(untrackCmd)
+	file_untrackCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	fileCmd.AddCommand(file_untrackCmd)
 
-	carapace.Gen(untrackCmd).PositionalAnyCompletion(
+	carapace.Gen(file_untrackCmd).PositionalAnyCompletion(
 		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/jj_completer/cmd/next.go
+++ b/completers/jj_completer/cmd/next.go
@@ -16,9 +16,12 @@ func init() {
 	carapace.Gen(nextCmd).Standalone()
 
 	nextCmd.Flags().Bool("conflict", false, "Jump to the next conflicted descendant")
-	nextCmd.Flags().Bool("edit", false, "Instead of creating a new working-copy commit on top of the target commit (like `jj new`), edit the target commit directly (like `jj edit`)")
+	nextCmd.Flags().BoolP("edit", "e", false, "Instead of creating a new working-copy commit on top of the target commit (like `jj new`), edit the target commit directly (like `jj edit`)")
 	nextCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	nextCmd.Flags().Bool("no-edit", false, "Instead of editing the target commit directly (like `jj edit`), create a new working-copy commit on top of the target commit (like `jj new`)")
 	rootCmd.AddCommand(nextCmd)
+
+	nextCmd.MarkFlagsMutuallyExclusive("edit", "no-edit")
 
 	carapace.Gen(nextCmd).PositionalCompletion(
 		jj.ActionNextCommits(100),

--- a/completers/jj_completer/cmd/prev.go
+++ b/completers/jj_completer/cmd/prev.go
@@ -16,9 +16,12 @@ func init() {
 	carapace.Gen(prevCmd).Standalone()
 
 	prevCmd.Flags().Bool("conflict", false, "Jump to the next conflicted descendant")
-	prevCmd.Flags().Bool("edit", false, "Edit the parent directly, instead of moving the working-copy commit")
+	prevCmd.Flags().BoolP("edit", "e", false, "Edit the parent directly, instead of moving the working-copy commit")
 	prevCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	prevCmd.Flags().Bool("no-edit", false, "Instead of editing the target commit directly (like `jj edit`), create a new working-copy commit on top of the target commit (like `jj new`)")
 	rootCmd.AddCommand(prevCmd)
+
+	prevCmd.MarkFlagsMutuallyExclusive("edit", "no-edit")
 
 	carapace.Gen(prevCmd).PositionalCompletion(
 		jj.ActionPrevCommits(100),


### PR DESCRIPTION
	- Renamed `jj untrack` to `jj file untrack`
	- Added `--no-edit` flags to `jj next` and `jj prev`