### PR TITLE
jj: re-add aliases

### DIFF
--- a/completers/common/jj_completer/cmd/bookmark.go
+++ b/completers/common/jj_completer/cmd/bookmark.go
@@ -8,6 +8,7 @@ import (
 var bookmarkCmd = &cobra.Command{
 	Use:   "bookmark",
 	Short: "Manage bookmarks [default alias: b]",
+	Aliases: []string{"b"},
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 

--- a/completers/common/jj_completer/cmd/commit.go
+++ b/completers/common/jj_completer/cmd/commit.go
@@ -9,6 +9,7 @@ import (
 var commitCmd = &cobra.Command{
 	Use:   "commit",
 	Short: "Update the description and create a new change on top [default alias: ci]",
+	Aliases: []string{"ci"},
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 

--- a/completers/common/jj_completer/cmd/status.go
+++ b/completers/common/jj_completer/cmd/status.go
@@ -8,6 +8,7 @@ import (
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show high-level repo status [default alias: st]",
+	Aliases: []string{"st"},
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 


### PR DESCRIPTION
These aliases were removed in #2991, causing things like typing `jj b <tab>` to not complete.