### PR TITLE
 Added pmap; update pgrep, pkill, sysctl, top to 4.0.5   

### DIFF
--- a/completers/pgrep_completer/cmd/root.go
+++ b/completers/pgrep_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/env"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/os"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
 	"github.com/spf13/cobra"
@@ -10,23 +11,27 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "pgrep",
 	Short: "look up processes based on name and other attributes",
-	Long:  "https://linux.die.net/man/1/pgrep",
+	Long:  "https://man7.org/linux/man-pages/man1/pgrep.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().String("cgroup", "", "match by cgroup v2 names")
 	rootCmd.Flags().BoolP("count", "c", false, "count of matching processes")
 	rootCmd.Flags().StringP("delimiter", "d", "", "specify output delimiter")
+	rootCmd.Flags().String("env", "", "match on environment variable")
 	rootCmd.Flags().StringP("euid", "u", "", "match by effective IDs")
 	rootCmd.Flags().BoolP("exact", "x", false, "match exactly with the command name")
 	rootCmd.Flags().BoolP("full", "f", false, "use full process name to match")
 	rootCmd.Flags().StringP("group", "G", "", "match real group IDs")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().BoolP("ignore-ancestors", "A", false, "exclude our ancestors from results")
 	rootCmd.Flags().BoolP("ignore-case", "i", false, "match case insensitively")
 	rootCmd.Flags().BoolP("inverse", "v", false, "negates the matching")
 	rootCmd.Flags().BoolP("lightweight", "w", false, "list all TID")
@@ -43,11 +48,13 @@ func init() {
 	rootCmd.Flags().StringP("pidfile", "F", "", "read PIDs from file")
 	rootCmd.Flags().StringP("runstates", "r", "", "match runstates")
 	rootCmd.Flags().StringP("session", "s", "", "match session IDs")
+	rootCmd.Flags().String("signal", "", "signal to send (either number or name)")
 	rootCmd.Flags().StringP("terminal", "t", "", "match by controlling terminal")
 	rootCmd.Flags().StringP("uid", "U", "", "match by real IDs")
 	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"env":       env.ActionNameValues(false).UniqueList(","),
 		"euid":      os.ActionUsers(),
 		"group":     os.ActionGroups().UniqueList(","),
 		"ns":        ps.ActionProcessIds(),
@@ -56,6 +63,7 @@ func init() {
 		"pidfile":   carapace.ActionFiles(),
 		"runstates": ps.ActionProcessStates().UniqueList(","),
 		"session":   os.ActionSessionIds().UniqueList(","),
+		"signal":    ps.ActionKillSignals(),
 		"terminal":  os.ActionTerminals().UniqueList(","),
 		"uid":       os.ActionUsers(),
 	})

--- a/completers/pkill_completer/cmd/root.go
+++ b/completers/pkill_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/env"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/os"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
 	"github.com/spf13/cobra"
@@ -10,32 +11,39 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "pkill",
 	Short: "look up for processes based on name and other attributes",
-	Long:  "https://linux.die.net/man/1/pkill",
+	Long:  "https://man7.org/linux/man-pages/man1/pgrep.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().String("cgroup", "", "match by cgroup v2 names")
 	rootCmd.Flags().BoolP("count", "c", false, "count of matching processes")
 	rootCmd.Flags().BoolP("echo", "e", false, "display what is killed")
+	rootCmd.Flags().String("env", "", "match on environment variable")
 	rootCmd.Flags().StringP("euid", "u", "", "match by effective IDs")
 	rootCmd.Flags().BoolP("exact", "x", false, "match exactly with the command name")
 	rootCmd.Flags().BoolP("full", "f", false, "use full process name to match")
 	rootCmd.Flags().StringP("group", "G", "", "match real group IDs")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().BoolP("ignore-ancestors", "A", false, "exclude our ancestors from results")
 	rootCmd.Flags().BoolP("ignore-case", "i", false, "match case insensitively")
 	rootCmd.Flags().BoolP("logpidfile", "L", false, "fail if PID file is not locked")
 	rootCmd.Flags().BoolP("newest", "n", false, "select most recently started")
 	rootCmd.Flags().String("ns", "", "match the processes that belong to the same namespace as <pid>")
 	rootCmd.Flags().String("nslist", "", "list which namespaces will be considered for the --ns option.")
+	rootCmd.Flags().StringP("older", "O", "", "select where older than seconds")
 	rootCmd.Flags().BoolP("oldest", "o", false, "select least recently started")
 	rootCmd.Flags().StringP("parent", "P", "", "match only child processes of the given parent")
 	rootCmd.Flags().StringP("pgroup", "g", "", "match listed process group IDs")
 	rootCmd.Flags().StringP("pidfile", "F", "", "read PIDs from file")
+	rootCmd.Flags().StringP("queue", "q", "", "integer value to be sent with the signal")
+	rootCmd.Flags().BoolP("require-handler", "H", false, "match only if signal handler is present")
 	rootCmd.Flags().StringP("runstates", "r", "", "match runstates [D,S,Z,...]")
 	rootCmd.Flags().StringP("session", "s", "", "match session IDs")
 	rootCmd.Flags().String("signal", "", "signal to send (either number or name)")
@@ -44,6 +52,7 @@ func init() {
 	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"env":       env.ActionNameValues(false).UniqueList(","),
 		"euid":      os.ActionUsers(),
 		"group":     os.ActionGroups(),
 		"nslist":    carapace.ActionValues("ipc", "mnt", "net", "pid", "user", "uts").UniqueList(","),

--- a/completers/pmap_completer/cmd/root.go
+++ b/completers/pmap_completer/cmd/root.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "pmap",
+	Short: "report memory map of a process",
+	Long:  "https://man7.org/linux/man-pages/man1/pmap.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("X", "X", false, "show even more details")
+	rootCmd.Flags().BoolS("XX", "XX", false, "show everything the kernel provides")
+	rootCmd.Flags().BoolP("create-rc", "n", false, "create new default rc")
+	rootCmd.Flags().StringP("create-rc-to", "N", "", "create new rc to file")
+	rootCmd.Flags().BoolP("device", "d", false, "show the device format")
+	rootCmd.Flags().BoolP("extended", "x", false, "show details")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
+	rootCmd.Flags().BoolP("quiet", "q", false, "do not display header and footer")
+	rootCmd.Flags().StringP("range", "A", "", "limit results to the given range")
+	rootCmd.Flags().BoolP("read-rc", "c", false, "read the default rc")
+	rootCmd.Flags().StringP("read-rc-from", "C", "", "read the rc from file")
+	rootCmd.Flags().BoolP("show-path", "p", false, "show path in the mapping")
+	rootCmd.Flags().BoolP("version", "V", false, "output version information and exit")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"create-rc-to": carapace.ActionFiles(),
+		"read-rc-from": carapace.ActionFiles(),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		ps.ActionProcessIds(),
+	)
+}

--- a/completers/pmap_completer/main.go
+++ b/completers/pmap_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/pmap_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/sysctl_completer/cmd/root.go
+++ b/completers/sysctl_completer/cmd/root.go
@@ -10,13 +10,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "sysctl",
 	Short: "configure kernel parameters at runtime",
-	Long:  "https://linux.die.net/man/8/sysctl",
+	Long:  "https://man7.org/linux/man-pages/man8/sysctl.8.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -26,6 +27,7 @@ func init() {
 	rootCmd.Flags().BoolP("binary", "b", false, "print value without new line")
 	rootCmd.Flags().BoolS("d", "d", false, "alias of -h")
 	rootCmd.Flags().Bool("deprecated", false, "include deprecated parameters to listing")
+	rootCmd.Flags().Bool("dry-run", false, "Print the key and values but do not write")
 	rootCmd.Flags().BoolS("f", "f", false, "alias of -p")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help and exit")
 	rootCmd.Flags().BoolP("ignore", "e", false, "ignore unknown variables errors")

--- a/completers/top_completer/cmd/root.go
+++ b/completers/top_completer/cmd/root.go
@@ -11,38 +11,40 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "top",
 	Short: "display Linux processes",
-	Long:  "https://linux.die.net/man/1/top",
+	Long:  "https://man7.org/linux/man-pages/man1/top.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("1", "1", false, "Starts top with the last remembered Cpu States portion of the  summary  area  reversed.")
-	rootCmd.Flags().StringS("E", "E", "", "Instructs top to force summary area memory to be scaled as")
-	rootCmd.Flags().BoolS("H", "H", false, "Instructs  top  to  display  individual  threads.")
-	rootCmd.Flags().StringS("O", "O", "", "print available field names")
-	rootCmd.Flags().BoolS("S", "S", false, "Starts  top  with the last remembered `S' state reversed.")
-	rootCmd.Flags().StringS("U", "U", "", "Display  only  processes  with  a  user  id or user name matching that given.")
-	rootCmd.Flags().BoolS("b", "b", false, "Starts top in Batch mode")
-	rootCmd.Flags().BoolS("c", "c", false, "Starts top with the last remembered `c' state reversed")
-	rootCmd.Flags().StringS("d", "d", "", "Specifies the delay between screen updates")
-	rootCmd.Flags().StringS("e", "e", "", "Instructs top to force task area memory to be scaled as")
-	rootCmd.Flags().BoolS("h", "h", false, "show help")
-	rootCmd.Flags().BoolS("i", "i", false, "Starts top with the last remembered `i' state reversed")
-	rootCmd.Flags().StringS("n", "n", "", "Specifies  the  maximum  number  of  iterations,  or  frames, top should produce before ending.")
-	rootCmd.Flags().StringS("o", "o", "", "Specifies the name of the field on which tasks will be sorted")
-	rootCmd.Flags().StringS("p", "p", "", "Monitor  only  processes with specified process IDs")
-	rootCmd.Flags().BoolS("s", "s", false, "Starts top with secure mode forced, even for root.")
-	rootCmd.Flags().StringS("u", "u", "", "Display  only  processes  with  a  user  id or user name matching that given.")
-	rootCmd.Flags().BoolS("v", "v", false, "show version")
-	rootCmd.Flags().BoolS("w", "w", false, "val    In Batch mode, when used without an argument top will format output using the  COLUMNS= and  LINES=  environment  variables, if  set.")
+	rootCmd.Flags().BoolP("accum-time-toggle", "S", false, "Starts top with the last remembered 'S' state reversed.")
+	rootCmd.Flags().BoolP("apply-defaults", "A", false, "Run top with build defaults only, ignoring all configuration files except /etc/toprc.")
+	rootCmd.Flags().BoolP("batch", "b", false, "Starts top in Batch mode")
+	rootCmd.Flags().BoolP("cmdline-toggle", "c", false, "Starts top with the last remembered 'c' state reversed.")
+	rootCmd.Flags().StringP("delay", "d", "", "Specifies the delay between screen updates")
+	rootCmd.Flags().StringP("filter-any-user", "U", "", "Display only processes with a user id or user name matching that given.")
+	rootCmd.Flags().StringP("filter-only-euser", "u", "", "Display only processes with a user id or user name matching that given.")
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage help text, then quit.")
+	rootCmd.Flags().BoolP("idle-toggle", "i", false, "Starts top with the last remembered 'i' state reversed.")
+	rootCmd.Flags().StringP("iterations", "n", "", "Specifies the maximum number of iterations, or frames, top should produce before ending.")
+	rootCmd.Flags().StringP("list-fields", "O", "", "print available field names")
+	rootCmd.Flags().StringP("pid", "p", "", "Monitor only processes with specified process IDs.")
+	rootCmd.Flags().StringP("scale-summary-mem", "E", "", "Instructs top to force summary area memory to be scaled as")
+	rootCmd.Flags().StringP("scale-task-mem", "e", "", "Instructs top to force task area memory to be scaled as")
+	rootCmd.Flags().BoolP("secure-mode", "s", false, "Starts top with secure mode forced, even for root.")
+	rootCmd.Flags().BoolP("single-cpu-toggle", "1", false, "Starts top with the last remembered Cpu States portion of the summary area reversed.")
+	rootCmd.Flags().StringP("sort-override", "o", "", "Specifies the name of the field on which tasks will be sorted")
+	rootCmd.Flags().BoolP("threads-show", "H", false, "Instructs top to display individual threads.")
+	rootCmd.Flags().BoolP("version", "V", false, "Display version information, then quit.")
+	rootCmd.Flags().BoolP("width", "w", false, "In Batch mode, when used without an argument top will format output using the COLUMNS= and LINES= environment variables, if set.")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"E": carapace.ActionValuesDescribed(
+		"scale-summary-mem": carapace.ActionValuesDescribed(
 			"k", "kibibytes",
 			"m", "mebibytes",
 			"g", "gibibytes",
@@ -50,16 +52,16 @@ func init() {
 			"p", "pebibytes",
 			"e", "exbibytes",
 		),
-		"U": os.ActionUsers(),
-		"e": carapace.ActionValuesDescribed(
+		"filter-any-user": os.ActionUsers(),
+		"scale-task-mem": carapace.ActionValuesDescribed(
 			"k", "kibibytes",
 			"m", "mebibytes",
 			"g", "gibibytes",
 			"t", "tebibytes",
 			"p", "pebibytes",
 		),
-		"o": action.ActionFields(),
-		"p": ps.ActionProcessIds().UniqueList(","),
-		"u": os.ActionUsers(),
+		"sort-override":     action.ActionFields(),
+		"pid":               ps.ActionProcessIds().UniqueList(","),
+		"filter-only-euser": os.ActionUsers(),
 	})
 }


### PR DESCRIPTION
- Added new completers:
  - `pmap`

- Updated the following to procps-ng 4.0.5:
  - `pgrep`
  - `pkill`
  - `sysctl`
  - `top`