### PR TITLE
goreleaser: `gobinary` is deprecated

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     binary: carapace
     tags:
       - release
-    gobinary: go-termux
+    tool: go-termux
 archives:
   - id: default
     builds:


### PR DESCRIPTION
renamed to `tool`
