### PR TITLE
nushell: ignore unknown shorthand flag error

### DIFF
--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -31,6 +31,7 @@ let carapace_completer = {|spans|
 
   carapace $spans.0 nushell ...$spans
   | from json
+  | if ($in | default [] | any {|| $in.display | str starts-with "ERR"}) { null } else { $in }
 }
 
 mut current = (($env | default {} config).config | default {} completions)


### PR DESCRIPTION
See https://www.nushell.sh/cookbook/external_completers.html#err-unknown-shorthand-flag-using-carapace for reference.