### PR TITLE
jj: fix revision flag logic for restore

### DIFF
--- a/completers/common/jj_completer/cmd/restore.go
+++ b/completers/common/jj_completer/cmd/restore.go
@@ -40,9 +40,20 @@ func init() {
 
 	carapace.Gen(restoreCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			fromFlag := restoreCmd.Flag("from")
+			intoFlag := restoreCmd.Flag("into")
+			if !intoFlag.Changed {
+				intoFlag = restoreCmd.Flag("to")
+			}
+
+			if !fromFlag.Changed && !intoFlag.Changed {
+				fromFlag.Value.Set("parents(@)")
+				intoFlag.Value.Set("@")
+			}
+
 			return jj.ActionRevDiffs(
-				restoreCmd.Flag("from").Value.String(),
-				restoreCmd.Flag("to").Value.String(),
+				fromFlag.Value.String(),
+				intoFlag.Value.String(),
 			).FilterArgs()
 		}),
 	)

--- a/pkg/actions/tools/jj/diff.go
+++ b/pkg/actions/tools/jj/diff.go
@@ -7,7 +7,7 @@ import (
 	"github.com/carapace-sh/carapace/pkg/style"
 )
 
-// ActionRevDiffs completes changes beetween revisions
+// ActionRevDiffs completes changes between revisions
 // Accepts up to two revisions
 //
 //	0: compare current workspace to parent revision


### PR DESCRIPTION
Fixes #2824

Default flags were not handled correctly and --to wasn't used to get completions when used.