### PR TITLE
Add ripsecrets completer

### DIFF
--- a/completers/ripsecrets_completer/cmd/root.go
+++ b/completers/ripsecrets_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "ripsecrets",
+	Short: "Prevent committing secret keys into your source code",
+	Long:  "https://github.com/sirwart/ripsecrets",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringSlice("additional-pattern", []string{}, "Additional regex pattern used to find secrets")
+	rootCmd.Flags().BoolP("help", "h", false, "Print help")
+	rootCmd.Flags().Bool("install-pre-commit", false, "Install ripsecrets as a pre-commit hook")
+	rootCmd.Flags().Bool("only-matching", false, "Print only the matched (non-empty) parts of a matching line")
+	rootCmd.Flags().Bool("strict-ignore", false, "Respect .secretsignore file even for files passed as arguments")
+	rootCmd.Flags().BoolP("version", "V", false, "Print version")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(carapace.ActionFiles())
+}

--- a/completers/ripsecrets_completer/main.go
+++ b/completers/ripsecrets_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/ripsecrets_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
There isn't an issue for this so I'll include the info that would go in one here.
This was initially generated with carapace-parse, and then manually edited from there while referencing https://github.com/sirwart/ripsecrets/blob/main/src/args.rs
It's a fairly simple command

### Command
ripsecrets

### Description
Command-line tool to find secrets in your code and prevent them from being committed

### Repository
https://github.com/sirwart/ripsecrets