### PR TITLE
ft(git-stash): Add push --staged|-S flag

### DIFF
--- a/completers/common/git_completer/cmd/stash_push.go
+++ b/completers/common/git_completer/cmd/stash_push.go
@@ -24,6 +24,7 @@ func init() {
 	stash_pushCmd.Flags().Bool("pathspec-file-nul", false, "pathspec elemts are seperated by NUL")
 	stash_pushCmd.Flags().String("pathspec-from-file", "", "read pathspec from file")
 	stash_pushCmd.Flags().BoolP("quiet", "q", false, "suppress feedback messages")
+	stash_pushCmd.Flags().BoolP("staged", "S", false, "only stash staged")
 	stashCmd.AddCommand(stash_pushCmd)
 
 	carapace.Gen(stash_pushCmd).FlagCompletion(carapace.ActionMap{


### PR DESCRIPTION
Introduced in Git 2.35
https://redirect.github.com/git/git/blob/v2.35.0/Documentation/RelNotes/2.35.0.txt#L31-L32

This seems to be the only missing flag from `git stash push` when comparing with the [docs](https://git-scm.com/docs/git-stash#Documentation/git-stash.txt-push-p--patch-S--staged-k--no-keep-index-u--include-untracked-a--all-q--quiet-m--messageltmessagegt--pathspec-from-fileltfilegt--pathspec-file-nul--ltpathspecgt82308203).