### PR TITLE
Add/update completers for systemd 257

### DIFF
--- a/completers/common/coredumpctl_completer/cmd/root.go
+++ b/completers/common/coredumpctl_completer/cmd/root.go
@@ -9,34 +9,38 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "coredumpctl",
 	Short: "List or retrieve coredumps from the journal",
-	Long:  "https://www.freedesktop.org/software/systemd/man/coredumpctl.html",
+	Long:  "https://www.freedesktop.org/software/systemd/man/latest/coredumpctl.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("1", "1", false, "Show information about most recent entry only")
-	rootCmd.Flags().Bool("all", false, "Look at all journal files instead of local ones")
-	rootCmd.Flags().String("debugger", "", "Use the given debugger")
-	rootCmd.Flags().StringP("debugger-arguments", "A", "", "Pass the given arguments to the debugger")
-	rootCmd.Flags().StringP("directory", "D", "", "Use journal files from directory")
-	rootCmd.Flags().StringP("field", "F", "", "List all values a certain field takes")
-	rootCmd.Flags().String("file", "", "Use journal file")
-	rootCmd.Flags().BoolP("help", "h", false, "Show this help")
-	rootCmd.Flags().String("json", "", "Generate JSON output")
-	rootCmd.Flags().StringS("n", "n", "", "Show maximum number of rows")
-	rootCmd.Flags().Bool("no-legend", false, "Do not print the column headers")
-	rootCmd.Flags().Bool("no-pager", false, "Do not pipe output into a pager")
-	rootCmd.Flags().StringP("output", "o", "", "Write output to FILE")
-	rootCmd.Flags().BoolP("quiet", "q", false, "Do not show info messages and privilege warning")
-	rootCmd.Flags().BoolP("reverse", "r", false, "Show the newest entries first")
-	rootCmd.Flags().StringP("since", "S", "", "Only print coredumps since the date")
-	rootCmd.Flags().StringP("until", "U", "", "Only print coredumps until the date")
-	rootCmd.Flags().Bool("version", false, "Print version string")
+	rootCmd.PersistentFlags().BoolS("1", "1", false, "Show information about most recent entry only")
+	rootCmd.PersistentFlags().Bool("all", false, "Look at all journal files instead of local ones")
+	rootCmd.PersistentFlags().String("debugger", "", "Use the given debugger")
+	rootCmd.PersistentFlags().StringP("debugger-arguments", "A", "", "Pass the given arguments to the debugger")
+	rootCmd.PersistentFlags().StringP("directory", "D", "", "Use journal files from directory")
+	rootCmd.PersistentFlags().StringP("field", "F", "", "List all values a certain field takes")
+	rootCmd.PersistentFlags().String("file", "", "Use journal file")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Show this help")
+	rootCmd.PersistentFlags().String("image", "", "Operate on disk image as filesystem root")
+	rootCmd.PersistentFlags().String("image-policy", "", "Specify disk image dissection policy")
+	rootCmd.PersistentFlags().String("json", "", "Generate JSON output")
+	rootCmd.PersistentFlags().StringS("n", "n", "", "Show maximum number of rows")
+	rootCmd.PersistentFlags().Bool("no-legend", false, "Do not print the column headers")
+	rootCmd.PersistentFlags().Bool("no-pager", false, "Do not pipe output into a pager")
+	rootCmd.PersistentFlags().StringP("output", "o", "", "Write output to FILE")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Do not show info messages and privilege warning")
+	rootCmd.PersistentFlags().BoolP("reverse", "r", false, "Show the newest entries first")
+	rootCmd.PersistentFlags().String("root", "", "Operate on an alternate filesystem root")
+	rootCmd.PersistentFlags().StringP("since", "S", "", "Only print coredumps since the date")
+	rootCmd.PersistentFlags().StringP("until", "U", "", "Only print coredumps until the date")
+	rootCmd.PersistentFlags().Bool("version", false, "Print version string")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"debugger": carapace.Batch(
@@ -44,8 +48,10 @@ func init() {
 			carapace.ActionFiles(),
 		).ToA(),
 		"directory": carapace.ActionDirectories(),
+		"image":     carapace.ActionFiles(),
 		"json":      carapace.ActionValues("pretty", "short", "off"),
 		"output":    carapace.ActionFiles(),
+		"root":      carapace.ActionDirectories(),
 		"since":     time.ActionDate(),
 		"until":     time.ActionDate(),
 	})

--- a/completers/common/halt_completer/cmd/root.go
+++ b/completers/common/halt_completer/cmd/root.go
@@ -8,7 +8,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "halt",
 	Short: "halt the machine",
-	Long:  "https://linux.die.net/man/8/halt",
+	Long:  "https://www.freedesktop.org/software/systemd/man/latest/halt.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
@@ -22,8 +22,10 @@ func init() {
 	rootCmd.Flags().BoolP("force", "f", false, "Force immediate halt/power-off/reboot")
 	rootCmd.Flags().Bool("halt", false, "Halt the machine")
 	rootCmd.Flags().Bool("help", false, "Show this help")
+	rootCmd.Flags().BoolP("no-sync", "n", false, "Don't sync hard disks/storage media before power-off, reboot, or halt")
 	rootCmd.Flags().Bool("no-wall", false, "Don't send wall message before halt/power-off/reboot")
 	rootCmd.Flags().BoolP("no-wtmp", "d", false, "Don't write wtmp record")
 	rootCmd.Flags().BoolP("poweroff", "p", false, "Switch off the machine")
 	rootCmd.Flags().Bool("reboot", false, "Reboot the machine")
+	rootCmd.Flags().BoolP("wtmp-only", "w", false, "Don't halt/power-off/reboot, just write wtmp record")
 }

--- a/completers/common/poweroff_completer/cmd/root.go
+++ b/completers/common/poweroff_completer/cmd/root.go
@@ -9,7 +9,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:                "poweroff",
 	Short:              "poweroff the machine",
-	Long:               "https://linux.die.net/man/8/poweroff",
+	Long:               "https://www.freedesktop.org/software/systemd/man/latest/poweroff.html",
 	Run:                func(cmd *cobra.Command, args []string) {},
 	DisableFlagParsing: true,
 }

--- a/completers/common/reboot_completer/cmd/root.go
+++ b/completers/common/reboot_completer/cmd/root.go
@@ -9,7 +9,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:                "reboot",
 	Short:              "reboot the machine",
-	Long:               "https://linux.die.net/man/8/reboot",
+	Long:               "https://www.freedesktop.org/software/systemd/man/latest/reboot.html",
 	Run:                func(cmd *cobra.Command, args []string) {},
 	DisableFlagParsing: true,
 }

--- a/completers/common/run0_completer/cmd/root.go
+++ b/completers/common/run0_completer/cmd/root.go
@@ -15,7 +15,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "run0",
 	Short: "Elevate privileges interactively",
-	Long:  "https://www.man7.org/linux/man-pages/man1/run0.1.html",
+	Long:  "https://www.freedesktop.org/software/systemd/man/latest/run0.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
@@ -35,8 +35,11 @@ func init() {
 	rootCmd.Flags().String("machine", "", "Operate on local container")
 	rootCmd.Flags().String("nice", "", "Nice level")
 	rootCmd.Flags().Bool("no-ask-password", false, "Do not prompt for password")
+	rootCmd.Flags().Bool("pipe", false, "Request direct pipe for stdio")
 	rootCmd.Flags().StringArray("property", nil, "Set service or scope unit property")
+	rootCmd.Flags().Bool("pty", false, "Request allocation of a pseudo TTY for stdio")
 	rootCmd.Flags().StringArray("setenv", nil, "Set environment variable")
+	rootCmd.Flags().String("shell-prompt-prefix", "", "Set $SHELL_PROMPT_PREFIX")
 	rootCmd.Flags().String("slice", "", "Run in the specified slice")
 	rootCmd.Flags().Bool("slice-inherit", false, "Inherit the slice")
 	rootCmd.Flags().String("unit", "", "Run under the specified unit name")

--- a/completers/common/shutdown_completer/cmd/root.go
+++ b/completers/common/shutdown_completer/cmd/root.go
@@ -9,13 +9,14 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "shutdown",
 	Short: "Shut down the system",
-	Long:  "https://linux.die.net/man/8/shutdown",
+	Long:  "https://www.freedesktop.org/software/systemd/man/latest/shutdown.html",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -27,6 +28,7 @@ func init() {
 	rootCmd.Flags().Bool("no-wall", false, "Don't send wall message before halt/power-off/reboot")
 	rootCmd.Flags().BoolP("poweroff", "P", false, "Power-off the machine")
 	rootCmd.Flags().BoolP("reboot", "r", false, "Reboot the machine")
+	rootCmd.Flags().Bool("show", false, "Show pending shutdown")
 
 	carapace.Gen(rootCmd).PositionalCompletion(
 		carapace.Batch(

--- a/completers/common/systemd-analyze_completer/cmd/action/action.go
+++ b/completers/common/systemd-analyze_completer/cmd/action/action.go
@@ -1,0 +1,86 @@
+package action
+
+import (
+	"regexp"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/systemctl"
+	"github.com/spf13/cobra"
+)
+
+func userFlag(cmd *cobra.Command) bool {
+	if flag := cmd.Root().Flag("user"); flag != nil && flag.Changed {
+		return true
+	}
+	return false
+}
+
+func ActionUnits(cmd *cobra.Command) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return systemctl.ActionUnits(systemctl.UnitOpts{User: userFlag(cmd), Active: true, Inactive: true})
+	})
+}
+
+func ActionServices(cmd *cobra.Command) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return systemctl.ActionServices(userFlag(cmd))
+	})
+}
+
+func ActionArchitectures() carapace.Action {
+	return carapace.ActionExecCommand("systemd-analyze", "architectures")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`(?m)^(\S+)\s+(\S+)$`)
+		matches := re.FindAllSubmatch(output, -1)
+
+		var vals []string
+		for _, match := range matches {
+			vals = append(vals, string(match[1]), string(match[2]))
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}
+
+func ActionCapabilities() carapace.Action {
+	return carapace.ActionExecCommand("systemd-analyze", "capability")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`(?m)^(cap_\S+)\s+(\d+)$`)
+		matches := re.FindAllSubmatch(output, -1)
+
+		var vals []string
+		for _, match := range matches {
+			vals = append(vals, string(match[1]), string(match[2]))
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}
+
+func ActionSyscallSets() carapace.Action {
+	return carapace.ActionExecCommand("systemd-analyze", "syscall-filter")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`(?m)^@(\S+)\n\s+#\s+(.*)$`)
+		matches := re.FindAllSubmatch(output, -1)
+
+		vals := []string{}
+		for _, match := range matches {
+			group := "@" + string(match[1])
+			description := string(match[2])
+			vals = append(vals, group, description)
+		}
+
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}
+
+func ActionFilesystemSets() carapace.Action {
+	return carapace.ActionExecCommand("systemd-analyze", "filesystems")(func(output []byte) carapace.Action {
+		re := regexp.MustCompile(`(?m)^@(\S+)\n\s+#\s+(.*)$`)
+		matches := re.FindAllSubmatch(output, -1)
+
+		vals := []string{}
+		for _, match := range matches {
+			group := "@" + string(match[1])
+			description := string(match[2])
+			vals = append(vals, group, description)
+		}
+
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}

--- a/completers/common/systemd-analyze_completer/cmd/architectures.go
+++ b/completers/common/systemd-analyze_completer/cmd/architectures.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var architecturesCmd = &cobra.Command{
+	Use:   "architectures",
+	Short: "List known architectures",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(architecturesCmd).Standalone()
+
+	rootCmd.AddCommand(architecturesCmd)
+
+	carapace.Gen(architecturesCmd).PositionalAnyCompletion(
+		action.ActionArchitectures(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/blame.go
+++ b/completers/common/systemd-analyze_completer/cmd/blame.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var blameCmd = &cobra.Command{
+	Use:   "blame",
+	Short: "Print list of running units ordered by time to init",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(blameCmd).Standalone()
+
+	rootCmd.AddCommand(blameCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/calendar.go
+++ b/completers/common/systemd-analyze_completer/cmd/calendar.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var calendarCmd = &cobra.Command{
+	Use:   "calendar",
+	Short: "Validate repetitive calendar time events",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(calendarCmd).Standalone()
+
+	rootCmd.AddCommand(calendarCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/capability.go
+++ b/completers/common/systemd-analyze_completer/cmd/capability.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var capabilityCmd = &cobra.Command{
+	Use:   "capability",
+	Short: "List capability definitions",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(capabilityCmd).Standalone()
+
+	rootCmd.AddCommand(capabilityCmd)
+
+	carapace.Gen(capabilityCmd).PositionalAnyCompletion(
+		action.ActionCapabilities(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/catConfig.go
+++ b/completers/common/systemd-analyze_completer/cmd/catConfig.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var catConfigCmd = &cobra.Command{
+	Use:   "cat-config",
+	Short: "Show configuration file and drop-ins",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(catConfigCmd).Standalone()
+
+	rootCmd.AddCommand(catConfigCmd)
+
+	carapace.Gen(catConfigCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/compareVersions.go
+++ b/completers/common/systemd-analyze_completer/cmd/compareVersions.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var compareVersionsCmd = &cobra.Command{
+	Use:   "compare-versions",
+	Short: "VERSION2 Compare two version strings",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(compareVersionsCmd).Standalone()
+
+	rootCmd.AddCommand(compareVersionsCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/condition.go
+++ b/completers/common/systemd-analyze_completer/cmd/condition.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var conditionCmd = &cobra.Command{
+	Use:   "condition",
+	Short: "Evaluate conditions and asserts",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(conditionCmd).Standalone()
+
+	rootCmd.AddCommand(conditionCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/criticalChain.go
+++ b/completers/common/systemd-analyze_completer/cmd/criticalChain.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var criticalChainCmd = &cobra.Command{
+	Use:   "critical-chain",
+	Short: "Print a tree of the time critical chain of units",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(criticalChainCmd).Standalone()
+
+	rootCmd.AddCommand(criticalChainCmd)
+
+	carapace.Gen(criticalChainCmd).PositionalAnyCompletion(
+		action.ActionUnits(criticalChainCmd).FilterArgs(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/dot.go
+++ b/completers/common/systemd-analyze_completer/cmd/dot.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var dotCmd = &cobra.Command{
+	Use:   "dot",
+	Short: "Output dependency graph in dot(1) format",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(dotCmd).Standalone()
+
+	rootCmd.AddCommand(dotCmd)
+
+	carapace.Gen(dotCmd).PositionalAnyCompletion(
+		action.ActionUnits(dotCmd).FilterArgs(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/dump.go
+++ b/completers/common/systemd-analyze_completer/cmd/dump.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var dumpCmd = &cobra.Command{
+	Use:   "dump",
+	Short: "Output state serialization of service manager",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(dumpCmd).Standalone()
+
+	rootCmd.AddCommand(dumpCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/exitStatus.go
+++ b/completers/common/systemd-analyze_completer/cmd/exitStatus.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var exitStatusCmd = &cobra.Command{
+	Use:   "exit-status",
+	Short: "List exit status definitions",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(exitStatusCmd).Standalone()
+
+	rootCmd.AddCommand(exitStatusCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/fdstore.go
+++ b/completers/common/systemd-analyze_completer/cmd/fdstore.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var fdstoreCmd = &cobra.Command{
+	Use:   "fdstore",
+	Short: "Show file descriptor store contents of service",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(fdstoreCmd).Standalone()
+
+	rootCmd.AddCommand(fdstoreCmd)
+	carapace.Gen(fdstoreCmd).PositionalAnyCompletion(
+		action.ActionServices(fdstoreCmd).FilterArgs(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/filesystems.go
+++ b/completers/common/systemd-analyze_completer/cmd/filesystems.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var filesystemsCmd = &cobra.Command{
+	Use:   "filesystems",
+	Short: "List known filesystems",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(filesystemsCmd).Standalone()
+
+	rootCmd.AddCommand(filesystemsCmd)
+
+	carapace.Gen(filesystemsCmd).PositionalAnyCompletion(
+		action.ActionFilesystemSets(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/hasTpm2.go
+++ b/completers/common/systemd-analyze_completer/cmd/hasTpm2.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var hasTpm2Cmd = &cobra.Command{
+	Use:   "has-tpm2",
+	Short: "Report whether TPM2 support is available",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(hasTpm2Cmd).Standalone()
+
+	rootCmd.AddCommand(hasTpm2Cmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/imagePolicy.go
+++ b/completers/common/systemd-analyze_completer/cmd/imagePolicy.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var imagePolicyCmd = &cobra.Command{
+	Use:   "image-policy",
+	Short: "Analyze image policy string",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(imagePolicyCmd).Standalone()
+
+	rootCmd.AddCommand(imagePolicyCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/inspectElf.go
+++ b/completers/common/systemd-analyze_completer/cmd/inspectElf.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var inspectElfCmd = &cobra.Command{
+	Use:   "inspect-elf",
+	Short: "Parse and print ELF package metadata",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(inspectElfCmd).Standalone()
+
+	rootCmd.AddCommand(inspectElfCmd)
+
+	carapace.Gen(inspectElfCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/malloc.go
+++ b/completers/common/systemd-analyze_completer/cmd/malloc.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var mallocCmd = &cobra.Command{
+	Use:   "malloc",
+	Short: "Dump malloc stats of a D-Bus service",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mallocCmd).Standalone()
+
+	rootCmd.AddCommand(mallocCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/pcrs.go
+++ b/completers/common/systemd-analyze_completer/cmd/pcrs.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var pcrsCmd = &cobra.Command{
+	Use:   "pcrs",
+	Short: "Show TPM2 PCRs and their names",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pcrsCmd).Standalone()
+
+	rootCmd.AddCommand(pcrsCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/plot.go
+++ b/completers/common/systemd-analyze_completer/cmd/plot.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var plotCmd = &cobra.Command{
+	Use:   "plot",
+	Short: "Output SVG graphic showing service initialization",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(plotCmd).Standalone()
+
+	rootCmd.AddCommand(plotCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/root.go
+++ b/completers/common/systemd-analyze_completer/cmd/root.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/systemctl"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "systemd-analyze",
+	Short: "Analyze and debug system manager",
+	Long:  "https://www.freedesktop.org/software/systemd/man/latest/systemd-analyze.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().String("base-time", "", "Calculate calendar times relative to specified time")
+	rootCmd.PersistentFlags().Bool("detailed", false, "Add more details to SVG plot, e.g. show activation timestamps")
+	rootCmd.PersistentFlags().String("from-pattern", "", "Show only origins in the graph")
+	rootCmd.PersistentFlags().String("fuzz", "", "Also print services which finished SECONDS earlier than the latest in the branch")
+	rootCmd.PersistentFlags().String("generators", "", "Do [not] run unit generators (requires privileges)")
+	rootCmd.PersistentFlags().Bool("global", false, "Operate on global user configuration")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Show this help")
+	rootCmd.PersistentFlags().StringP("host", "H", "", "Operate on remote host")
+	rootCmd.PersistentFlags().String("image", "", "Operate on disk image as filesystem root")
+	rootCmd.PersistentFlags().String("image-policy", "", "Specify disk image dissection policy")
+	rootCmd.PersistentFlags().String("instance", "", "Specify fallback instance name for template units")
+	rootCmd.PersistentFlags().String("iterations", "", "Show the specified number of iterations")
+	rootCmd.PersistentFlags().String("json", "", "Generate JSON output of the security analysis table, or plot's raw time data")
+	rootCmd.PersistentFlags().StringP("machine", "M", "", "Operate on local container")
+	rootCmd.PersistentFlags().String("man", "", "Do [not] check for existence of man pages")
+	rootCmd.PersistentFlags().BoolP("mask", "m", false, "Parse parameter as numeric capability mask")
+	rootCmd.PersistentFlags().Bool("no-legend", false, "Disable column headers and hints in plot with either --table or --json=")
+	rootCmd.PersistentFlags().Bool("no-pager", false, "Do not pipe output into a pager")
+	rootCmd.PersistentFlags().String("offline", "", "Perform a security review on unit file(s)")
+	rootCmd.PersistentFlags().Bool("order", false, "Show only order in the graph")
+	rootCmd.PersistentFlags().String("profile", "", "Include the specified profile in the security review of the unit(s)")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Do not emit hints")
+	rootCmd.PersistentFlags().String("recursive-errors", "", "Control which units are verified")
+	rootCmd.PersistentFlags().Bool("require", false, "Show only requirement in the graph")
+	rootCmd.PersistentFlags().String("root", "", "Operate on an alternate filesystem root")
+	rootCmd.PersistentFlags().String("scale-svg", "", "Stretch x-axis of plot by FACTOR")
+	rootCmd.PersistentFlags().String("security-policy", "", "Use custom JSON security policy instead of built-in one")
+	rootCmd.PersistentFlags().Bool("system", false, "Operate on system systemd instance")
+	rootCmd.PersistentFlags().Bool("table", false, "Output plot's raw time data as a table")
+	rootCmd.PersistentFlags().String("threshold", "", "Exit with a non-zero status when overall exposure level is over threshold value")
+	rootCmd.PersistentFlags().Bool("tldr", false, "Skip comments and empty lines")
+	rootCmd.PersistentFlags().String("to-pattern", "", "Show only destinations in the graph")
+	rootCmd.PersistentFlags().String("unit", "", "Evaluate conditions and asserts of unit")
+	rootCmd.PersistentFlags().Bool("user", false, "Operate on user systemd instance")
+	rootCmd.PersistentFlags().Bool("version", false, "Show package version")
+
+	rootCmd.Flag("generators").NoOptDefVal = " "
+	rootCmd.Flag("man").NoOptDefVal = " "
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"generators":       carapace.ActionValues("yes", "no").StyleF(style.ForKeyword),
+		"image":            carapace.ActionFiles(),
+		"json":             carapace.ActionValues("pretty", "short", "off"),
+		"man":              carapace.ActionValues("yes", "no").StyleF(style.ForKeyword),
+		"offline":          carapace.ActionValues("yes", "no").StyleF(style.ForKeyword),
+		"profile":          carapace.ActionFiles(),
+		"recursive-errors": carapace.ActionValues("yes", "no", "one").StyleF(style.ForKeyword),
+		"root":             carapace.ActionDirectories(),
+		"security-policy":  carapace.ActionFiles(),
+		"unit": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return systemctl.ActionUnits(systemctl.UnitOpts{User: rootCmd.Flag("user").Changed, Active: true, Inactive: true})
+		}),
+	})
+}

--- a/completers/common/systemd-analyze_completer/cmd/security.go
+++ b/completers/common/systemd-analyze_completer/cmd/security.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var securityCmd = &cobra.Command{
+	Use:   "security",
+	Short: "Analyze security of unit",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(securityCmd).Standalone()
+
+	rootCmd.AddCommand(securityCmd)
+
+	carapace.Gen(securityCmd).PositionalAnyCompletion(
+		action.ActionServices(securityCmd).FilterArgs(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/smbios11.go
+++ b/completers/common/systemd-analyze_completer/cmd/smbios11.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var smbios11Cmd = &cobra.Command{
+	Use:   "smbios11",
+	Short: "List strings passed via SMBIOS Type #11",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(smbios11Cmd).Standalone()
+
+	rootCmd.AddCommand(smbios11Cmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/srk.go
+++ b/completers/common/systemd-analyze_completer/cmd/srk.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var srkCmd = &cobra.Command{
+	Use:   "srk",
+	Short: "Write TPM2 SRK (to FILE)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(srkCmd).Standalone()
+
+	rootCmd.AddCommand(srkCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/syscallFilter.go
+++ b/completers/common/systemd-analyze_completer/cmd/syscallFilter.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var syscallFilterCmd = &cobra.Command{
+	Use:   "syscall-filter",
+	Short: "List syscalls in seccomp filters",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(syscallFilterCmd).Standalone()
+
+	rootCmd.AddCommand(syscallFilterCmd)
+
+	carapace.Gen(syscallFilterCmd).PositionalAnyCompletion(
+		action.ActionSyscallSets(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/cmd/time.go
+++ b/completers/common/systemd-analyze_completer/cmd/time.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var timeCmd = &cobra.Command{
+	Use:   "time",
+	Short: "Print time required to boot the machine",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(timeCmd).Standalone()
+
+	rootCmd.AddCommand(timeCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/timespan.go
+++ b/completers/common/systemd-analyze_completer/cmd/timespan.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var timespanCmd = &cobra.Command{
+	Use:   "timespan",
+	Short: "Validate a time span",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(timespanCmd).Standalone()
+
+	rootCmd.AddCommand(timespanCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/timestamp.go
+++ b/completers/common/systemd-analyze_completer/cmd/timestamp.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var timestampCmd = &cobra.Command{
+	Use:   "timestamp",
+	Short: "Validate a timestamp",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(timestampCmd).Standalone()
+
+	rootCmd.AddCommand(timestampCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/unitFiles.go
+++ b/completers/common/systemd-analyze_completer/cmd/unitFiles.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var unitFilesCmd = &cobra.Command{
+	Use:   "unit-files",
+	Short: "List files and symlinks for units",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(unitFilesCmd).Standalone()
+
+	rootCmd.AddCommand(unitFilesCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/unitPaths.go
+++ b/completers/common/systemd-analyze_completer/cmd/unitPaths.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var unitPathsCmd = &cobra.Command{
+	Use:   "unit-paths",
+	Short: "List load directories for units",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(unitPathsCmd).Standalone()
+
+	rootCmd.AddCommand(unitPathsCmd)
+}

--- a/completers/common/systemd-analyze_completer/cmd/verify.go
+++ b/completers/common/systemd-analyze_completer/cmd/verify.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var verifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Check unit files for correctness",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(verifyCmd).Standalone()
+
+	rootCmd.AddCommand(verifyCmd)
+
+	carapace.Gen(verifyCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/systemd-analyze_completer/main.go
+++ b/completers/common/systemd-analyze_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/systemd-analyze_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
- Added new completers:
  - `systemd-analyze`

- Updated the following to systemd 257:
  - `coredumpctl`
  - `run0`
  - `shutdown`
  - `halt`
  - `poweroff`
  - `reboot`