### PR TITLE
Make Nushell init script backwards and forwards compatible for v0.106.0

### DIFF
--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -14,7 +14,7 @@ func Nushell(completers []string) string {
 
 let carapace_completer = {|spans|
   # if the current command is an alias, get it's expansion
-  let expanded_alias = (scope aliases | where name == $spans.0 | get -o 0.expansion)
+  let expanded_alias = (scope aliases | where name == $spans.0 | $in.0?.expansion?)
 
   # overwrite
   let spans = (if $expanded_alias != null  {
@@ -32,7 +32,8 @@ mut current = (($env | default {} config).config | default {} completions)
 $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
 | default true enable
-| default { $carapace_completer } completer)
+# backwards compatible workaround for default, see nushell #15654
+| upsert completer { if $in == null { $carapace_completer } else { $in } })
 
 $env.config = $current
     `

--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -14,7 +14,7 @@ func Nushell(completers []string) string {
 
 let carapace_completer = {|spans|
   # if the current command is an alias, get it's expansion
-  let expanded_alias = (scope aliases | where name == $spans.0 | get -i 0 | get -i expansion)
+  let expanded_alias = (scope aliases | where name == $spans.0 | get -o 0.expansion)
 
   # overwrite
   let spans = (if $expanded_alias != null  {


### PR DESCRIPTION
In Nushell version 0.106.0, the `get --ignore-errors` option was renamed to `get --optional`. This PR changes the usage of `get -i` to direct optional cell path accesses. This should ensure that the carapace integration works both before and after Nushell version 0.106.0.

Furthermore, this tweaks the fix from #2796 to be compatible before v0.105.0 as well. It's a bit of an inelegant workaround, but it gets the job done.

Both of these tweaks works on v0.106.0, and also work at least as far back as 0.94.0 which is the oldest version I have on hand to test with.

Sorry to have another change to the Nushell integration script so soon!

Fixes #2876