### PR TITLE
Added pidof, tload, pwdx, slabtop completers; update w, uptime, pidwait, watch to 4.0.5

### DIFF
--- a/completers/pidof_completer/cmd/root.go
+++ b/completers/pidof_completer/cmd/root.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "pidof",
+	Short: "find the process ID of a running program",
+	Long:  "https://man7.org/linux/man-pages/man1/pidof.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("check-root", "c", false, "omit processes with different root")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().BoolP("lightweight", "t", false, "list threads too")
+	rootCmd.Flags().StringP("omit-pid", "o", "", "omit processes with PID")
+	rootCmd.Flags().BoolS("q", "q", false, "quiet mode, only set the exit code")
+	rootCmd.Flags().StringP("separator", "S", "", "use SEP as separator put between PIDs")
+	rootCmd.Flags().BoolP("single-shot", "s", false, "return one PID only")
+	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
+	rootCmd.Flags().BoolP("with-workers", "w", false, "show kernel workers too")
+	rootCmd.Flags().BoolS("x", "x", false, "also find shells running the named scripts")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"omit-pid": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return carapace.Batch(
+				ps.ActionProcessIds(),
+				carapace.ActionValuesDescribed("%PPID", "Parent process"),
+			).ToA().UniqueList(",")
+		}),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		ps.ActionProcessExecutables(),
+	)
+}

--- a/completers/pidof_completer/main.go
+++ b/completers/pidof_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/pidof_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/pidwait_completer/cmd/root.go
+++ b/completers/pidwait_completer/cmd/root.go
@@ -8,9 +8,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "pwait",
+	Use:   "pidwait",
 	Short: "wait for processes based on name and other attributes",
-	Long:  "https://linux.die.net/man/1/pgrep",
+	Long:  "https://man7.org/linux/man-pages/man1/pgrep.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 

--- a/completers/pidwait_completer/cmd/root.go
+++ b/completers/pidwait_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/env"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/os"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
 	"github.com/spf13/cobra"
@@ -17,16 +18,20 @@ var rootCmd = &cobra.Command{
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().String("cgroup", "", "match by cgroup v2 names")
 	rootCmd.Flags().BoolP("count", "c", false, "count of matching processes")
 	rootCmd.Flags().BoolP("echo", "e", false, "display PIDs before waiting")
+	rootCmd.Flags().String("env", "", "match on environment variable")
 	rootCmd.Flags().StringP("euid", "u", "", "match by effective IDs")
 	rootCmd.Flags().BoolP("exact", "x", false, "match exactly with the command name")
 	rootCmd.Flags().BoolP("full", "f", false, "use full process name to match")
 	rootCmd.Flags().StringP("group", "G", "", "match real group IDs")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().BoolP("ignore-ancestors", "A", false, "exclude our ancestors from results")
 	rootCmd.Flags().BoolP("ignore-case", "i", false, "match case insensitively")
 	rootCmd.Flags().BoolP("logpidfile", "L", false, "fail if PID file is not locked")
 	rootCmd.Flags().BoolP("newest", "n", false, "select most recently started")
@@ -39,11 +44,13 @@ func init() {
 	rootCmd.Flags().StringP("pidfile", "F", "", "read PIDs from file")
 	rootCmd.Flags().StringP("runstates", "r", "", "match runstates [D,S,Z,...]")
 	rootCmd.Flags().StringP("session", "s", "", "match session IDs")
+	rootCmd.Flags().String("signal", "", "signal to send (either number or name)")
 	rootCmd.Flags().StringP("terminal", "t", "", "match by controlling terminal")
 	rootCmd.Flags().StringP("uid", "U", "", "match by real IDs")
 	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"env":       env.ActionNameValues(false).UniqueList(","),
 		"euid":      os.ActionUsers(),
 		"group":     os.ActionGroups().UniqueList(","),
 		"ns":        ps.ActionProcessIds(),
@@ -52,6 +59,7 @@ func init() {
 		"pidfile":   carapace.ActionFiles(),
 		"runstates": ps.ActionProcessStates().UniqueList(","),
 		"session":   os.ActionSessionIds().UniqueList(","),
+		"signal":    ps.ActionKillSignals(),
 		"terminal":  os.ActionTerminals().UniqueList(","),
 		"uid":       os.ActionUsers(),
 	})

--- a/completers/pidwait_completer/main.go
+++ b/completers/pidwait_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/pidwait_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/pwait_completer/main.go
+++ b/completers/pwait_completer/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/carapace-sh/carapace-bin/completers/pwait_completer/cmd"
-
-func main() {
-	cmd.Execute()
-}

--- a/completers/pwdx_completer/cmd/root.go
+++ b/completers/pwdx_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "pwdx",
+	Short: "report current working directory of a process",
+	Long:  "https://man7.org/linux/man-pages/man1/pwdx.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		ps.ActionProcessIds(),
+	)
+}

--- a/completers/pwdx_completer/main.go
+++ b/completers/pwdx_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/pwdx_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/slabtop_completer/cmd/root.go
+++ b/completers/slabtop_completer/cmd/root.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "slabtop",
+	Short: "display kernel slab cache information in real time",
+	Long:  "https://man7.org/linux/man-pages/man1/slabtop.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("delay", "d", "", "delay updates")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().Bool("human", false, "show human-readable output")
+	rootCmd.Flags().BoolP("once", "o", false, "only display once, then exit")
+	rootCmd.Flags().StringP("sort", "s", "", "specify sort criteria by character")
+	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"sort": carapace.ActionValuesDescribed(
+			"a", "sort by number of active objects",
+			"b", "sort by objects per slab",
+			"c", "sort by cache size",
+			"l", "sort by number of slabs",
+			"n", "sort by name",
+			"o", "sort by number of objects (the default)",
+			"p", "sort by (non display) pages per slab",
+			"s", "sort by object size",
+			"u", "sort by cache utilization",
+			"v", "sort by (non display) number of active slabs",
+		),
+	})
+}

--- a/completers/slabtop_completer/main.go
+++ b/completers/slabtop_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/slabtop_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/tload_completer/cmd/root.go
+++ b/completers/tload_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "tload",
+	Short: "graphic representation of system load average",
+	Long:  "https://www.man7.org/linux/man-pages/man1/tload.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("delay", "d", "", "update delay in seconds")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().StringP("scale", "s", "", "vertical scale")
+	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
+}

--- a/completers/tload_completer/main.go
+++ b/completers/tload_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/tload_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/uptime_completer/cmd/root.go
+++ b/completers/uptime_completer/cmd/root.go
@@ -8,18 +8,21 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "uptime",
 	Short: "Tell how long the system has been running",
-	Long:  "https://linux.die.net/man/1/uptime",
+	Long:  "https://man7.org/linux/man-pages/man1/uptime.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().BoolP("container", "c", false, "show container uptime")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
 	rootCmd.Flags().BoolP("pretty", "p", false, "show uptime in pretty format")
+	rootCmd.Flags().BoolP("raw", "r", false, "show uptime values in raw format")
 	rootCmd.Flags().BoolP("since", "s", false, "system up since")
 	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
 }

--- a/completers/w_completer/cmd/root.go
+++ b/completers/w_completer/cmd/root.go
@@ -2,28 +2,36 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/os"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "w",
 	Short: "Show who is logged on and what they are doing",
-	Long:  "https://linux.die.net/man/1/w",
+	Long:  "https://man7.org/linux/man-pages/man1/w.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().BoolP("container", "c", false, "show container uptime")
 	rootCmd.Flags().BoolP("from", "f", false, "show remote hostname field")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
 	rootCmd.Flags().BoolP("ip-addr", "i", false, "display IP address instead of hostname (if possible)")
 	rootCmd.Flags().BoolP("no-current", "u", false, "ignore current process username")
 	rootCmd.Flags().BoolP("no-header", "h", false, "do not print header")
 	rootCmd.Flags().BoolP("old-style", "o", false, "old style output")
+	rootCmd.Flags().BoolP("pids", "p", false, "show the PID(s) of processes in WHAT")
 	rootCmd.Flags().BoolP("short", "s", false, "short format")
 	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		os.ActionUsers(),
+	)
 }

--- a/completers/watch_completer/cmd/root.go
+++ b/completers/watch_completer/cmd/root.go
@@ -8,13 +8,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "watch",
 	Short: "execute a program periodically, showing output fullscreen",
-	Long:  "https://linux.die.net/man/1/watch",
+	Long:  "https://man7.org/linux/man-pages/man1/watch.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -22,13 +23,17 @@ func init() {
 	rootCmd.Flags().BoolP("chgexit", "g", false, "exit when output from command changes")
 	rootCmd.Flags().BoolP("color", "c", false, "interpret ANSI color and style sequences")
 	rootCmd.Flags().StringP("differences", "d", "", "highlight changes between updates")
+	rootCmd.Flags().StringP("equexit", "q", "", "exit when output from command does not change")
 	rootCmd.Flags().BoolP("errexit", "e", false, "exit if command has a non-zero exit")
 	rootCmd.Flags().BoolP("exec", "x", false, "pass command to exec instead of \"sh -c\"")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
 	rootCmd.Flags().StringP("interval", "n", "", "seconds to wait between updates")
+	rootCmd.Flags().BoolP("no-color", "C", false, "do not interpret ANSI color and style sequences")
+	rootCmd.Flags().BoolP("no-rerun", "r", false, "do not rerun program on window resize")
 	rootCmd.Flags().BoolP("no-title", "t", false, "turn off header")
 	rootCmd.Flags().BoolP("no-wrap", "w", false, "turn off line wrapping")
 	rootCmd.Flags().BoolP("precise", "p", false, "attempt run command in precise intervals")
+	rootCmd.Flags().BoolP("shotsdir", "s", false, "directory to store screenshots")
 	rootCmd.Flags().BoolP("version", "v", false, "output version information and exit")
 
 	rootCmd.Flag("differences").NoOptDefVal = " "


### PR DESCRIPTION
- Added new completers:
  - `pidof`
  - `tload`
  - `pwdx`
  - `slabtop`

- Updated the following to procps-ng 4.0.5:
  - `w`
  - `uptime`
  - `pidwait` (previously `pwait`)
  - `watch`