### PR TITLE
add ramalama completer

### DIFF
--- a/completers/ramalama_completer/cmd/root.go
+++ b/completers/ramalama_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "ramalama",
+	Short:              "tool for working with LLM models",
+	Long:               "https://ramalama.ai/",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionArgcomplete("ramalama"),
+	)
+}

--- a/completers/ramalama_completer/main.go
+++ b/completers/ramalama_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/ramalama_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Add completer for https://ramalama.ai.

This tool uses `argcomplete` as seen from its included [bash-completion](https://github.com/containers/ramalama/blob/83a75f16f745f9c0d67664c4e8e1a780e3634caa/completions/bash-completion/completions/ramalama).