### PR TITLE
Add/update completers for util-linux 2.41

### DIFF
--- a/completers/cfdisk_completer/cmd/root.go
+++ b/completers/cfdisk_completer/cmd/root.go
@@ -10,19 +10,22 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "cfdisk",
 	Short: "display or manipulate a disk partition table",
-	Long:  "https://en.wikipedia.org/wiki/Cfdisk",
+	Long:  "https://man7.org/linux/man-pages/man8/cfdisk.8.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	rootCmd.Flags().StringP("color", "L", "", "colorize output")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
 	rootCmd.Flags().String("lock", "", "use exclusive device lock")
+	rootCmd.Flags().BoolP("read-only", "r", false, "forced open cfdisk in read-only mode")
+	rootCmd.Flags().StringP("sector-size", "b", "", "physical and logical sector size")
 	rootCmd.Flags().BoolP("version", "V", false, "display version")
 	rootCmd.Flags().BoolP("zero", "z", false, "start with zeroed partition table")
 
@@ -30,8 +33,9 @@ func init() {
 	rootCmd.Flag("lock").NoOptDefVal = " "
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"color": carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
-		"lock":  carapace.ActionValues("yes", "no", "nonblock").StyleF(style.ForKeyword),
+		"color":       carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
+		"lock":        carapace.ActionValues("yes", "no", "nonblock").StyleF(style.ForKeyword),
+		"sector-size": carapace.ActionValues("512", "1024", "2048", "4096"),
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(

--- a/completers/lsclocks_completer/cmd/action/action.go
+++ b/completers/lsclocks_completer/cmd/action/action.go
@@ -1,0 +1,29 @@
+package action
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+func ActionColumns() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"TYPE", "type",
+		"ID", "numeric id",
+		"CLOCK", "symbolic name",
+		"NAME", "readable name",
+		"TIME", "numeric time",
+		"ISO_TIME", "human readable ISO time",
+		"RESOL", "human readable resolution",
+		"RESOL_RAW", "resolution",
+		"REL_TIME", "human readable relative time",
+		"NS_OFFSET", "namespace offset",
+	)
+}
+
+func ActionClocks() carapace.Action {
+	return carapace.ActionExecCommand("lsclocks", "--output", "CLOCK")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		return carapace.ActionValues(lines[1:]...)
+	})
+}

--- a/completers/lsclocks_completer/cmd/root.go
+++ b/completers/lsclocks_completer/cmd/root.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/lsclocks_completer/cmd/action"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "lsclocks",
+	Short: "display system clocks",
+	Long:  "https://man7.org/linux/man-pages/man1/lsclocks.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("cpu-clock", "c", "", "also display CPU clock of specified process")
+	rootCmd.Flags().StringP("dynamic-clock", "d", "", "also display specified dynamic clock")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().BoolP("json", "J", false, "use JSON output format")
+	rootCmd.Flags().Bool("no-discover-dynamic", false, "do not try to discover dynamic clocks")
+	rootCmd.Flags().BoolP("noheadings", "n", false, "don't print headings")
+	rootCmd.Flags().StringP("output", "o", "", "output columns")
+	rootCmd.Flags().Bool("output-all", false, "output all columns")
+	rootCmd.Flags().BoolP("raw", "r", false, "use raw output format")
+	rootCmd.Flags().StringP("time", "t", "", "show current time of single clock")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"cpu-clock":     ps.ActionProcessIds(),
+		"dynamic-clock": carapace.ActionFiles(),
+		"output":        action.ActionColumns().UniqueList(","),
+		"time":          action.ActionClocks(),
+	})
+}

--- a/completers/lsclocks_completer/main.go
+++ b/completers/lsclocks_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/lsclocks_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/lsirq_completer/cmd/action/action.go
+++ b/completers/lsirq_completer/cmd/action/action.go
@@ -1,0 +1,13 @@
+package action
+
+import (
+	"github.com/carapace-sh/carapace"
+)
+
+func ActionColumns() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"IRQ", "interrupts",
+		"TOTAL", "total count",
+		"NAME", "name",
+	)
+}

--- a/completers/lsirq_completer/cmd/root.go
+++ b/completers/lsirq_completer/cmd/root.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/lsirq_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "lsirq",
+	Short: "utility to display kernel interrupt information",
+	Long:  "https://man7.org/linux/man-pages/man1/lsirq.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("cpu-list", "C", "", "only show counters for these CPUs")
+	rootCmd.Flags().BoolP("help", "h", false, "display this help")
+	rootCmd.Flags().BoolP("json", "J", false, "use JSON output format")
+	rootCmd.Flags().BoolP("noheadings", "n", false, "don't print headings")
+	rootCmd.Flags().StringP("output", "o", "", "define which output columns to use")
+	rootCmd.Flags().BoolP("pairs", "P", false, "use key=\"value\" output format")
+	rootCmd.Flags().BoolP("softirq", "S", false, "show softirqs instead of interrupts")
+	rootCmd.Flags().StringP("sort", "s", "", "specify sort column")
+	rootCmd.Flags().StringP("threshold", "t", "", "only IRQs with counters above <N>")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"output": action.ActionColumns().UniqueList(","),
+		"sort":   action.ActionColumns(),
+	})
+}

--- a/completers/lsirq_completer/main.go
+++ b/completers/lsirq_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/lsirq_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/lslocks_completer/cmd/action/action.go
+++ b/completers/lslocks_completer/cmd/action/action.go
@@ -1,18 +1,24 @@
 package action
 
-import "github.com/carapace-sh/carapace"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
 
 func ActionColumns() carapace.Action {
-	return carapace.ActionValuesDescribed(
-		"COMMAND", "command of the process holding the lock",
-		"PID", "PID of the process holding the lock",
-		"TYPE", "kind of lock",
-		"SIZE", "size of the lock",
-		"MODE", "lock access mode",
-		"M", "mandatory state of the lock: 0 (none), 1 (set)",
-		"START", "relative byte offset of the lock",
-		"END", "ending offset of the lock",
-		"PATH", "path of the locked file",
-		"BLOCKER", "PID of the process blocking the lock",
-	)
+	return carapace.ActionExecCommand("lslocks", "--list-columns")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`^\s*(\S+)\s+<[^>]+>\s+(.*)$`)
+		var values []string
+
+		for _, line := range strings.Split(string(output), "\n") {
+			if matches := re.FindStringSubmatch(line); len(matches) == 3 {
+				name, description := matches[1], matches[2]
+				values = append(values, name, description)
+			}
+		}
+
+		return carapace.ActionValuesDescribed(values...)
+	})
 }

--- a/completers/lslocks_completer/cmd/root.go
+++ b/completers/lslocks_completer/cmd/root.go
@@ -17,12 +17,14 @@ var rootCmd = &cobra.Command{
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	rootCmd.Flags().BoolP("bytes", "b", false, "print SIZE in bytes rather than in human readable format")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
 	rootCmd.Flags().BoolP("json", "J", false, "use JSON output format")
+	rootCmd.Flags().BoolP("list-columns", "H", false, "list the available columns")
 	rootCmd.Flags().BoolP("noheadings", "n", false, "don't print headings")
 	rootCmd.Flags().BoolP("noinaccessible", "i", false, "ignore locks without read permissions")
 	rootCmd.Flags().BoolP("notruncate", "u", false, "don't truncate text in columns")

--- a/completers/lsns_completer/cmd/action/action.go
+++ b/completers/lsns_completer/cmd/action/action.go
@@ -1,21 +1,24 @@
 package action
 
-import "github.com/carapace-sh/carapace"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
 
 func ActionColumns() carapace.Action {
-	return carapace.ActionValuesDescribed(
-		"NS", "namespace identifier (inode number)",
-		"TYPE", "kind of namespace",
-		"PATH", "path to the namespace",
-		"NPROCS", "number of processes in the namespace",
-		"PID", "lowest PID in the namespace",
-		"PPID", "PPID of the PID",
-		"COMMAND", "command line of the PID",
-		"UID", "UID of the PID",
-		"USER", "username of the PID",
-		"NETNSID", "namespace ID as used by network subsystem",
-		"NSFS", "nsfs mountpoint (usually used network subsystem)",
-		"PNS", "parent namespace identifier (inode number)",
-		"ONS", "owner namespace identifier (inode number)",
-	)
+	return carapace.ActionExecCommand("lsns", "--list-columns")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`^\s*(\S+)\s+<[^>]+>\s+(.*)$`)
+		var values []string
+
+		for _, line := range strings.Split(string(output), "\n") {
+			if matches := re.FindStringSubmatch(line); len(matches) == 3 {
+				name, description := matches[1], matches[2]
+				values = append(values, name, description)
+			}
+		}
+
+		return carapace.ActionValuesDescribed(values...)
+	})
 }

--- a/completers/lsns_completer/cmd/root.go
+++ b/completers/lsns_completer/cmd/root.go
@@ -17,25 +17,33 @@ var rootCmd = &cobra.Command{
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().StringP("filter", "Q", "", "apply display filter")
 	rootCmd.Flags().BoolP("help", "h", false, "display this help")
 	rootCmd.Flags().BoolP("json", "J", false, "use JSON output format")
 	rootCmd.Flags().BoolP("list", "l", false, "use list format output")
+	rootCmd.Flags().BoolP("list-columns", "H", false, "list the available columns")
 	rootCmd.Flags().BoolP("noheadings", "n", false, "don't print headings")
 	rootCmd.Flags().BoolP("notruncate", "u", false, "don't truncate text in columns")
 	rootCmd.Flags().BoolP("nowrap", "W", false, "don't use multi-line representation")
 	rootCmd.Flags().StringP("output", "o", "", "define which output columns to use")
 	rootCmd.Flags().Bool("output-all", false, "output all columns")
+	rootCmd.Flags().BoolP("persistent", "P", false, "namespaces without processes")
 	rootCmd.Flags().BoolP("raw", "r", false, "use the raw output format")
 	rootCmd.Flags().StringP("task", "p", "", "print process namespaces")
+	rootCmd.Flags().StringP("tree", "T", "", "use tree format (parent, owner, or process)")
 	rootCmd.Flags().StringP("type", "t", "", "namespace type (mnt, net, ipc, user, pid, uts, cgroup, time)")
 	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	rootCmd.Flag("tree").NoOptDefVal = " "
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"output": action.ActionColumns().UniqueList(","),
 		"task":   ps.ActionProcessIds(),
+		"tree":   carapace.ActionValues("parent", "owner", "process"),
 		"type":   carapace.ActionValues("mnt", "net", "ipc", "user", "pid", "uts", "cgroup", "time"),
 	})
 }


### PR DESCRIPTION
- Added new completers:
  - `lsclocks`
  - `lsirq`

- Updated the following to util-linux 2.41:
  - `lslocks`
  - `cfdisk`
  - `lsns`