### PR TITLE
Add/update completers for util-linux 2.41

### DIFF
--- a/completers/cal_completer/cmd/root.go
+++ b/completers/cal_completer/cmd/root.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "cal",
+	Short: "display a calendar",
+	Long:  "https://man7.org/linux/man-pages/man1/cal.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().String("color", "", "colorize messages")
+	rootCmd.Flags().StringP("columns", "c", "", "amount of columns to use")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().Bool("iso", false, "alias for --reform=iso")
+	rootCmd.Flags().BoolP("julian", "j", false, "use day-of-year for all calendars")
+	rootCmd.Flags().BoolP("monday", "m", false, "Monday as first day of week")
+	rootCmd.Flags().StringP("months", "n", "", "show num months starting with date's month")
+	rootCmd.Flags().BoolP("one", "1", false, "show only a single month (default)")
+	rootCmd.Flags().String("reform", "", "Gregorian reform date")
+	rootCmd.Flags().BoolP("span", "S", false, "span the date when displaying multiple months")
+	rootCmd.Flags().BoolP("sunday", "s", false, "Sunday as first day of week")
+	rootCmd.Flags().BoolP("three", "3", false, "show three months spanning the date")
+	rootCmd.Flags().BoolP("twelve", "Y", false, "show the next twelve months")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+	rootCmd.Flags().BoolP("vertical", "v", false, "show day vertically instead of line")
+	rootCmd.Flags().StringP("week", "w", "", "show US or ISO-8601 week numbers")
+	rootCmd.Flags().BoolP("year", "y", false, "show the whole year")
+
+	rootCmd.Flag("color").NoOptDefVal = " "
+	rootCmd.Flag("week").NoOptDefVal = " "
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"color":  carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
+		"reform": carapace.ActionValues("1752", "gregorian", "iso", "julian"),
+	})
+}

--- a/completers/cal_completer/main.go
+++ b/completers/cal_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/cal_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/chcpu_completer/cmd/root.go
+++ b/completers/chcpu_completer/cmd/root.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "chcpu",
+	Short: "configure CPUs",
+	Long:  "https://man7.org/linux/man-pages/man8/chcpu.8.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("configure", "c", "", "configure cpus")
+	rootCmd.Flags().StringP("deconfigure", "g", "", "deconfigure cpus")
+	rootCmd.Flags().StringP("disable", "d", "", "disable cpus")
+	rootCmd.Flags().StringP("dispatch", "p", "", "set dispatching mode")
+	rootCmd.Flags().StringP("enable", "e", "", "enable cpus")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().BoolP("rescan", "r", false, "trigger rescan of cpus")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"dispatch": carapace.ActionValues("horizontal", "vertical"),
+	})
+}

--- a/completers/chcpu_completer/main.go
+++ b/completers/chcpu_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/chcpu_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/lsblk_completer/cmd/action/action.go
+++ b/completers/lsblk_completer/cmd/action/action.go
@@ -1,0 +1,24 @@
+package action
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+func ActionColumns() carapace.Action {
+	return carapace.ActionExecCommand("lsblk", "--list-columns")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`^\s*(\S+)\s+<[^>]+>\s+(.*)$`)
+		var values []string
+
+		for _, line := range strings.Split(string(output), "\n") {
+			if matches := re.FindStringSubmatch(line); len(matches) == 3 {
+				name, description := matches[1], matches[2]
+				values = append(values, name, description)
+			}
+		}
+
+		return carapace.ActionValuesDescribed(values...)
+	})
+}

--- a/completers/lsblk_completer/cmd/root.go
+++ b/completers/lsblk_completer/cmd/root.go
@@ -2,123 +2,81 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/lsblk_completer/cmd/action"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/fs"
+	"github.com/carapace-sh/carapace/pkg/style"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "lsblk",
 	Short: "list block devices",
-	Long:  "https://linux.die.net/man/8/lsblk",
+	Long:  "https://man7.org/linux/man-pages/man8/lsblk.8.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	rootCmd.Flags().BoolP("all", "a", false, "print all devices")
 	rootCmd.Flags().BoolP("ascii", "i", false, "use ascii characters only")
 	rootCmd.Flags().BoolP("bytes", "b", false, "print SIZE in bytes rather than in human readable format")
+	rootCmd.Flags().String("ct", "", "define a custom counter")
+	rootCmd.Flags().String("ct-filter", "", "restrict the next counter")
 	rootCmd.Flags().StringP("dedup", "E", "", "de-duplicate output by <column>")
 	rootCmd.Flags().BoolP("discard", "D", false, "print discard capabilities")
 	rootCmd.Flags().StringP("exclude", "e", "", "exclude devices by major number (default: RAM disks)")
+	rootCmd.Flags().StringP("filter", "Q", "", "print only lines matching the expression")
 	rootCmd.Flags().BoolP("fs", "f", false, "output info about filesystems")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().String("highlight", "", "colorize lines matching the expression")
+	rootCmd.Flags().String("hyperlink", "", "Print mountpoint paths as terminal hyperlinks")
 	rootCmd.Flags().StringP("include", "I", "", "show only devices with specified major numbers")
 	rootCmd.Flags().BoolP("inverse", "s", false, "inverse dependencies")
 	rootCmd.Flags().BoolP("json", "J", false, "use JSON output format")
 	rootCmd.Flags().BoolP("list", "l", false, "use list format output")
+	rootCmd.Flags().BoolP("list-columns", "H", false, "list the available columns")
 	rootCmd.Flags().BoolP("merge", "M", false, "group parents of sub-trees (usable for RAIDs, Multi-path)")
 	rootCmd.Flags().BoolP("nodeps", "d", false, "don't print slaves or holders")
+	rootCmd.Flags().BoolP("noempty", "A", false, "don't print empty devices")
 	rootCmd.Flags().BoolP("noheadings", "n", false, "don't print headings")
+	rootCmd.Flags().BoolP("nvme", "N", false, "output info about NVMe devices")
 	rootCmd.Flags().StringP("output", "o", "", "output columns")
 	rootCmd.Flags().BoolP("output-all", "O", false, "output all columns")
 	rootCmd.Flags().BoolP("pairs", "P", false, "use key=\"value\" output format")
 	rootCmd.Flags().BoolP("paths", "p", false, "print complete device path")
 	rootCmd.Flags().BoolP("perms", "m", false, "output info about permissions")
+	rootCmd.Flags().String("properties-by", "", "methods used to gather data")
 	rootCmd.Flags().BoolP("raw", "r", false, "use raw output format")
 	rootCmd.Flags().BoolP("scsi", "S", false, "output info about SCSI devices")
+	rootCmd.Flags().BoolP("shell", "y", false, "use column names that can be used as shell variables")
 	rootCmd.Flags().StringP("sort", "x", "", "sort output by <column>")
 	rootCmd.Flags().String("sysroot", "", "use specified directory as system root")
 	rootCmd.Flags().BoolP("topology", "t", false, "output info about topology")
 	rootCmd.Flags().StringP("tree", "T", "", "use tree format output")
 	rootCmd.Flags().BoolP("version", "V", false, "display version")
-	rootCmd.Flags().BoolP("zoned", "z", false, "print zone model")
+	rootCmd.Flags().BoolP("virtio", "v", false, "output info about virtio devices")
+	rootCmd.Flags().StringP("width", "w", "", "specifies output width as number of characters")
+	rootCmd.Flags().BoolP("zoned", "z", false, "print zone related information")
 
+	rootCmd.Flag("hyperlink").NoOptDefVal = " "
 	rootCmd.Flag("tree").NoOptDefVal = " "
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"dedup":   ActionColumns().UniqueList(","),
-		"output":  ActionColumns().UniqueList(","),
-		"sort":    ActionColumns(),
-		"sysroot": carapace.ActionDirectories(),
-		"tree":    ActionColumns(),
+		"dedup":         action.ActionColumns().UniqueList(","),
+		"hyperlink":     carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
+		"output":        action.ActionColumns().UniqueList(","),
+		"properties-by": carapace.ActionValues("udev", "blkid", "file", "none").UniqueList(","),
+		"sort":          action.ActionColumns(),
+		"sysroot":       carapace.ActionDirectories(),
+		"tree":          action.ActionColumns(),
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
 		fs.ActionBlockDevices(),
-	)
-}
-
-func ActionColumns() carapace.Action {
-	return carapace.ActionValuesDescribed(
-		"NAME", "device name",
-		"KNAME", "internal kernel device name",
-		"PATH", "path to the device node",
-		"MAJ:MIN", "major:minor device number",
-		"FSAVAIL", "filesystem size available",
-		"FSSIZE", "filesystem size",
-		"FSTYPE", "filesystem type",
-		"FSUSED", "filesystem size used",
-		"FSUSE%", "filesystem use percentage",
-		"FSVER", "filesystem version",
-		"MOUNTPOINT", "where the device is mounted",
-		"LABEL", "filesystem LABEL",
-		"UUID", "filesystem UUID",
-		"PTUUID", "partition table identifier (usually UUID)",
-		"PTTYPE", "partition table type",
-		"PARTTYPE", "partition type code or UUID",
-		"PARTTYPENAME", "partition type name",
-		"PARTLABEL", "partition LABEL",
-		"PARTUUID", "partition UUID",
-		"PARTFLAGS", "partition flags",
-		"RA", "read-ahead of the device",
-		"RO", "read-only device",
-		"RM", "removable device",
-		"HOTPLUG", "removable or hotplug device (usb, pcmcia, ...)",
-		"MODEL", "device identifier",
-		"SERIAL", "disk serial number",
-		"SIZE", "size of the device",
-		"STATE", "state of the device",
-		"OWNER", "user name",
-		"GROUP", "group name",
-		"MODE", "device node permissions",
-		"ALIGNMENT", "alignment offset",
-		"MIN-IO", "minimum I/O size",
-		"OPT-IO", "optimal I/O size",
-		"PHY-SEC", "physical sector size",
-		"LOG-SEC", "logical sector size",
-		"ROTA", "rotational device",
-		"SCHED", "I/O scheduler name",
-		"RQ-SIZE", "request queue size",
-		"TYPE", "device type",
-		"DISC-ALN", "discard alignment offset",
-		"DISC-GRAN", "discard granularity",
-		"DISC-MAX", "discard max bytes",
-		"DISC-ZERO", "discard zeroes data",
-		"WSAME", "write same max bytes",
-		"WWN", "unique storage identifier",
-		"RAND", "adds randomness",
-		"PKNAME", "internal parent kernel device name",
-		"HCTL", "Host:Channel:Target:Lun for SCSI",
-		"TRAN", "device transport type",
-		"SUBSYSTEMS", "de-duplicated chain of subsystems",
-		"REV", "device revision",
-		"VENDOR", "device vendor",
-		"ZONED", "zone model",
-		"DAX", "dax-capable device",
 	)
 }

--- a/completers/lscpu_completer/cmd/root.go
+++ b/completers/lscpu_completer/cmd/root.go
@@ -2,19 +2,21 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "lscpu",
 	Short: "display information about the CPU architecture",
-	Long:  "https://linux.die.net/man/1/lscpu",
+	Long:  "https://man7.org/linux/man-pages/man1/lscpu.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -24,32 +26,38 @@ func init() {
 	rootCmd.Flags().StringP("extended", "e", "", "print out an extended readable format")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
 	rootCmd.Flags().BoolP("hex", "x", false, "print hexadecimal masks rather than lists of CPUs")
+	rootCmd.Flags().String("hierarchic", "", "use subsections in summary")
 	rootCmd.Flags().BoolP("json", "J", false, "use JSON for default or extended format")
 	rootCmd.Flags().BoolP("offline", "c", false, "print offline CPUs only")
 	rootCmd.Flags().BoolP("online", "b", false, "print online CPUs only (default for -p)")
 	rootCmd.Flags().Bool("output-all", false, "print all available columns for -e, -p or -C")
 	rootCmd.Flags().StringP("parse", "p", "", "print out a parsable format")
 	rootCmd.Flags().BoolP("physical", "y", false, "print physical instead of logical IDs")
+	rootCmd.Flags().BoolP("raw", "r", false, "use raw output format (for -e, -p and -C)")
 	rootCmd.Flags().StringP("sysroot", "s", "", "use specified directory as system root")
 	rootCmd.Flags().BoolP("version", "V", false, "display version")
 
 	rootCmd.Flag("caches").NoOptDefVal = " "
 	rootCmd.Flag("extended").NoOptDefVal = " "
+	rootCmd.Flag("hierarchic").NoOptDefVal = " "
 	rootCmd.Flag("parse").NoOptDefVal = " "
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"caches":   ActionCacheColumns().UniqueList(","),
-		"extended": ActionFormatColumns().UniqueList(","),
-		"parse":    ActionFormatColumns().UniqueList(","),
-		"sysroot":  carapace.ActionDirectories(),
+		"caches":     ActionCacheColumns().UniqueList(","),
+		"extended":   ActionFormatColumns().UniqueList(","),
+		"hierarchic": carapace.ActionValues("auto", "always", "never").StyleF(style.ForKeyword),
+		"parse":      ActionFormatColumns().UniqueList(","),
+		"sysroot":    carapace.ActionDirectories(),
 	})
 }
 
 func ActionFormatColumns() carapace.Action {
 	return carapace.ActionValuesDescribed(
+		"BOGOMIPS", "crude measurement of CPU speed",
 		"CPU", "logical CPU number",
 		"CORE", "logical core number",
 		"SOCKET", "logical socket number",
+		"CLUSTER", "logical cluster number",
 		"NODE", "logical NUMA node number",
 		"BOOK", "logical book number",
 		"DRAWER", "logical drawer number",
@@ -58,8 +66,11 @@ func ActionFormatColumns() carapace.Action {
 		"ADDRESS", "physical address of a CPU",
 		"CONFIGURED", "shows if the hypervisor has allocated the CPU",
 		"ONLINE", "shows if Linux currently makes use of the CPU",
+		"MHZ", "shows the current MHz of the CPU",
+		"SCALMHZ%", "shows scaling percentage of the CPU frequency",
 		"MAXMHZ", "shows the maximum MHz of the CPU",
 		"MINMHZ", "shows the minimum MHz of the CPU",
+		"MODELNAME", "shows CPU model name",
 	)
 }
 

--- a/completers/lsfd_completer/cmd/action/action.go
+++ b/completers/lsfd_completer/cmd/action/action.go
@@ -1,0 +1,24 @@
+package action
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+func ActionColumns() carapace.Action {
+	return carapace.ActionExecCommand("lsfd", "--list-columns")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`^\s*(\S+)\s+<[^>]+>\s+(.*)$`)
+		var values []string
+
+		for _, line := range strings.Split(string(output), "\n") {
+			if matches := re.FindStringSubmatch(line); len(matches) == 3 {
+				name, description := matches[1], matches[2]
+				values = append(values, name, description)
+			}
+		}
+
+		return carapace.ActionValuesDescribed(values...)
+	})
+}

--- a/completers/lsfd_completer/cmd/root.go
+++ b/completers/lsfd_completer/cmd/root.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/lsfd_completer/cmd/action"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "lsfd",
+	Short: "list file descriptors",
+	Long:  "https://man7.org/linux/man-pages/man1/lsfd.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().Bool("_drop-privilege", false, "(testing purpose) do setuid(1) just after starting")
+	rootCmd.Flags().StringP("counter", "C", "", "define custom counter for --summary output")
+	rootCmd.Flags().Bool("debug-filter", false, "dump the internal data structure of filter and exit")
+	rootCmd.Flags().Bool("dump-counters", false, "dump counter definitions")
+	rootCmd.Flags().StringP("filter", "Q", "", "apply display filter")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().String("hyperlink", "", "print paths as terminal hyperlinks")
+	rootCmd.Flags().StringP("inet", "i", "", "list only IPv4 and/or IPv6 sockets")
+	rootCmd.Flags().BoolP("json", "J", false, "use JSON output format")
+	rootCmd.Flags().BoolP("list-columns", "H", false, "list the available columns")
+	rootCmd.Flags().BoolP("noheadings", "n", false, "don't print headings")
+	rootCmd.Flags().BoolP("notruncate", "u", false, "don't truncate text in columns")
+	rootCmd.Flags().StringP("output", "o", "", "output columns (see --list-columns)")
+	rootCmd.Flags().StringP("pid", "p", "", "collect information only specified processes")
+	rootCmd.Flags().BoolP("raw", "r", false, "use raw output format")
+	rootCmd.Flags().String("summary", "", "print summary information")
+	rootCmd.Flags().BoolP("threads", "l", false, "list in threads level")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	rootCmd.Flag("hyperlink").NoOptDefVal = " "
+	rootCmd.Flag("inet").NoOptDefVal = " "
+	rootCmd.Flag("summary").NoOptDefVal = " "
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"hyperlink": carapace.ActionValues("auto", "always", "never").StyleF(style.ForKeyword),
+		"inet":      carapace.ActionValues("4", "6"),
+		"output":    action.ActionColumns().UniqueList(","),
+		"pid":       ps.ActionProcessIds().UniqueList(","),
+		"summary":   carapace.ActionValues("only", "append", "never").StyleF(style.ForKeyword),
+	})
+}

--- a/completers/lsfd_completer/main.go
+++ b/completers/lsfd_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/lsfd_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/more_completer/cmd/root.go
+++ b/completers/more_completer/cmd/root.go
@@ -7,18 +7,20 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "more",
-	Short: "file perusal filter for crt viewing",
-	Long:  "https://linux.die.net/man/1/more",
+	Short: "display the contents of a file in a terminal",
+	Long:  "https://man7.org/linux/man-pages/man1/more.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	rootCmd.Flags().BoolP("clean-print", "p", false, "do not scroll, clean screen and display text")
+	rootCmd.Flags().BoolP("exit-on-eof", "e", false, "exit on end-of-file")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
 	rootCmd.Flags().StringP("lines", "n", "", "the number of lines per screenful")
 	rootCmd.Flags().BoolP("logical", "f", false, "count logical rather than screen lines")

--- a/completers/script_completer/cmd/root.go
+++ b/completers/script_completer/cmd/root.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "script",
+	Short: "make typescript of terminal session",
+	Long:  "https://man7.org/linux/man-pages/man1/script.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("append", "a", false, "append to the log file")
+	rootCmd.Flags().StringP("command", "c", "", "run command rather than interactive shell")
+	rootCmd.Flags().StringP("echo", "E", "", "echo input in session (auto, always or never)")
+	rootCmd.Flags().BoolP("flush", "f", false, "run flush after each write")
+	rootCmd.Flags().Bool("force", false, "use output file even when it is a link")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().StringP("log-in", "I", "", "log stdin to file")
+	rootCmd.Flags().StringP("log-io", "B", "", "log stdin and stdout to file")
+	rootCmd.Flags().StringP("log-out", "O", "", "log stdout to file (default)")
+	rootCmd.Flags().StringP("log-timing", "T", "", "log timing information to file")
+	rootCmd.Flags().StringP("logging-format", "m", "", "force to 'classic' or 'advanced' format")
+	rootCmd.Flags().StringP("output-limit", "o", "", "terminate if output files exceed size")
+	rootCmd.Flags().BoolP("quiet", "q", false, "be quiet")
+	rootCmd.Flags().BoolP("return", "e", false, "return exit code of the child process")
+	rootCmd.Flags().StringP("timing", "t", "", "deprecated alias to -T (default file is stderr)")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	rootCmd.Flag("timing").NoOptDefVal = " "
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"echo":           carapace.ActionValues("auto", "always", "never").StyleF(style.ForKeyword),
+		"log-in":         carapace.ActionFiles(),
+		"log-io":         carapace.ActionFiles(),
+		"log-out":        carapace.ActionFiles(),
+		"log-timing":     carapace.ActionFiles(),
+		"logging-format": carapace.ActionValues("advanced", "classic"),
+		"timing":         carapace.ActionFiles(),
+	})
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/script_completer/main.go
+++ b/completers/script_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/script_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/scriptlive_completer/cmd/root.go
+++ b/completers/scriptlive_completer/cmd/root.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "scriptlive",
+	Short: "re-run session typescripts, using timing information",
+	Long:  "https://man7.org/linux/man-pages/man1/scriptlive.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("command", "c", "", "run command rather than interactive shell")
+	rootCmd.Flags().StringP("divisor", "d", "", "speed up or slow down execution with time divisor")
+	rootCmd.Flags().StringP("echo", "E", "", "echo input in session (auto, always or never)")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().StringP("log-in", "I", "", "script stdin log file")
+	rootCmd.Flags().StringP("log-io", "B", "", "script stdin and stdout log file")
+	rootCmd.Flags().StringP("log-timing", "T", "", "alias to -t")
+	rootCmd.Flags().StringP("maxdelay", "m", "", "wait at most this many seconds between updates")
+	rootCmd.Flags().StringP("timing", "t", "", "script timing log file")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"echo":       carapace.ActionValues("auto", "always", "never").StyleF(style.ForKeyword),
+		"log-in":     carapace.ActionFiles(),
+		"log-io":     carapace.ActionFiles(),
+		"log-timing": carapace.ActionFiles(),
+		"timing":     carapace.ActionFiles(),
+	})
+}

--- a/completers/scriptlive_completer/main.go
+++ b/completers/scriptlive_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/scriptlive_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/scriptreplay_completer/cmd/root.go
+++ b/completers/scriptreplay_completer/cmd/root.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "scriptreplay",
+	Short: "play back typescripts, using timing information",
+	Long:  "https://man7.org/linux/man-pages/man1/scriptreplay.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("cr-mode", "c", "", "CR char mode")
+	rootCmd.Flags().StringP("divisor", "d", "", "speed up or slow down execution with time divisor")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().StringP("log-in", "I", "", "script stdin log file")
+	rootCmd.Flags().StringP("log-io", "B", "", "script stdin and stdout log file")
+	rootCmd.Flags().StringP("log-out", "O", "", "script stdout log file (default)")
+	rootCmd.Flags().StringP("log-timing", "T", "", "alias to -t")
+	rootCmd.Flags().StringP("maxdelay", "m", "", "wait at most this many seconds between updates")
+	rootCmd.Flags().StringP("stream", "x", "", "stream type")
+	rootCmd.Flags().Bool("summary", false, "display overview about recorded session and exit")
+	rootCmd.Flags().StringP("timing", "t", "", "script timing log file")
+	rootCmd.Flags().StringP("typescript", "s", "", "deprecated alias to -O")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"cr-mode":    carapace.ActionValues("auto", "always", "never"),
+		"log-in":     carapace.ActionFiles(),
+		"log-io":     carapace.ActionFiles(),
+		"log-out":    carapace.ActionFiles(),
+		"log-timing": carapace.ActionFiles(),
+		"stream":     carapace.ActionValues("out", "in", "signal", "info"),
+		"timing":     carapace.ActionFiles(),
+		"typescript": carapace.ActionFiles(),
+	})
+}

--- a/completers/scriptreplay_completer/main.go
+++ b/completers/scriptreplay_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/scriptreplay_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/su_completer/cmd/root.go
+++ b/completers/su_completer/cmd/root.go
@@ -9,13 +9,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "su",
 	Short: "run a command with substitute user and group ID",
-	Long:  "https://linux.die.net/man/1/su",
+	Long:  "https://man7.org/linux/man-pages/man1/su.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -25,6 +26,7 @@ func init() {
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
 	rootCmd.Flags().BoolP("login", "l", false, "make the shell a login shell")
 	rootCmd.Flags().BoolS("m", "m", false, "do not reset environment variables")
+	rootCmd.Flags().BoolS("no-pty", "T", false, "do not create a new pseudo-terminal (bad security!)")
 	rootCmd.Flags().BoolP("preserve-environment", "p", false, "do not reset environment variables")
 	rootCmd.Flags().BoolP("pty", "P", false, "create a new pseudo-terminal")
 	rootCmd.Flags().String("session-command", "", "pass a single command and do not create a new session")


### PR DESCRIPTION
- Added new completers:
  - `chcpu`
  - `cal`
  - `script`
  - `scriptlive`
  - `scriptreplay`
  - `lsfd`

- Updated the following to util-linux 2.41:
  - `su`
  - `lsblk`
  - `more`
  - `lscpu`