### PR TITLE
feat: git fetch refspec completion

### DIFF
--- a/completers/common/git_completer/cmd/fetch.go
+++ b/completers/common/git_completer/cmd/fetch.go
@@ -98,22 +98,17 @@ func init() {
 
 			// if we have no remote (<repository> or <group>) yet, complete that
 			if len(c.Args) == 0 {
-				return git.ActionRemotes().FilterArgs()
+				return git.ActionRemotes()
 			}
 
 			remote := c.Args[0]
+			return carapace.ActionMultiPartsN(":", 2, func(c carapace.Context) carapace.Action {
+				if len(c.Parts) == 0 {
+					return git.ActionRemoteBranchNames(remote)
+				}
 
-			return carapace.ActionValues("<src>:<dst>").
-				MultiPartsP(":", "<.*>", func(placeholder string, _ map[string]string) carapace.Action {
-					switch placeholder {
-					case "<src>":
-						return git.ActionRemoteBranchNames(remote)
-					case "<dst>":
-						return git.ActionLocalBranches()
-					default:
-						return carapace.ActionValues()
-					}
-				})
+				return git.ActionLocalBranches()
+			})
 		}),
 	)
 }


### PR DESCRIPTION
`git fetch <remote> <remote-tracking-branch>:<local-branch>` can be used to fast-forward a local branch without checkout. 

This PR adds completion for the `<remote-tracking-branch>:<local-branch>` part. 
git calls it `<refspec>` in it's manpage and docs: https://git-scm.com/docs/git-fetch