### PR TITLE
fix: check for all possible adb states when parsing device output

### DIFF
--- a/pkg/actions/tools/adb/device.go
+++ b/pkg/actions/tools/adb/device.go
@@ -7,17 +7,33 @@ import (
 )
 
 // ActionDevices completes adb device serial numbers
+//
+// Device states from https://android.googlesource.com/platform/packages/modules/adb/+/refs/heads/main/adb.cpp
 func ActionDevices() carapace.Action {
 	return carapace.ActionExecCommand("adb", "devices", "-l")(func(output []byte) carapace.Action {
 		vals := make([]string, 0)
 
+		validStates := map[string]bool{
+			"device":       true,
+			"offline":      true,
+			"bootloader":   true,
+			"recovery":     true,
+			"rescue":       true,
+			"sideload":     true,
+			"unauthorized": true,
+			"authorizing":  true,
+			"connecting":   true,
+			"detached":     true,
+		}
+
 		for _, line := range strings.Split(string(output), "\n") {
 			fields := strings.Fields(line)
-			if len(fields) < 2 || fields[1] != "device" {
+			if len(fields) < 2 || !validStates[fields[1]] {
 				continue
 			}
 
 			serial := fields[0]
+			state := fields[1]
 			props := make(map[string]string)
 			for _, field := range fields[2:] {
 				if key, value, ok := strings.Cut(field, ":"); ok {
@@ -29,9 +45,18 @@ func ActionDevices() carapace.Action {
 			if model := props["model"]; model != "" {
 				desc = strings.ReplaceAll(model, "_", " ")
 				desc = strings.ReplaceAll(desc, "x86 64", "x86_64")
-				if usb := props["usb"]; usb != "" {
-					desc += " (usb:" + usb + ")"
+			}
+			if state != "device" {
+				if desc != "" {
+					desc += " "
 				}
+				desc += "[" + state + "]"
+			}
+			if usb := props["usb"]; usb != "" {
+				if desc != "" {
+					desc += " "
+				}
+				desc += "(usb:" + usb + ")"
 			}
 
 			vals = append(vals, serial, desc)


### PR DESCRIPTION
- Follow-up to #3085

I forgot to add every possible device state, `device` is the default, but a device can be in many different states. This PR supports all the various states when parsing the output of `adb devices -l`. If a device is not in the `device` state, its state is added to the description as well.