### PR TITLE
nushell: modularize Nushell init script

### DIFF
--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -10,33 +10,34 @@ func Nushell(completers []string) string {
 	if runtime.GOOS == "windows" {
 		windowsSnippet = " | str replace --regex  '\\.exe$' ''"
 	}
-	snippet := `%v%v
+	snippet := `export-env {
+  %v
 
-let carapace_completer = {|spans|
-  # if the current command is an alias, get it's expansion
-  let expanded_alias = (scope aliases | where name == $spans.0 | $in.0?.expansion?)
+  let carapace_completer = {|spans|
+    # if the current command is an alias, get it's expansion
+    let expanded_alias = (scope aliases | where name == $spans.0 | $in.0?.expansion?)
 
-  # overwrite
-  let spans = (if $expanded_alias != null  {
-    # put the first word of the expanded alias first in the span
-    $spans | skip 1 | prepend ($expanded_alias | split row " " | take 1%v)
-  } else {
-    $spans | skip 1 | prepend ($spans.0%v)
-  })
+    # overwrite
+    let spans = (if $expanded_alias != null  {
+      # put the first word of the expanded alias first in the span
+      $spans | skip 1 | prepend ($expanded_alias | split row " " | take 1%v)
+    } else {
+      $spans | skip 1 | prepend ($spans.0%v)
+    })
 
-  carapace $spans.0 nushell ...$spans
-  | from json
-}
+    carapace $spans.0 nushell ...$spans
+    | from json
+  }
 
-mut current = (($env | default {} config).config | default {} completions)
-$current.completions = ($current.completions | default {} external)
-$current.completions.external = ($current.completions.external
-| default true enable
-# backwards compatible workaround for default, see nushell #15654
-| upsert completer { if $in == null { $carapace_completer } else { $in } })
+  mut current = (($env | default {} config).config | default {} completions)
+  $current.completions = ($current.completions | default {} external)
+  $current.completions.external = ($current.completions.external
+  | default true enable
+  # backwards compatible workaround for default, see nushell #15654
+  | upsert completer { if $in == null { $carapace_completer } else { $in } })
 
-$env.config = $current
-    `
+  $env.config = $current
+}%v`
 
-	return fmt.Sprintf(snippet, pathSnippet("nushell"), envSnippet("nushell"), windowsSnippet, windowsSnippet)
+	return fmt.Sprintf(snippet, pathSnippet("nushell"), windowsSnippet, windowsSnippet, envSnippet("nushell"))
 }


### PR DESCRIPTION
I'm not *super* familiar with Go, but here's my own attempt at solving my own issue.

Essentially, it encapsulates all "environment-modifying" sections of the code (a.k.a. everything but `envSnippet("nushell")` part) within `export-env` block. This should be enough for Nushell to recognize the init script as a module, while keeping things compatible with the traditional `source` approach.

The module feature in Nushell has been around for quite a while, so I don't think backward compatibility is too much of a concern. Tested Nushell versions are: 0.103.0, 0.104.0, 0.105.0, 0.106.0.

Fixes #2909.