### PR TITLE
jj: Disable coloring explicitly when parsing diff summary

### DIFF
--- a/pkg/actions/tools/jj/diff.go
+++ b/pkg/actions/tools/jj/diff.go
@@ -30,7 +30,7 @@ func ActionRevDiffs(revisions ...string) carapace.Action {
 			return carapace.ActionMessage("invalid amount of args [ActionRevChanges]")
 		}
 
-		return carapace.ActionExecCommand("jj", "diff", "--summary", "--from", from, "--to", to)(func(output []byte) carapace.Action {
+		return carapace.ActionExecCommand("jj", "--color", "never", "diff", "--summary", "--from", from, "--to", to)(func(output []byte) carapace.Action {
 			lines := strings.Split(string(output), "\n")
 
 			vals := make([]string, 0)


### PR DESCRIPTION
Let's do this explicitly no matter what user specified in their configuration (e.g. `ui.color = always`), as we rely on this when parsing its output.