### PR TITLE
carapace-lint: auto-fix flags order

### DIFF
--- a/cmd/carapace-lint/cmd/root.go
+++ b/cmd/carapace-lint/cmd/root.go
@@ -97,10 +97,8 @@ func Lint(path string) error {
 		}
 	}
 
-	defs := []flagsBlockDef{}
-
-	i := 0
-	for i < len(lines) {
+	var defs []flagsBlockDef
+	for i := 0; i < len(lines); {
 		// regular line, do nothing
 		if !lines[i].isFlagLine() {
 			i++
@@ -109,13 +107,12 @@ func Lint(path string) error {
 
 		// `i` is the start of a contiguous "flags block".
 		// we now have to find it's end
-		j := i
+		j := i + 1
 		for j < len(lines) && lines[j].isFlagLine() {
 			j++
 		}
 
-		// the flags block consists of only one flag line.
-		// there is no need to sort
+		// the flags block consists of only one flag line
 		if i == j {
 			continue
 		}
@@ -124,7 +121,9 @@ func Lint(path string) error {
 			Start: i,
 			End:   j,
 		})
-		i = j
+
+		// we know that `j` is no flag line and can safely skip it
+		i = j + 1
 	}
 
 	if fixFlagsOrder {


### PR DESCRIPTION
## Usage

`go run ./cmd/carapace-lint --fix-flags-order completers/*/*/cmd/*.go`

## Description

This PR adds a flag to `carapace-lint` named `--fix-flags-order` to automatically sort flags alphabetically. This works by 
sorting it's source and writing it back to the file.

As before, this "groups" flags into blocks meaning only adjacent flags without other source code in between are sorted.

## Example

(before sorting)
```go
// first block
rootCmd.Flags().Bool("author", false, "with -l, print the author of each file")
rootCmd.Flags().BoolP("almost-all", "A", false, "do not list implied . and ..")

// second block
rootCmd.Flags().BoolS("c", "c", false, "with -lt: sort by, and show, ctime (time of last")
rootCmd.Flags().String("block-size", "", "with -l, scale sizes by SIZE when printing them;")
rootCmd.Flags().BoolP("all", "a", false, "do not ignore entries starting with .")
```

(after sorting)
```go
// first block
rootCmd.Flags().BoolP("almost-all", "A", false, "do not list implied . and ..")
rootCmd.Flags().Bool("author", false, "with -l, print the author of each file")

// second block
rootCmd.Flags().BoolP("all", "a", false, "do not ignore entries starting with .")
rootCmd.Flags().String("block-size", "", "with -l, scale sizes by SIZE when printing them;")
rootCmd.Flags().BoolS("c", "c", false, "with -lt: sort by, and show, ctime (time of last")
```