### PR TITLE
adb: add device completions for the `-s` flag

### DIFF
--- a/completers/common/adb_completer/cmd/root.go
+++ b/completers/common/adb_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/adb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -16,6 +17,7 @@ var rootCmd = &cobra.Command{
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
@@ -27,6 +29,10 @@ func init() {
 	rootCmd.Flags().BoolS("e", "e", false, "use TCP/IP device (error if multiple TCP/IP devices available)")
 	rootCmd.Flags().StringS("s", "s", "", "use device with given serial (overrides $ANDROID_SERIAL)")
 	rootCmd.Flags().StringS("t", "t", "", "use device with given transport id")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"s": adb.ActionDevices(),
+	})
 
 	carapace.Gen(rootCmd).PreInvoke(func(cmd *cobra.Command, _ *pflag.Flag, action carapace.Action) carapace.Action {
 		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {

--- a/pkg/actions/tools/adb/device.go
+++ b/pkg/actions/tools/adb/device.go
@@ -1,0 +1,41 @@
+package adb
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionDevices completes adb device serial numbers
+func ActionDevices() carapace.Action {
+	return carapace.ActionExecCommand("adb", "devices", "-l")(func(output []byte) carapace.Action {
+		vals := make([]string, 0)
+
+		for _, line := range strings.Split(string(output), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 || fields[1] != "device" {
+				continue
+			}
+
+			serial := fields[0]
+			props := make(map[string]string)
+			for _, field := range fields[2:] {
+				if key, value, ok := strings.Cut(field, ":"); ok {
+					props[key] = value
+				}
+			}
+
+			var desc string
+			if model := props["model"]; model != "" {
+				desc = strings.ReplaceAll(model, "_", " ")
+				desc = strings.ReplaceAll(desc, "x86 64", "x86_64")
+				if usb := props["usb"]; usb != "" {
+					desc += " (usb:" + usb + ")"
+				}
+			}
+
+			vals = append(vals, serial, desc)
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}


### PR DESCRIPTION
### Problem

The adb completer doesn't complete devices when specifying a device with the `-s` flag.

### Solution

I've added support for completing devices with the `-s` flag. Currently, it parses the output of `adb devices -l` which looks like the following:

```
List of devices attached
<SERIAL> device usb:<USB> product:<PRODUCT> model:<MODEL> device:<DEVICE> transport_id:<TRANSPORT_ID>
```

For each device we add a description that shows the device model and usb port. The device models in adb's output replaces spaces with underscores (see [here](https://android.googlesource.com/platform/packages/modules/adb/+/refs/heads/main/transport.cpp#1337)), so we undo that to show a more human-friendly model name. However, this messes up the architecture `x86_64` in generic android emulators, so we undo this one specifically. All other architectures do not have an underscore in them (see [here](https://cs.android.com/android/platform/superproject/main/+/main:build/soong/android/arch.go;l=1789?q=arch.go&ss=android%2Fplatform%2Fsuperproject%2Fmain))  .

The screenshots below show it working with multiple devices attached:

<img width="555" height="86" alt="image" src="https://github.com/user-attachments/assets/d0e7f0ae-3beb-4112-bcbe-63177524ee35" />
<img width="596" height="80" alt="image" src="https://github.com/user-attachments/assets/086c15f8-e691-481a-822a-b7e2e438d151" />
