### PR TITLE
Add/update completers for GNU coreutils 9.7

### DIFF
--- a/completers/chgrp_completer/cmd/root.go
+++ b/completers/chgrp_completer/cmd/root.go
@@ -9,13 +9,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "chgrp",
 	Short: "change group ownership",
-	Long:  "https://en.wikipedia.org/wiki/Chgrp",
+	Long:  "https://man7.org/linux/man-pages/man1/chgrp.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -24,6 +25,7 @@ func init() {
 	rootCmd.Flags().BoolS("P", "P", false, "do not traverse any symbolic links (default)")
 	rootCmd.Flags().BoolP("changes", "c", false, "like verbose but report only when a change is made")
 	rootCmd.Flags().Bool("dereference", false, "affect the referent of each symbolic link (this is the default), rather than the symbolic link itself")
+	rootCmd.Flags().String("from", "", "change the ownership of each file only if its current owner and/or group match those specified here")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
 	rootCmd.Flags().BoolP("no-dereference", "h", false, "affect symbolic links instead of any referenced file (useful only on systems that can change the ownership of a symlink)")
 	rootCmd.Flags().Bool("no-preserve-root", false, "do not treat '/' specially (the default)")
@@ -36,6 +38,7 @@ func init() {
 	rootCmd.Flags().Bool("version", false, "output version information and exit")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"from":      os.ActionUserGroup(),
 		"reference": carapace.ActionFiles(),
 	})
 

--- a/completers/chmod_completer/cmd/root.go
+++ b/completers/chmod_completer/cmd/root.go
@@ -9,18 +9,24 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "chmod",
 	Short: "change file mode bits",
-	Long:  "https://en.wikipedia.org/wiki/Chmod",
+	Long:  "https://www.man7.org/linux/man-pages/man1/chmod.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().BoolS("H", "H", false, "if a command line argument is a symbolic link to a directory, traverse it")
+	rootCmd.Flags().BoolS("L", "L", false, "traverse every symbolic link to a directory encountered")
+	rootCmd.Flags().BoolS("P", "P", false, "do not traverse any symbolic links")
 	rootCmd.Flags().BoolP("changes", "c", false, "like verbose but report only when a change is made")
+	rootCmd.Flags().Bool("dereference", false, "affect the referent of each symbolic link, rather than the symbolic link itself")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
+	rootCmd.Flags().BoolP("no-dereference", "h", false, "affect each symbolic link, rather than the referent")
 	rootCmd.Flags().Bool("no-preserve-root", false, "do not treat '/' specially (the default)")
 	rootCmd.Flags().Bool("preserve-root", false, "fail to operate recursively on '/'")
 	rootCmd.Flags().Bool("quiet", false, "suppress most error messages")

--- a/completers/chown_completer/cmd/root.go
+++ b/completers/chown_completer/cmd/root.go
@@ -9,13 +9,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "chown",
 	Short: "change file owner and group",
-	Long:  "https://en.wikipedia.org/wiki/Chown",
+	Long:  "https://man7.org/linux/man-pages/man1/chown.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -24,11 +25,12 @@ func init() {
 	rootCmd.Flags().BoolS("P", "P", false, "do not traverse any symbolic links (default)")
 	rootCmd.Flags().BoolP("changes", "c", false, "like verbose but report only when a change is made")
 	rootCmd.Flags().Bool("dereference", false, "affect the referent of each symbolic link")
-	rootCmd.Flags().String("from", "", "change the owner and/or group of each file only if its current owner and/or group match those specified here.")
+	rootCmd.Flags().String("from", "", "change the ownership of each file only if its current owner and/or group match those specified here")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
 	rootCmd.Flags().BoolP("no-dereference", "h", false, "affect symbolic links instead of any referenced file")
 	rootCmd.Flags().Bool("no-preserve-root", false, "do not treat '/' specially (the default)")
 	rootCmd.Flags().Bool("preserve-root", false, "fail to operate recursively on '/'")
+	rootCmd.Flags().Bool("quiet", false, "suppress most error messages")
 	rootCmd.Flags().BoolP("recursive", "R", false, "operate on files and directories recursively")
 	rootCmd.Flags().String("reference", "", "use RFILE's owner and group rather than specifying OWNER:GROUP values")
 	rootCmd.Flags().StringP("silent", "f", "", "suppress most error messages")

--- a/completers/cksum_completer/cmd/root.go
+++ b/completers/cksum_completer/cmd/root.go
@@ -7,19 +7,51 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "cksum",
-	Short: "checksum and count the bytes in a file",
-	Long:  "https://en.wikipedia.org/wiki/Cksum",
+	Short: "compute and verify file checksums",
+	Long:  "https://www.man7.org/linux/man-pages/man1/cksum.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().StringP("algorithm", "a", "", "select the digest type to use")
+	rootCmd.Flags().Bool("base64", false, "emit base64-encoded digests, not hexadecimal")
+	rootCmd.Flags().BoolP("check", "c", false, "read checksums from the FILEs and check them")
+	rootCmd.Flags().Bool("debug", false, "indicate which implementation used")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
+	rootCmd.Flags().Bool("ignore-missing", false, "don't fail or report status for missing files")
+	rootCmd.Flags().StringP("length", "l", "", "digest length in bits; must not exceed the max for the blake2 algorithm and must be a multiple of 8")
+	rootCmd.Flags().Bool("quiet", false, "don't print OK for each successfully verified file")
+	rootCmd.Flags().Bool("raw", false, "emit a raw binary digest, not hexadecimal")
+	rootCmd.Flags().Bool("status", false, "don't output anything, status code shows success")
+	rootCmd.Flags().Bool("strict", false, "exit non-zero for improperly formatted checksum lines")
+	rootCmd.Flags().Bool("tag", false, "create a BSD-style checksum (the default)")
+	rootCmd.Flags().Bool("untagged", false, "create a reversed style checksum, without digest type")
 	rootCmd.Flags().Bool("version", false, "output version information and exit")
+	rootCmd.Flags().BoolP("warn", "w", false, "warn about improperly formatted checksum lines")
+	rootCmd.Flags().BoolP("zero", "z", false, "end each output line with NUL, not newline, and disable file name escaping")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"algorithm": carapace.ActionValuesDescribed(
+			"sysv", "equivalent to sum -s",
+			"bsd", "equivalent to sum -r",
+			"crc", "equivalent to cksum",
+			"crc32b", "only available through cksum",
+			"md5", "equivalent to md5sum",
+			"sha1", "equivalent to sha1sum",
+			"sha224", "equivalent to sha224sum",
+			"sha256", "equivalent to sha256sum",
+			"sha384", "equivalent to sha384sum",
+			"sha512", "equivalent to sha512sum",
+			"blake2b", "equivalent to b2sum",
+			"sm3", "only available through cksum",
+		),
+	})
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(carapace.ActionFiles())
 }

--- a/completers/cp_completer/cmd/root.go
+++ b/completers/cp_completer/cmd/root.go
@@ -9,13 +9,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "cp",
 	Short: "copy files and directories",
-	Long:  "https://linux.die.net/man/1/cp",
+	Long:  "https://man7.org/linux/man-pages/man1/cp.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -29,19 +30,21 @@ func init() {
 	rootCmd.Flags().String("context", "", "like -Z, or if CTX is specified then set the SELinux or SMACK security context to CTX")
 	rootCmd.Flags().Bool("copy-contents", false, "copy contents of special files when recursive")
 	rootCmd.Flags().BoolS("d", "d", false, "same as --no-dereference --preserve=links")
+	rootCmd.Flags().Bool("debug", false, "explain how a file is copied")
 	rootCmd.Flags().BoolP("dereference", "L", false, "always follow symbolic links in SOURCE")
 	rootCmd.Flags().BoolP("force", "f", false, "if an existing destination file cannot be opened, remove it and try again (this option is ignored when the -n option is also used)")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
 	rootCmd.Flags().BoolP("interactive", "i", false, "prompt before overwrite (overrides a previous -n option)")
+	rootCmd.Flags().Bool("keep-directory-symlink", false, "follow existing symlinks to directories")
 	rootCmd.Flags().BoolP("link", "l", false, "hard link files instead of copying")
-	rootCmd.Flags().BoolP("no-clobber", "n", false, "do not overwrite an existing file (overrides a previous -i option)")
+	rootCmd.Flags().BoolP("no-clobber", "n", false, "(deprecated) silently skip existing files")
 	rootCmd.Flags().BoolP("no-dereference", "P", false, "never follow symbolic links in SOURCE")
 	rootCmd.Flags().StringSlice("no-preserve", []string{}, "don't preserve the specified attributes")
 	rootCmd.Flags().BoolP("no-target-directory", "T", false, "treat DEST as a normal file")
 	rootCmd.Flags().BoolP("one-file-system", "x", false, "stay on this file system")
 	rootCmd.Flags().BoolS("p", "p", false, "same as --preserve=mode,ownership,timestamps")
 	rootCmd.Flags().Bool("parents", false, "use full source file name under DIRECTORY")
-	rootCmd.Flags().StringSlice("preserve", []string{""}, "preserve the specified attributes (default: mode,ownership,timestamps), if possible additional attributes: context, links, xattr, all")
+	rootCmd.Flags().StringSlice("preserve", []string{}, "preserve the specified attributes")
 	rootCmd.Flags().BoolP("recursive", "r", false, "copy directories recursively")
 	rootCmd.Flags().String("reflink", "", "control clone/CoW copies")
 	rootCmd.Flags().Bool("remove-destination", false, "remove each existing destination file before attempting to open it (contrast with --force)")
@@ -50,17 +53,25 @@ func init() {
 	rootCmd.Flags().StringP("suffix", "S", "", "override the usual backup suffix")
 	rootCmd.Flags().BoolP("symbolic-link", "s", false, "make symbolic links instead of copying")
 	rootCmd.Flags().StringP("target-directory", "t", "", "copy all SOURCE arguments into DIRECTORY")
-	rootCmd.Flags().BoolP("update", "u", false, "copy only when the SOURCE file is newer than the destination file or when the destination file is missing")
+	rootCmd.Flags().BoolS("u", "u", false, "equivalent to --update[=older]")
+	rootCmd.Flags().String("update", "", "control which existing files are updated")
 	rootCmd.Flags().BoolP("verbose", "v", false, "explain what is being done")
 	rootCmd.Flags().Bool("version", false, "output version information and exit")
 
+	rootCmd.Flag("backup").NoOptDefVal = " "
+	rootCmd.Flag("context").NoOptDefVal = " "
+	rootCmd.Flag("preserve").NoOptDefVal = " "
+	rootCmd.Flag("reflink").NoOptDefVal = " "
+	rootCmd.Flag("update").NoOptDefVal = " "
+
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"backup":           carapace.ActionValues("never", "nil", "none", "numbered", "off", "simple", "t"),
+		"backup":           carapace.ActionValues("never", "nil", "none", "numbered", "off", "simple", "t", "existing"),
 		"no-preserve":      carapace.ActionValues("all", "context", "links", "mode", "ownership", "timestamps", "xattr"),
 		"preserve":         carapace.ActionValues("all", "context", "links", "mode", "ownership", "timestamps", "xattr"),
-		"reflink":          carapace.ActionValues("alway", "auto").StyleF(style.ForKeyword),
+		"reflink":          carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
 		"sparse":           carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
 		"target-directory": carapace.ActionDirectories(),
+		"update":           carapace.ActionValues("all", "none", "none-fail", "older"),
 	})
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(

--- a/completers/cut_completer/cmd/root.go
+++ b/completers/cut_completer/cmd/root.go
@@ -8,17 +8,17 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "cut",
 	Short: "remove sections from each line of files",
-	Long:  "https://linux.die.net/man/1/cut",
+	Long:  "https://man7.org/linux/man-pages/man1/cut.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("M", "M", false, "from first to M'th (included) byte, character or field")
 	rootCmd.Flags().StringP("bytes", "b", "", "select only these bytes")
 	rootCmd.Flags().StringP("characters", "c", "", "select only these characters")
 	rootCmd.Flags().Bool("complement", false, "complement the set of selected bytes, characters")

--- a/completers/df_completer/cmd/action/action.go
+++ b/completers/df_completer/cmd/action/action.go
@@ -1,0 +1,31 @@
+package action
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+func ActionColumns() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"source", "The source of the mount point, usually a device",
+		"fstype", "File system type",
+		"itotal", "Total number of inodes",
+		"iused", "Number of used inodes",
+		"iavail", "Number of available inodes",
+		"ipcent", "Percentage of IUSED divided by ITOTAL",
+		"size", "Total number of blocks",
+		"used", "Number of used blocks",
+		"avail", "Number of available blocks",
+		"pcent", "Percentage of USED divided by SIZE",
+		"file", "The file name if specified on the command line",
+		"target", "The mount point",
+	)
+}
+
+func ActionFilesystemTypes() carapace.Action {
+	return carapace.ActionExecCommand("df", "--output=fstype")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		return carapace.ActionValues(lines[1:]...)
+	})
+}

--- a/completers/df_completer/cmd/root.go
+++ b/completers/df_completer/cmd/root.go
@@ -2,19 +2,21 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/df_completer/cmd/action"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "df",
 	Short: "report file system disk space usage",
-	Long:  "https://linux.die.net/man/1/df",
+	Long:  "https://man7.org/linux/man-pages/man1/df.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -37,13 +39,12 @@ func init() {
 	rootCmd.Flags().BoolS("v", "v", false, "(ignored)")
 	rootCmd.Flags().Bool("version", false, "output version information and exit")
 
-	types := []string{"adfs", "cgroup2", "efivarfs", "hfs", "pipefs", "securityfs", "ufs", "autofs", "configfs", "ext2", "hpfs", "proc", "sockfs", "vfat", "bdev", "cpuset", "ext3", "hugetlbfs", "pstore", "swap"}
+	rootCmd.Flag("output").NoOptDefVal = " "
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		// TODO should be lists of values (comma separated)
-		"exclude-type": carapace.ActionValues(types...),
-		"output":       carapace.ActionValues("avail", "file", "fstype", "iavail", "ipcent", "itotal", "iused", "pcent", "size", "source", "target", "used"),
-		"type":         carapace.ActionValues(types...),
+		"exclude-type": action.ActionFilesystemTypes(),
+		"output":       action.ActionColumns().UniqueList(","),
+		"type":         action.ActionFilesystemTypes(),
 	})
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(

--- a/completers/factor_completer/cmd/root.go
+++ b/completers/factor_completer/cmd/root.go
@@ -8,16 +8,18 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "factor",
 	Short: "factor numbers",
-	Long:  "https://linux.die.net/man/1/factor",
+	Long:  "https://man7.org/linux/man-pages/man1/factor.1.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().BoolP("exponents", "h", false, "print repeated factors in form p^e unless e is 1")
 	rootCmd.Flags().Bool("help", false, "display this help and exit")
 	rootCmd.Flags().Bool("version", false, "output version information and exit")
 }

--- a/completers/nproc_completer/cmd/root.go
+++ b/completers/nproc_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "nproc",
+	Short: "print the number of processing units available",
+	Long:  "https://www.man7.org/linux/man-pages/man1/nproc.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().Bool("all", false, "print the number of installed processors")
+	rootCmd.Flags().Bool("help", false, "display this help and exit")
+	rootCmd.Flags().String("ignore", "", "if possible, exclude N processing units")
+	rootCmd.Flags().Bool("version", false, "output version information and exit")
+}

--- a/completers/nproc_completer/main.go
+++ b/completers/nproc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/nproc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/numfmt_completer/cmd/root.go
+++ b/completers/numfmt_completer/cmd/root.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "numfmt",
+	Short: "Convert numbers from/to human-readable strings",
+	Long:  "https://www.man7.org/linux/man-pages/man1/numfmt.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().Bool("debug", false, "print warnings about invalid input")
+	rootCmd.Flags().StringP("delimiter", "d", "", "use X instead of whitespace for field delimiter")
+	rootCmd.Flags().String("field", "", "replace the numbers in these input fields (default=1)")
+	rootCmd.Flags().String("format", "", "use printf style floating-point FORMAT")
+	rootCmd.Flags().String("from", "", "auto-scale input numbers to UNITs")
+	rootCmd.Flags().String("from-unit", "", "specify the input unit size (instead of the default 1)")
+	rootCmd.Flags().Bool("grouping", false, "use locale-defined grouping of digits")
+	rootCmd.Flags().String("header", "", "print (without converting) the first N header lines")
+	rootCmd.Flags().Bool("help", false, "display this help and exit")
+	rootCmd.Flags().String("invalid", "", "failure mode for invalid numbers")
+	rootCmd.Flags().String("padding", "", "pad the output to N characters")
+	rootCmd.Flags().String("round", "", "use METHOD for rounding when scaling")
+	rootCmd.Flags().String("suffix", "", "add SUFFIX to output numbers, and accept optional SUFFIX in input numbers")
+	rootCmd.Flags().String("to", "", "auto-scale output numbers to UNITs")
+	rootCmd.Flags().String("to-unit", "", "the output unit size (instead of the default 1)")
+	rootCmd.Flags().Bool("version", false, "output version information and exit")
+	rootCmd.Flags().BoolP("zero-terminated", "z", false, "line delimiter is NUL, not newline")
+
+	rootCmd.Flag("header").NoOptDefVal = " "
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"from":    carapace.ActionValues("none", "auto", "si", "iec", "iec-i"),
+		"invalid": carapace.ActionValues("abort", "fail", "warn", "ignore"),
+		"round":   carapace.ActionValues("up", "down", "from-zero", "towards-zero", "nearest"),
+		"to":      carapace.ActionValues("none", "auto", "si", "iec", "iec-i"),
+	})
+}

--- a/completers/numfmt_completer/main.go
+++ b/completers/numfmt_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/numfmt_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/timeout_completer/cmd/root.go
+++ b/completers/timeout_completer/cmd/root.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "timeout",
+	Short: "run a command with a time limit",
+	Long:  "https://man7.org/linux/man-pages/man1/timeout.1.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+	rootCmd.Flags().SetInterspersed(false)
+
+	rootCmd.Flags().BoolP("foreground", "f", false, "when not running timeout directly from a shell prompt, allow COMMAND to read from the TTY and get TTY signals")
+	rootCmd.Flags().Bool("help", false, "display this help and exit")
+	rootCmd.Flags().StringP("kill-after", "k", "", "also send a KILL signal if COMMAND is still running this long after the initial signal was sent")
+	rootCmd.Flags().BoolP("preserve-status", "p", false, "exit with the same status as COMMAND, even when the command times out")
+	rootCmd.Flags().StringP("signal", "s", "", "specify the signal to be sent on timeout")
+	rootCmd.Flags().BoolP("verbose", "v", false, "diagnose to stderr any signal sent upon timeout")
+	rootCmd.Flags().Bool("version", false, "output version information and exit")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"signal": ps.ActionKillSignals(),
+	})
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin().Shift(1),
+	)
+}

--- a/completers/timeout_completer/main.go
+++ b/completers/timeout_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/timeout_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
- Added new completers:
  - `timeout`
  - `nproc`
  - `numfmt`

- Updated the following to GNU coreutils 9.7:
  - `factor`
  - `cp`
  - `chgrp`
  - `chmod`
  - `chown`
  - `cksum`
  - `cut`
  - `df`