### PR TITLE
tsh: improved kube clusters integration

### DIFF
--- a/completers/tsh_completer/cmd/kube_login.go
+++ b/completers/tsh_completer/cmd/kube_login.go
@@ -28,4 +28,8 @@ func init() {
 	carapace.Gen(kube_loginCmd).FlagCompletion(carapace.ActionMap{
 		"cluster": tsh.ActionClusters(),
 	})
+
+	carapace.Gen(kube_loginCmd).PositionalCompletion(
+		tsh.ActionKubeClusters(),
+	)
 }

--- a/completers/tsh_completer/cmd/proxy_kube.go
+++ b/completers/tsh_completer/cmd/proxy_kube.go
@@ -22,6 +22,9 @@ func init() {
 	proxy_kubeCmd.Flags().StringP("format", "f", "", "Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.")
 	proxy_kubeCmd.Flags().StringP("kube-namespace", "n", "", "Configure the default Kubernetes namespace.")
 	proxy_kubeCmd.Flags().StringP("port", "p", "", "Specifies the source port used by the proxy listener")
+	proxy_kubeCmd.Flags().StringP("set-context-name", "", "", "Define a custom context name or template.")
+	proxy_kubeCmd.Flags().StringArrayP("labels", "", nil, "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)")
+	proxy_kubeCmd.Flags().BoolP("exec", "", false, "Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.")
 	proxyCmd.AddCommand(proxy_kubeCmd)
 
 	carapace.Gen(proxy_kubeCmd).FlagCompletion(carapace.ActionMap{

--- a/completers/tsh_completer/cmd/proxy_kube.go
+++ b/completers/tsh_completer/cmd/proxy_kube.go
@@ -19,12 +19,12 @@ func init() {
 	proxy_kubeCmd.Flags().String("as", "", "Configure custom Kubernetes user impersonation.")
 	proxy_kubeCmd.Flags().String("as-groups", "", "Configure custom Kubernetes group impersonation.")
 	proxy_kubeCmd.Flags().StringP("cluster", "c", "", "Specify the Teleport cluster to connect")
+	proxy_kubeCmd.Flags().BoolP("exec", "", false, "Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.")
 	proxy_kubeCmd.Flags().StringP("format", "f", "", "Optional format to print the commands for setting environment variables, one of: unix, command-prompt, powershell, text. Default is unix.")
 	proxy_kubeCmd.Flags().StringP("kube-namespace", "n", "", "Configure the default Kubernetes namespace.")
+	proxy_kubeCmd.Flags().StringArrayP("labels", "", nil, "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)")
 	proxy_kubeCmd.Flags().StringP("port", "p", "", "Specifies the source port used by the proxy listener")
 	proxy_kubeCmd.Flags().StringP("set-context-name", "", "", "Define a custom context name or template.")
-	proxy_kubeCmd.Flags().StringArrayP("labels", "", nil, "List of comma separated labels to filter by labels (e.g. key1=value1,key2=value2)")
-	proxy_kubeCmd.Flags().BoolP("exec", "", false, "Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.")
 	proxyCmd.AddCommand(proxy_kubeCmd)
 
 	carapace.Gen(proxy_kubeCmd).FlagCompletion(carapace.ActionMap{

--- a/completers/tsh_completer/cmd/proxy_kube.go
+++ b/completers/tsh_completer/cmd/proxy_kube.go
@@ -29,4 +29,8 @@ func init() {
 		"format":  carapace.ActionValues("unix", "command-prompt", "powershell", "text"),
 		"port":    net.ActionPorts(),
 	})
+
+	carapace.Gen(proxy_kubeCmd).PositionalCompletion(
+		tsh.ActionKubeClusters(),
+	)
 }

--- a/pkg/actions/tools/tsh/kube.go
+++ b/pkg/actions/tools/tsh/kube.go
@@ -1,0 +1,27 @@
+package tsh
+
+import (
+	"encoding/json"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+)
+
+func ActionKubeClusters() carapace.Action {
+	return carapace.ActionExecCommand("tsh", "kube", "ls", "--format", "json")(func(output []byte) carapace.Action {
+		var clusters []struct {
+			KubeClusterName string `json:"kube_cluster_name"`
+		}
+
+		if err := json.Unmarshal(output, &clusters); err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		vals := make([]string, 0)
+		for _, cluster := range clusters {
+			s := style.Green
+			vals = append(vals, cluster.KubeClusterName, s)
+		}
+		return carapace.ActionStyledValues(vals...)
+	})
+}


### PR DESCRIPTION
This PR adds support for listing Kubernetes clusters from a Teleport cluster and adds dynamic completion for the `tsh proxy kube` and `tsh kube login` commands.