### PR TITLE
make man macos compatible

### DIFF
--- a/pkg/actions/tools/man/page.go
+++ b/pkg/actions/tools/man/page.go
@@ -14,7 +14,7 @@ import (
 func ActionPages() carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 		return carapace.ActionExecCommand("man", "-k", c.Value)(func(output []byte) carapace.Action {
-			r := regexp.MustCompile(`^(?P<name>.*) \(\d+\) +- (?P<description>.*)$`)
+			r := regexp.MustCompile(`^(?P<name>.*?) ?\(\d+\).* +- (?P<description>.*)$`)
 
 			vals := make([]string, 0)
 			for _, line := range strings.Split(string(output), "\n") {


### PR DESCRIPTION
`man -k` command on Mac has slightly different output, for example:
```bash
man -k kube
...
kubeadm-alpha(1), kubeadm alpha(1) - Kubeadm experimental sub-commands
...
```

There are no space before parenthesis, and there may be several results on one line. I modified the regexp to be compatible with this output.