### PR TITLE
just: add support for private recipes and modules

### DIFF
--- a/pkg/actions/tools/just/recipe.go
+++ b/pkg/actions/tools/just/recipe.go
@@ -6,12 +6,18 @@ import (
 	"github.com/carapace-sh/carapace"
 )
 
-type attributes []map[string]string
+type attributes []any
 
 func (a attributes) Description() string {
 	for _, attr := range a {
-		if doc, ok := attr["doc"]; ok {
-			return doc
+		switch attr := attr.(type) {
+		case map[string]interface{}:
+			if doc, ok := attr["doc"]; ok {
+				if doc == nil {
+					return ""
+				}
+				return doc.(string)
+			}
 		}
 	}
 	return ""

--- a/pkg/actions/tools/just/recipe.go
+++ b/pkg/actions/tools/just/recipe.go
@@ -27,6 +27,7 @@ type recipe struct {
 	Attributes attributes `json:"attributes"`
 	Name       string     `json:"name"`
 	Doc        string     `json:"doc"`
+	Private    bool       `json:"private"`
 }
 
 func (r recipe) Description() string {
@@ -63,7 +64,9 @@ func ActionRecipes(path string) carapace.Action {
 
 			vals := make([]string, 0)
 			for _, recipe := range jf.Recipes {
-				vals = append(vals, recipe.Name, recipe.Description())
+				if !recipe.Private {
+					vals = append(vals, recipe.Name, recipe.Description())
+				}
 			}
 
 			for _, alias := range jf.Aliases {

--- a/pkg/actions/tools/just/recipe.go
+++ b/pkg/actions/tools/just/recipe.go
@@ -43,7 +43,32 @@ type justfile struct {
 		Name       string     `json:"name"`
 		Target     string     `json:"target"`
 	} `json:"aliases"`
-	Recipes map[string]recipe `json:"recipes"`
+	Recipes map[string]recipe   `json:"recipes"`
+	Modules map[string]justfile `json:"modules"`
+}
+
+func (jf justfile) AllRecipesWithPrefix(prefix string) []string {
+	vals := make([]string, 0, 4)
+	for _, recipe := range jf.Recipes {
+		if !recipe.Private {
+			vals = append(vals, prefix+recipe.Name, recipe.Description())
+		}
+	}
+
+	for _, alias := range jf.Aliases {
+		if recipe, ok := jf.Recipes[alias.Target]; ok {
+			vals = append(vals, prefix+alias.Name, recipe.Description())
+		}
+	}
+
+	for mod, jf := range jf.Modules {
+		vals = append(vals, jf.AllRecipesWithPrefix(prefix+mod+"::")...)
+	}
+	return vals
+}
+
+func (jf justfile) AllRecipes() []string {
+	return jf.AllRecipesWithPrefix("")
 }
 
 // ActionRecipes completes recipes
@@ -62,18 +87,7 @@ func ActionRecipes(path string) carapace.Action {
 				return carapace.ActionMessage(err.Error())
 			}
 
-			vals := make([]string, 0)
-			for _, recipe := range jf.Recipes {
-				if !recipe.Private {
-					vals = append(vals, recipe.Name, recipe.Description())
-				}
-			}
-
-			for _, alias := range jf.Aliases {
-				if recipe, ok := jf.Recipes[alias.Target]; ok {
-					vals = append(vals, alias.Name, recipe.Description())
-				}
-			}
+			vals := jf.AllRecipes()
 			return carapace.ActionValuesDescribed(vals...)
 		})
 	}).Tag("recipes")


### PR DESCRIPTION
This PR adds support for:

- Value-less attributes: Attributes like `[no-cd]`, which are represented as strings and not maps. Previously carapace would just crash if they show up.
- Private recipes: Private recipes are now hidden from completion.
- Modules: Support for completing recipes within imported [modules](https://just.systems/man/en/modules1190.html).