### PR TITLE
add fileicon completer

### DIFF
--- a/completers/common/fileicon_completer/cmd/get.go
+++ b/completers/common/fileicon_completer/cmd/get.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "get a file or folder's custom icon",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(getCmd).Standalone()
+
+	getCmd.Flags().BoolP("force", "f", false, "force replacement of existing output file")
+	getCmd.Flags().BoolP("quiet", "q", false, "silence status output")
+	rootCmd.AddCommand(getCmd)
+
+	carapace.Gen(getCmd).PositionalCompletion(carapace.ActionFiles())
+}

--- a/completers/common/fileicon_completer/cmd/rm.go
+++ b/completers/common/fileicon_completer/cmd/rm.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rmCmd = &cobra.Command{
+	Use:   "rm",
+	Short: "remove a custom icon from a file or folder",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(rmCmd).Standalone()
+
+	rmCmd.Flags().BoolP("quiet", "q", false, "silence status output")
+	rootCmd.AddCommand(rmCmd)
+
+	carapace.Gen(rmCmd).PositionalCompletion(carapace.ActionFiles())
+}

--- a/completers/common/fileicon_completer/cmd/root.go
+++ b/completers/common/fileicon_completer/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fileicon",
+	Short: "macOS CLI for managing custom icons for files and folders",
+	Long:  "https://github.com/mklement0/fileicon",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "print usage information")
+	rootCmd.Flags().Bool("home", false, "open fileicon's home page")
+	rootCmd.Flags().Bool("man", false, "display the manual page")
+	rootCmd.Flags().Bool("man-source", false, "print raw, embedded Markdown-formatted man-page source")
+	rootCmd.Flags().Bool("version", false, "output version number")
+	rootCmd.Flag("man-source").Hidden = true
+}

--- a/completers/common/fileicon_completer/cmd/set.go
+++ b/completers/common/fileicon_completer/cmd/set.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "set a custom icon for a file or folder",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(setCmd).Standalone()
+
+	setCmd.Flags().BoolP("quiet", "q", false, "silence status output")
+	rootCmd.AddCommand(setCmd)
+
+	carapace.Gen(setCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/fileicon_completer/cmd/test.go
+++ b/completers/common/fileicon_completer/cmd/test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "test if a file or folder has a custom icon",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(testCmd).Standalone()
+
+	testCmd.Flags().BoolP("quiet", "q", false, "silence status output")
+	rootCmd.AddCommand(testCmd)
+
+	carapace.Gen(testCmd).PositionalCompletion(carapace.ActionFiles())
+}

--- a/completers/common/fileicon_completer/main.go
+++ b/completers/common/fileicon_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/fileicon_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Adds completions for https://github.com/mklement0/fileicon, a small utility for managing file/folder icons on mac os