### PR TITLE
Add `sd` completer

### DIFF
--- a/completers/common/sd_completer/cmd/root.go
+++ b/completers/common/sd_completer/cmd/root.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "sd",
+	Short: "Intuitive find & replace CLI",
+	Long:  "https://github.com/chmln/sd",
+	Run:   func(*cobra.Command, []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("preview", "p", false, "Display changes in a human reviewable format (the specifics of the format are likely to change in the future)")
+	rootCmd.Flags().BoolP("fixed-strings", "F", false, "Treat FIND and REPLACE_WITH args as literal strings")
+	rootCmd.Flags().IntP("max-replacements", "n", 0, "Limit the number of replacements that can occur per file. 0 indicates unlimited replacements")
+	rootCmd.Flags().StringP("flags", "f", "", "Regex flags. May be combined")
+	rootCmd.Flags().BoolP("help", "h", false, "Print help (see a summary with '-h')")
+	rootCmd.Flags().BoolP("version", "V", false, "Print version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"flags": carapace.ActionValuesDescribed(
+			"c", "case-sensitive",
+			"e", "disable multi-line matching",
+			"i", "case-insensitive",
+			"m", "multi-line matching",
+			"s", "make `.` match newlines",
+			"w", "match full words only",
+		).UniqueList(""),
+	})
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionMessage("string / regex to find"),
+		carapace.ActionMessage("string to replace with"),
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/sd_completer/cmd/root.go
+++ b/completers/common/sd_completer/cmd/root.go
@@ -38,8 +38,8 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionMessage("string / regex to find"),
-		carapace.ActionMessage("string to replace with"),
-		carapace.ActionFiles(),
+		carapace.ActionValues(), // positional 1 ≙ string/regex to find
+		carapace.ActionValues(), // positional 2 ≙ string to replace with
+		carapace.ActionFiles(),  // positional 3 ≙ optional files to replace in (default is to read from stdin)
 	)
 }

--- a/completers/common/sd_completer/main.go
+++ b/completers/common/sd_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/sd_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Completer for [sd](https://github.com/chmln/sd)

`sd` doesn't have a online documentation for it's flags and arguments. You can use the following command to print it's help:

```bash
docker run --rm -it alpine sh -c "apk add --no-cache curl && curl -sL https://github.com/chmln/sd/releases/download/v1.0.0/sd-v1.0.0-x86_64-unknown-linux-musl.tar.gz | tar -xz && ./sd-v1.0.0-x86_64-unknown-linux-musl/sd --help"
```