### PR TITLE
Fix elvish init snippet

### DIFF
--- a/cmd/carapace/cmd/lazyinit/elvish.go
+++ b/cmd/carapace/cmd/lazyinit/elvish.go
@@ -25,7 +25,7 @@ put %v | each {|c|
 
 	var quotedCompleters []string
 	for _, c := range completers {
-	    quotedCompleters = append(quotedCompleters, fmt.Sprintf("%q", c))
+		quotedCompleters = append(quotedCompleters, fmt.Sprintf("%q", c))
 	}
 
 	return fmt.Sprintf(snippet, pathSnippet("elvish"), strings.Join(quotedCompleters, " "), windowsSnippet)


### PR DESCRIPTION
The previous version generated the following elvish script for me

```elvish
put ! 5g 5l 6g 6l 7z 7za 7zr 8g 8l Makemodule.am Mosaic SuSEconfig VBoxHeadless VBoxSDL [ a2disconf a2dismod  [ | each {|c|
    set edit:completion:arg-completer[$c] = {|@arg|
        set edit:completion:arg-completer[$c] = {|@arg| }
        eval (carapace $c elvish | slurp)
        $edit:completion:arg-completer[$c] $@arg
    }
}
```

The problem here is that '[' has special meaning for elvish, causing the whole thing to fail with a `Exception: Parse error: should be ']'`.

The updated version quotes all completers, avoiding this problem.