### PR TITLE
docs: add PowerShell MenuComplete requirement note

### DIFF
--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -80,6 +80,14 @@ Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
 carapace _carapace | Out-String | Invoke-Expression
 ```
 
+> **Note:** The `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` line is **required**.
+> The default `Complete` function (used by PSReadLine's `Emacs` edit mode) will display raw ANSI escape codes
+> (e.g. `^[[21;22;23;24;25;29m^[[39;49m`) in the prompt instead of styled completions.
+>
+> If you use `Set-PSReadLineOption -EditMode Emacs`, make sure it is placed **before** the
+> `Set-PSReadlineKeyHandler` line above, as it resets key bindings and would override the `Tab` binding
+> back to `Complete`.
+
 ![](./setup-powershell.png)
 
 ## Tcsh


### PR DESCRIPTION
## Summary

Adds a note to the PowerShell setup instructions explaining that:

1. `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` is **required** — the default `Complete` function will display raw ANSI escape codes (e.g. `^[[21;22;23;24;25;29m^[[39;49m`) in the prompt.

2. If using `Set-PSReadLineOption -EditMode Emacs`, it must be placed **before** the Tab key handler line, as it resets key bindings.

This was identified in carapace-sh/carapace#997 (comment: https://github.com/carapace-sh/carapace/issues/997#issuecomment-3566731943).

Fixes #3078