### PR TITLE
Update Nushell init script for v0.105.0

### DIFF
--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -32,7 +32,7 @@ mut current = (($env | default {} config).config | default {} completions)
 $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
 | default true enable
-| default $carapace_completer completer)
+| default { $carapace_completer } completer)
 
 $env.config = $current
     `


### PR DESCRIPTION
This is a preemptive PR to account for a breaking change which will be part of the next Nushell version, following the merge of https://github.com/nushell/nushell/pull/15654. The change will be part of the v0.105.0 release, which will be on June 10th. This shouldn't be merged until then (or perhaps it could be merged early if carapace will have a release right before June 10th).

The default command now runs closures in order to support lazy evaluation, so to return a closure with `default` you must put the closure in the closure now. I've updated the Nushell init file to account for this.