### PR TITLE
carapace-fmt: adopt flag types from linter

### DIFF
--- a/cmd/carapace-fmt/cmd/root.go
+++ b/cmd/carapace-fmt/cmd/root.go
@@ -89,7 +89,7 @@ func format(path string) (string, error) {
 
 	writer := bufio.NewWriter(tmpfile)
 
-	r := regexp.MustCompile(`\.Flags\(\)\.(Bool|String)[^(]*\("(?P<name>[^"]+)"`)
+	r := regexp.MustCompile(`\.Flags\(\)\.(Bool|String|Float|Int|Uint|Count)[^(]*\("(?P<name>[^"]+)"`)
 
 	toSort := make(map[string]string)
 	for scanner.Scan() {

--- a/completers/common/sd_completer/cmd/root.go
+++ b/completers/common/sd_completer/cmd/root.go
@@ -20,10 +20,10 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	rootCmd.Flags().BoolP("fixed-strings", "F", false, "Treat FIND and REPLACE_WITH args as literal strings")
-	rootCmd.Flags().BoolP("preview", "p", false, "Display changes in a human reviewable format (the specifics of the format are likely to change in the future)")
-	rootCmd.Flags().IntP("max-replacements", "n", 0, "Limit the number of replacements that can occur per file. 0 indicates unlimited replacements")
 	rootCmd.Flags().StringP("flags", "f", "", "Regex flags. May be combined")
 	rootCmd.Flags().BoolP("help", "h", false, "Print help (see a summary with '-h')")
+	rootCmd.Flags().IntP("max-replacements", "n", 0, "Limit the number of replacements that can occur per file. 0 indicates unlimited replacements")
+	rootCmd.Flags().BoolP("preview", "p", false, "Display changes in a human reviewable format (the specifics of the format are likely to change in the future)")
 	rootCmd.Flags().BoolP("version", "V", false, "Print version")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{


### PR DESCRIPTION
related: https://github.com/carapace-sh/carapace-bin/pull/2837
