### PR TITLE
fix filename completion for 'kubectl delete -f'

### DIFF
--- a/completers/common/kubectl_completer/cmd/delete.go
+++ b/completers/common/kubectl_completer/cmd/delete.go
@@ -40,6 +40,7 @@ func init() {
 
 	carapace.Gen(deleteCmd).FlagCompletion(carapace.ActionMap{
 		"dry-run":   kubectl.ActionDryRunModes(),
+		"filename":  carapace.ActionFiles(),
 		"kustomize": carapace.ActionDirectories(),
 		"output":    kubectl.ActionOutputFormats(),
 	})


### PR DESCRIPTION
Completion for `kubectl delete -f <tab>` generates a list of k8s resources. This patch will generate a list of file paths instead (similar to `kubectl apply -f <tab>`).