### PR TITLE
Updated setup docs for nushell to address issue of creating `~/.config/carapace` on each init

### DIFF
--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -38,12 +38,14 @@ carapace _carapace | source
 ## Nushell
 
 ```sh
-## ~/.config/nushell/env.nu
+# ~/.config/nushell/env.nu
 $env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense' # optional
+
+# run the following in terminal
 mkdir ~/.cache/carapace
 carapace _carapace nushell | save --force ~/.cache/carapace/init.nu
 
-#~/.config/nushell/config.nu
+# ~/.config/nushell/config.nu
 source ~/.cache/carapace/init.nu
 ```
 


### PR DESCRIPTION
https://github.com/carapace-sh/carapace/issues/1073

<img width="745" alt="image" src="https://github.com/user-attachments/assets/e906a593-9feb-4a59-94f0-f741a61e88d9" />
