### PR TITLE
Update nushell setup instructions for OS agnostic path separator

### DIFF
--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -52,10 +52,10 @@ carapace _carapace | source
 ## ${UserConfigDir}/nushell/env.nu
 $env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense' # optional
 mkdir $"($nu.cache-dir)"
-carapace _carapace nushell | save --force $"($nu.cache-dir)/carapace.nu"
+carapace _carapace nushell | save --force ([$nu.cache-dir "carapace.nu"] | path join)
 
 # ${UserConfigDir}/nushell/config.nu
-source $"($nu.cache-dir)/carapace.nu"
+source ([$nu.cache-dir "carapace.nu"] | path join)
 ```
 
 ![](./setup-nushell.png)


### PR DESCRIPTION
Replace hardcoded `/` with a `path join` instead so it works the same on Windows file systems.