### PR TITLE
[Doc] Fix issue for zsh users

### DIFF
--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -106,6 +106,7 @@ exec($(carapace _carapace))
 
 ```sh
 # ${UserConfigDir}/zsh/.zshrc
+autoload -U compinit && compinit
 export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense' # optional
 zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
 source <(carapace _carapace)


### PR DESCRIPTION
On zsh on macos, following the instruction will lead to this error
``` 
command not found: compdef
``` 

This PR adds a small doc fix to prevent this error from happening