### PR TITLE
added mix completer

### DIFF
--- a/completers/mix_completer/cmd/help.go
+++ b/completers/mix_completer/cmd/help.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/mix"
+	"github.com/spf13/cobra"
+)
+
+var helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "prints documentation for a given task",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(helpCmd).Standalone()
+
+	rootCmd.AddCommand(helpCmd)
+
+	carapace.Gen(helpCmd).PositionalCompletion(
+		mix.ActionMixTasks(),
+	)
+}

--- a/completers/mix_completer/cmd/root.go
+++ b/completers/mix_completer/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/mix"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
 	"github.com/spf13/cobra"
 )
 
@@ -19,8 +20,18 @@ func Execute() error {
 
 func init() {
 	carapace.Gen(rootCmd).Standalone()
+	rootCmd.Flags().SetInterspersed(false)
+
+	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().BoolP("version", "v", false, "show version")
 
 	carapace.Gen(rootCmd).PositionalCompletion(
 		mix.ActionMixTasks(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return bridge.ActionCarapaceBin("mix." + c.Args[0]).Shift(1)
+		}),
 	)
 }

--- a/completers/mix_completer/cmd/root.go
+++ b/completers/mix_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/mix"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mix",
+	Short: "A build automation tool for working with applications written in the Elixir programming language",
+	Long:  "https://hexdocs.pm/mix/Mix.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		mix.ActionMixTasks(),
+	)
+}

--- a/completers/mix_completer/main.go
+++ b/completers/mix_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/mix_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/mix/mix.go
+++ b/pkg/actions/tools/mix/mix.go
@@ -1,0 +1,29 @@
+// package mix contains mix related actions
+package mix
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionMixTasks completes mix tasks
+//
+//	install
+//	deps.get
+func ActionMixTasks() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionExecCommand("mix", "help")(func(output []byte) carapace.Action {
+			lines := strings.Split(string(output), "\n")
+			r := regexp.MustCompile(`^mix (\S+)\s*# (.*)`)
+			vals := make([]string, 0)
+			for _, line := range lines {
+				if matches := r.FindStringSubmatch(line); matches != nil {
+					vals = append(vals, matches[1], matches[2])
+				}
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		})
+	})
+}

--- a/pkg/actions/tools/mix/mix.go
+++ b/pkg/actions/tools/mix/mix.go
@@ -13,17 +13,15 @@ import (
 //	install
 //	deps.get
 func ActionMixTasks() carapace.Action {
-	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		return carapace.ActionExecCommand("mix", "help")(func(output []byte) carapace.Action {
-			lines := strings.Split(string(output), "\n")
-			r := regexp.MustCompile(`^mix (\S+)\s*# (.*)`)
-			vals := make([]string, 0)
-			for _, line := range lines {
-				if matches := r.FindStringSubmatch(line); matches != nil {
-					vals = append(vals, matches[1], matches[2])
-				}
+	return carapace.ActionExecCommand("mix", "help")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		r := regexp.MustCompile(`^mix (\S+)\s*# (.*)`)
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if matches := r.FindStringSubmatch(line); matches != nil {
+				vals = append(vals, matches[1], matches[2])
 			}
-			return carapace.ActionValuesDescribed(vals...)
-		})
-	})
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	}).Tag("tasks")
 }


### PR DESCRIPTION
Hi there! Saw there was no completer for [mix](https://hexdocs.pm/mix/Mix.html), so I figured I'd take a stab at it. This is my first time writing go so feel free to give any feedback.

There are maybe some other things I could add like listing the `deps` for input into things like `mix deps.update`, but I wasn't totally sure how to so figured I could leave it to someone in the future (since to me those aren't high use commands).