### PR TITLE
fix missing s in `git interpret-trailers` command

### DIFF
--- a/completers/git_completer/cmd/interpretTrailers.go
+++ b/completers/git_completer/cmd/interpretTrailers.go
@@ -6,7 +6,7 @@ import (
 )
 
 var interpretTrailerCmd = &cobra.Command{
-	Use:     "interpret-trailer",
+	Use:     "interpret-trailers",
 	Short:   "Add or parse structured information in commit messages",
 	Run:     func(cmd *cobra.Command, args []string) {},
 	GroupID: groups[group_low_level_helper].ID,


### PR DESCRIPTION
There is not much to add, it's all in the title :-)