### PR TITLE
feat: add osc completer for OpenStack CLI

### DIFF
--- a/completers/common/osc_completer/cmd/api.go
+++ b/completers/common/osc_completer/cmd/api.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var apiCmd = &cobra.Command{
+	Use:   "api",
+	Short: "Perform direct API requests to OpenStack services",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(apiCmd).Standalone()
+
+	apiCmd.Flags().String("service", "", "Service type")
+	apiCmd.Flags().String("url", "", "URL path")
+	apiCmd.Flags().String("method", "", "HTTP method")
+	apiCmd.Flags().String("body", "", "Request body")
+
+	rootCmd.AddCommand(apiCmd)
+
+	carapace.Gen(apiCmd).FlagCompletion(carapace.ActionMap{
+		"method": carapace.ActionValues("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"),
+	})
+}

--- a/completers/common/osc_completer/cmd/auth.go
+++ b/completers/common/osc_completer/cmd/auth.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Cloud authentication operations",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var authLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Login to the cloud",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var authShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show current authentication information",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(authCmd).Standalone()
+	carapace.Gen(authLoginCmd).Standalone()
+	carapace.Gen(authShowCmd).Standalone()
+
+	rootCmd.AddCommand(authCmd)
+	authCmd.AddCommand(authLoginCmd)
+	authCmd.AddCommand(authShowCmd)
+}

--- a/completers/common/osc_completer/cmd/blockStorage.go
+++ b/completers/common/osc_completer/cmd/blockStorage.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var blockStorageCmd = &cobra.Command{
+	Use:   "block-storage",
+	Short: "Block Storage (Volume) service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var blockStorageVolumeCmd = &cobra.Command{
+	Use:   "volume",
+	Short: "Volume commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var blockStorageSnapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Snapshot commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var blockStorageBackupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Backup commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var blockStorageVolumeTypeCmd = &cobra.Command{
+	Use:   "volume-type",
+	Short: "Volume Type commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(blockStorageCmd).Standalone()
+	carapace.Gen(blockStorageVolumeCmd).Standalone()
+	carapace.Gen(blockStorageSnapshotCmd).Standalone()
+	carapace.Gen(blockStorageBackupCmd).Standalone()
+	carapace.Gen(blockStorageVolumeTypeCmd).Standalone()
+
+	rootCmd.AddCommand(blockStorageCmd)
+	blockStorageCmd.AddCommand(blockStorageVolumeCmd)
+	blockStorageCmd.AddCommand(blockStorageSnapshotCmd)
+	blockStorageCmd.AddCommand(blockStorageBackupCmd)
+	blockStorageCmd.AddCommand(blockStorageVolumeTypeCmd)
+
+	for _, cmd := range []*cobra.Command{blockStorageVolumeCmd, blockStorageSnapshotCmd, blockStorageBackupCmd, blockStorageVolumeTypeCmd} {
+		listCmd := &cobra.Command{Use: "list", Short: "List resources", Run: func(cmd *cobra.Command, args []string) {}}
+		showCmd := &cobra.Command{Use: "show", Short: "Show resource details", Run: func(cmd *cobra.Command, args []string) {}}
+		createCmd := &cobra.Command{Use: "create", Short: "Create a resource", Run: func(cmd *cobra.Command, args []string) {}}
+		deleteCmd := &cobra.Command{Use: "delete", Short: "Delete a resource", Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(listCmd).Standalone()
+		carapace.Gen(showCmd).Standalone()
+		carapace.Gen(createCmd).Standalone()
+		carapace.Gen(deleteCmd).Standalone()
+		cmd.AddCommand(listCmd, showCmd, createCmd, deleteCmd)
+	}
+}

--- a/completers/common/osc_completer/cmd/catalog.go
+++ b/completers/common/osc_completer/cmd/catalog.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var catalogCmd = &cobra.Command{
+	Use:   "catalog",
+	Short: "Service catalog commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var catalogListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List service catalog entries",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(catalogCmd).Standalone()
+	carapace.Gen(catalogListCmd).Standalone()
+
+	rootCmd.AddCommand(catalogCmd)
+	catalogCmd.AddCommand(catalogListCmd)
+}

--- a/completers/common/osc_completer/cmd/completion.go
+++ b/completers/common/osc_completer/cmd/completion.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Output shell completion code for the specified shell",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(completionCmd).Standalone()
+
+	rootCmd.AddCommand(completionCmd)
+
+	carapace.Gen(completionCmd).PositionalCompletion(
+		carapace.ActionValues("bash", "zsh", "fish", "powershell"),
+	)
+}

--- a/completers/common/osc_completer/cmd/compute.go
+++ b/completers/common/osc_completer/cmd/compute.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var computeCmd = &cobra.Command{
+	Use:   "compute",
+	Short: "Compute service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(computeCmd).Standalone()
+	rootCmd.AddCommand(computeCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"server", "Server commands"},
+		{"flavor", "Flavor commands"},
+		{"keypair", "Keypair commands"},
+		{"aggregate", "Host Aggregate commands"},
+		{"availability-zone", "Availability Zone commands"},
+		{"hypervisor", "Hypervisor commands"},
+		{"quota-set", "Quota Set commands"},
+		{"server-group", "Server Group commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		computeCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}
+
+func addCrudSubcommands(parent *cobra.Command) {
+	cmds := []struct {
+		use   string
+		short string
+	}{
+		{"list", "List resources"},
+		{"show", "Show resource details"},
+		{"create", "Create a resource"},
+		{"delete", "Delete a resource"},
+		{"set", "Update a resource"},
+	}
+	for _, c := range cmds {
+		sub := &cobra.Command{Use: c.use, Short: c.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		parent.AddCommand(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/containerInfrastructure.go
+++ b/completers/common/osc_completer/cmd/containerInfrastructure.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var containerInfraCmd = &cobra.Command{
+	Use:     "container-infrastructure",
+	Short:   "Container Infrastructure Management service commands",
+	Aliases: []string{"container-infrastructure-management", "container"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(containerInfraCmd).Standalone()
+	rootCmd.AddCommand(containerInfraCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"cluster", "Cluster commands"},
+		{"cluster-template", "Cluster Template commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		containerInfraCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/dns.go
+++ b/completers/common/osc_completer/cmd/dns.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var dnsCmd = &cobra.Command{
+	Use:   "dns",
+	Short: "DNS service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(dnsCmd).Standalone()
+	rootCmd.AddCommand(dnsCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"zone", "Zone commands"},
+		{"recordset", "Recordset commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		dnsCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/identity.go
+++ b/completers/common/osc_completer/cmd/identity.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var identityCmd = &cobra.Command{
+	Use:   "identity",
+	Short: "Identity (Keystone) service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(identityCmd).Standalone()
+	rootCmd.AddCommand(identityCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"project", "Project commands"},
+		{"user", "User commands"},
+		{"group", "Group commands"},
+		{"role", "Role commands"},
+		{"domain", "Domain commands"},
+		{"region", "Region commands"},
+		{"application-credential", "Application Credential commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		identityCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/image.go
+++ b/completers/common/osc_completer/cmd/image.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var imageCmd = &cobra.Command{
+	Use:   "image",
+	Short: "Image service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(imageCmd).Standalone()
+	rootCmd.AddCommand(imageCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"image", "Image commands"},
+		{"schema", "Schema commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		imageCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/loadBalancer.go
+++ b/completers/common/osc_completer/cmd/loadBalancer.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var loadBalancerCmd = &cobra.Command{
+	Use:   "load-balancer",
+	Short: "Load Balancer service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(loadBalancerCmd).Standalone()
+	rootCmd.AddCommand(loadBalancerCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"loadbalancer", "Load Balancer commands"},
+		{"listener", "Listener commands"},
+		{"pool", "Pool commands"},
+		{"member", "Member commands"},
+		{"healthmonitor", "Health Monitor commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		loadBalancerCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/network.go
+++ b/completers/common/osc_completer/cmd/network.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var networkCmd = &cobra.Command{
+	Use:   "network",
+	Short: "Network service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(networkCmd).Standalone()
+	rootCmd.AddCommand(networkCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"network", "Network commands"},
+		{"subnet", "Subnet commands"},
+		{"port", "Port commands"},
+		{"router", "Router commands"},
+		{"floating-ip", "Floating IP commands"},
+		{"security-group", "Security Group commands"},
+		{"security-group-rule", "Security Group Rule commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		networkCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/objectStore.go
+++ b/completers/common/osc_completer/cmd/objectStore.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var objectStoreCmd = &cobra.Command{
+	Use:   "object-store",
+	Short: "Object Store service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(objectStoreCmd).Standalone()
+	rootCmd.AddCommand(objectStoreCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"account", "Account commands"},
+		{"container", "Container commands"},
+		{"object", "Object commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		objectStoreCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/placement.go
+++ b/completers/common/osc_completer/cmd/placement.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var placementCmd = &cobra.Command{
+	Use:   "placement",
+	Short: "Placement service commands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(placementCmd).Standalone()
+	rootCmd.AddCommand(placementCmd)
+
+	subresources := []struct {
+		use   string
+		short string
+	}{
+		{"resource-provider", "Resource Provider commands"},
+		{"resource-class", "Resource Class commands"},
+		{"allocation", "Allocation commands"},
+	}
+
+	for _, r := range subresources {
+		sub := &cobra.Command{Use: r.use, Short: r.short, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(sub).Standalone()
+		placementCmd.AddCommand(sub)
+		addCrudSubcommands(sub)
+	}
+}

--- a/completers/common/osc_completer/cmd/root.go
+++ b/completers/common/osc_completer/cmd/root.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "osc",
+	Short: "OpenStack command line interface",
+	Long:  "https://github.com/gtema/openstack",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	// Connection options
+	rootCmd.PersistentFlags().String("os-cloud", "", "Name reference to the clouds.yaml entry for the cloud configuration")
+	rootCmd.PersistentFlags().Bool("cloud-config-from-env", false, "Get the cloud config from environment variables")
+	rootCmd.PersistentFlags().String("os-cloud-name", "", "Cloud name used when configuration is retrieved from environment variables")
+	rootCmd.PersistentFlags().String("os-project-id", "", "Project ID to use instead of the one in connection profile")
+	rootCmd.PersistentFlags().String("os-project-name", "", "Project Name to use instead of the one in the connection profile")
+	rootCmd.PersistentFlags().String("os-region-name", "", "Region Name to use instead of the one in the connection profile")
+	rootCmd.PersistentFlags().String("os-client-config-file", "", "Custom path to the clouds.yaml config file")
+	rootCmd.PersistentFlags().String("os-client-secure-file", "", "Custom path to the secure.yaml config file")
+	rootCmd.PersistentFlags().String("auth-helper-cmd", "", "External authentication helper command")
+
+	// Output options
+	rootCmd.PersistentFlags().StringP("output", "o", "", "Output format")
+	rootCmd.PersistentFlags().StringArrayP("fields", "f", nil, "Fields to return in the output")
+	rootCmd.PersistentFlags().BoolP("pretty", "p", false, "Pretty print the output")
+	rootCmd.PersistentFlags().CountP("verbose", "v", "Verbosity level")
+	rootCmd.PersistentFlags().String("table-arrangement", "dynamic", "Output Table arrangement")
+	rootCmd.PersistentFlags().Bool("timing", false, "Record HTTP request timings")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"output":            carapace.ActionValues("json", "wide"),
+		"table-arrangement": carapace.ActionValues("dynamic", "dynamic-full-width", "disabled"),
+		"os-client-config-file": carapace.ActionFiles(),
+		"os-client-secure-file": carapace.ActionFiles(),
+	})
+}

--- a/completers/common/osc_completer/main.go
+++ b/completers/common/osc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/osc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/linux/eopkg_completer/cmd/addRepo.go
+++ b/completers/linux/eopkg_completer/cmd/addRepo.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var addRepoCmd = &cobra.Command{
+	Use:     "add-repo",
+	Short:   "Add a repository",
+	Aliases: []string{"ar"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(addRepoCmd).Standalone()
+
+	addRepoCmd.Flags().String("at", "", "Add repository at given position")
+	addRepoCmd.Flags().Bool("ignore-check", false, "Ignore repository distribution check")
+
+	rootCmd.AddCommand(addRepoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/autoremove.go
+++ b/completers/linux/eopkg_completer/cmd/autoremove.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var autoremoveCmd = &cobra.Command{
+	Use:     "autoremove",
+	Short:   "Remove packages and dependencies",
+	Aliases: []string{"rmf"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(autoremoveCmd).Standalone()
+
+	autoremoveCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	autoremoveCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+	autoremoveCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	autoremoveCmd.Flags().BoolP("dry-run", "n", false, "Do not perform any action, just show what would be done")
+	autoremoveCmd.Flags().Bool("purge", false, "Remove package and purge")
+
+	rootCmd.AddCommand(autoremoveCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/build.go
+++ b/completers/linux/eopkg_completer/cmd/build.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var buildCmd = &cobra.Command{
+	Use:     "build",
+	Short:   "Build eopkg packages",
+	Aliases: []string{"bi"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(buildCmd).Standalone()
+
+	buildCmd.Flags().Bool("fetch", false, "Break build after fetching the source archive")
+	buildCmd.Flags().Bool("unpack", false, "Break build after unpacking the source archive")
+	buildCmd.Flags().Bool("setup", false, "Break build after running the setup action")
+	buildCmd.Flags().Bool("build", false, "Break build after running the build action")
+	buildCmd.Flags().Bool("check", false, "Break build after running the check action")
+	buildCmd.Flags().Bool("install", false, "Break build after running the install action")
+	buildCmd.Flags().Bool("package", false, "Create the eopkg package")
+	buildCmd.Flags().Bool("ignore-build-no", false, "Do not take build no into account")
+	buildCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	buildCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	buildCmd.Flags().StringP("output-dir", "O", "", "Output directory for produced packages")
+	buildCmd.Flags().Bool("ignore-action-errors", false, "Bypass errors from ActionsAPI")
+	buildCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	buildCmd.Flags().Bool("ignore-check", false, "Skip check action")
+	buildCmd.Flags().Bool("create-static", false, "Create a statically linked package")
+	buildCmd.Flags().String("package-format", "", "Create the package using the given format")
+	buildCmd.Flags().Bool("use-quilt", false, "Use quilt to apply patches")
+	buildCmd.Flags().Bool("ignore-sandbox", false, "Do not use build sandbox")
+
+	rootCmd.AddCommand(buildCmd)
+
+	carapace.Gen(buildCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/eopkg_completer/cmd/check.go
+++ b/completers/linux/eopkg_completer/cmd/check.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Verify package installation",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(checkCmd).Standalone()
+
+	checkCmd.Flags().StringP("component", "c", "", "Check installed packages under given component")
+	checkCmd.Flags().Bool("config", false, "Check only changed config files of the packages")
+
+	rootCmd.AddCommand(checkCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/clean.go
+++ b/completers/linux/eopkg_completer/cmd/clean.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var cleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Clean stale locks",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(cleanCmd).Standalone()
+
+	rootCmd.AddCommand(cleanCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/configurePending.go
+++ b/completers/linux/eopkg_completer/cmd/configurePending.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configurePendingCmd = &cobra.Command{
+	Use:     "configure-pending",
+	Short:   "Configure pending packages",
+	Aliases: []string{"cp"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configurePendingCmd).Standalone()
+
+	configurePendingCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	configurePendingCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+	configurePendingCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	configurePendingCmd.Flags().BoolP("dry-run", "n", false, "Do not perform any action, just show what would be done")
+
+	rootCmd.AddCommand(configurePendingCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/deleteCache.go
+++ b/completers/linux/eopkg_completer/cmd/deleteCache.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var deleteCacheCmd = &cobra.Command{
+	Use:     "delete-cache",
+	Short:   "Delete cache files",
+	Aliases: []string{"dc"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(deleteCacheCmd).Standalone()
+
+	rootCmd.AddCommand(deleteCacheCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/delta.go
+++ b/completers/linux/eopkg_completer/cmd/delta.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var deltaCmd = &cobra.Command{
+	Use:     "delta",
+	Short:   "Create a delta package",
+	Aliases: []string{"dt"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(deltaCmd).Standalone()
+
+	deltaCmd.Flags().StringP("output-dir", "O", "", "Output directory for produced packages")
+
+	rootCmd.AddCommand(deltaCmd)
+
+	carapace.Gen(deltaCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".eopkg"),
+	)
+}

--- a/completers/linux/eopkg_completer/cmd/disableRepo.go
+++ b/completers/linux/eopkg_completer/cmd/disableRepo.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var disableRepoCmd = &cobra.Command{
+	Use:     "disable-repo",
+	Short:   "Disable a repository",
+	Aliases: []string{"dr"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(disableRepoCmd).Standalone()
+
+	rootCmd.AddCommand(disableRepoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/emerge.go
+++ b/completers/linux/eopkg_completer/cmd/emerge.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var emergeCmd = &cobra.Command{
+	Use:     "emerge",
+	Short:   "Build and install packages from source",
+	Aliases: []string{"em"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(emergeCmd).Standalone()
+
+	emergeCmd.Flags().Bool("ignore-build-no", false, "Do not take build no into account")
+	emergeCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	emergeCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	emergeCmd.Flags().StringP("output-dir", "O", "", "Output directory for produced packages")
+	emergeCmd.Flags().Bool("ignore-action-errors", false, "Bypass errors from ActionsAPI")
+	emergeCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	emergeCmd.Flags().Bool("ignore-check", false, "Skip check action")
+	emergeCmd.Flags().Bool("create-static", false, "Create a statically linked package")
+	emergeCmd.Flags().String("package-format", "", "Create the package using the given format")
+	emergeCmd.Flags().Bool("use-quilt", false, "Use quilt to apply patches")
+	emergeCmd.Flags().Bool("ignore-sandbox", false, "Do not use build sandbox")
+	emergeCmd.Flags().StringP("component", "c", "", "Emerge component's packages")
+	emergeCmd.Flags().Bool("ignore-file-conflicts", false, "Ignore file conflicts")
+	emergeCmd.Flags().Bool("ignore-package-conflicts", false, "Ignore package conflicts")
+	emergeCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+
+	rootCmd.AddCommand(emergeCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/enableRepo.go
+++ b/completers/linux/eopkg_completer/cmd/enableRepo.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var enableRepoCmd = &cobra.Command{
+	Use:     "enable-repo",
+	Short:   "Enable a repository",
+	Aliases: []string{"er"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(enableRepoCmd).Standalone()
+
+	rootCmd.AddCommand(enableRepoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/fetch.go
+++ b/completers/linux/eopkg_completer/cmd/fetch.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var fetchCmd = &cobra.Command{
+	Use:     "fetch",
+	Short:   "Fetch a package",
+	Aliases: []string{"fc"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(fetchCmd).Standalone()
+
+	fetchCmd.Flags().StringP("output-dir", "O", "", "Output directory for fetched packages")
+
+	rootCmd.AddCommand(fetchCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/graph.go
+++ b/completers/linux/eopkg_completer/cmd/graph.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var graphCmd = &cobra.Command{
+	Use:   "graph",
+	Short: "Graph package relations",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(graphCmd).Standalone()
+
+	graphCmd.Flags().BoolP("repository", "R", false, "Graph only from repository")
+	graphCmd.Flags().Bool("installed", false, "Graph only installed packages")
+	graphCmd.Flags().Bool("ignore-installed", false, "Do not show installed packages")
+	graphCmd.Flags().StringP("output", "o", "", "Output file for graph")
+
+	rootCmd.AddCommand(graphCmd)
+
+	carapace.Gen(graphCmd).FlagCompletion(carapace.ActionMap{
+		"output": carapace.ActionFiles(),
+	})
+}

--- a/completers/linux/eopkg_completer/cmd/history.go
+++ b/completers/linux/eopkg_completer/cmd/history.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var historyCmd = &cobra.Command{
+	Use:     "history",
+	Short:   "History of eopkg operations",
+	Aliases: []string{"hs"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(historyCmd).Standalone()
+
+	historyCmd.Flags().StringP("last", "l", "", "Output only the last n operations")
+	historyCmd.Flags().BoolP("snapshot", "s", false, "Take snapshot of the current system")
+	historyCmd.Flags().StringP("takeback", "t", "", "Takeback to a given operation number")
+
+	rootCmd.AddCommand(historyCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/index.go
+++ b/completers/linux/eopkg_completer/cmd/index.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var indexCmd = &cobra.Command{
+	Use:     "index",
+	Short:   "Index eopkg packages",
+	Aliases: []string{"ix"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(indexCmd).Standalone()
+
+	indexCmd.Flags().BoolP("absolute-urls", "a", false, "Store absolute links for index file")
+	indexCmd.Flags().StringP("output", "o", "", "Index output file")
+	indexCmd.Flags().Bool("skip-sources", false, "Do not include sources in index")
+	indexCmd.Flags().Bool("skip-signing", false, "Do not sign the index")
+
+	rootCmd.AddCommand(indexCmd)
+
+	carapace.Gen(indexCmd).FlagCompletion(carapace.ActionMap{
+		"output": carapace.ActionFiles(),
+	})
+
+	carapace.Gen(indexCmd).PositionalAnyCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/linux/eopkg_completer/cmd/info.go
+++ b/completers/linux/eopkg_completer/cmd/info.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Display package info",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(infoCmd).Standalone()
+
+	infoCmd.Flags().BoolP("files", "f", false, "Show a list of package files")
+	infoCmd.Flags().StringP("component", "c", "", "Info about the given component")
+	infoCmd.Flags().Bool("files-path", false, "Show only paths")
+	infoCmd.Flags().BoolP("short", "s", false, "Do not show details")
+	infoCmd.Flags().Bool("xml", false, "Output in XML format")
+
+	rootCmd.AddCommand(infoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/install.go
+++ b/completers/linux/eopkg_completer/cmd/install.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var installCmd = &cobra.Command{
+	Use:     "install",
+	Short:   "Install packages",
+	Aliases: []string{"it"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(installCmd).Standalone()
+
+	installCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	installCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+	installCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	installCmd.Flags().BoolP("dry-run", "n", false, "Do not perform any action, just show what would be done")
+	installCmd.Flags().Bool("ignore-build-no", false, "Do not take build no into account")
+	installCmd.Flags().Bool("reinstall", false, "Reinstall already installed packages")
+	installCmd.Flags().Bool("ignore-check", false, "Skip distribution/version check")
+	installCmd.Flags().Bool("ignore-file-conflicts", false, "Ignore file conflicts")
+	installCmd.Flags().Bool("ignore-package-conflicts", false, "Ignore package conflicts")
+	installCmd.Flags().StringP("component", "c", "", "Install component's packages")
+	installCmd.Flags().StringP("repository", "r", "", "Name of the to be searched repository")
+	installCmd.Flags().Bool("fetch-only", false, "Fetch upgrades but do not install")
+	installCmd.Flags().String("exclude", "", "Packages to exclude from install")
+	installCmd.Flags().String("exclude-from", "", "File containing packages to exclude")
+
+	rootCmd.AddCommand(installCmd)
+
+	carapace.Gen(installCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".eopkg"),
+	)
+}

--- a/completers/linux/eopkg_completer/cmd/listAvailable.go
+++ b/completers/linux/eopkg_completer/cmd/listAvailable.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listAvailableCmd = &cobra.Command{
+	Use:     "list-available",
+	Short:   "List available packages in the repositories",
+	Aliases: []string{"la"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listAvailableCmd).Standalone()
+
+	listAvailableCmd.Flags().BoolP("long", "l", false, "Show in long format")
+	listAvailableCmd.Flags().StringP("component", "c", "", "List available packages under given component")
+	listAvailableCmd.Flags().BoolP("uninstalled", "U", false, "Show only uninstalled packages")
+
+	rootCmd.AddCommand(listAvailableCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listComponents.go
+++ b/completers/linux/eopkg_completer/cmd/listComponents.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listComponentsCmd = &cobra.Command{
+	Use:     "list-components",
+	Short:   "List available components",
+	Aliases: []string{"lc"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listComponentsCmd).Standalone()
+
+	listComponentsCmd.Flags().BoolP("long", "l", false, "Show in long format")
+	listComponentsCmd.Flags().StringP("repository", "r", "", "Name of the repository")
+
+	rootCmd.AddCommand(listComponentsCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listInstalled.go
+++ b/completers/linux/eopkg_completer/cmd/listInstalled.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listInstalledCmd = &cobra.Command{
+	Use:     "list-installed",
+	Short:   "List installed packages",
+	Aliases: []string{"li"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listInstalledCmd).Standalone()
+
+	listInstalledCmd.Flags().Bool("without-buildno", false, "Show packages without build number")
+	listInstalledCmd.Flags().BoolP("long", "l", false, "Show in long format")
+	listInstalledCmd.Flags().StringP("component", "c", "", "List installed packages under given component")
+	listInstalledCmd.Flags().BoolP("install-info", "i", false, "Show detailed install info")
+
+	rootCmd.AddCommand(listInstalledCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listNewest.go
+++ b/completers/linux/eopkg_completer/cmd/listNewest.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listNewestCmd = &cobra.Command{
+	Use:     "list-newest",
+	Short:   "List newest packages in the repositories",
+	Aliases: []string{"ln"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listNewestCmd).Standalone()
+
+	listNewestCmd.Flags().String("since", "", "List packages added after given date")
+	listNewestCmd.Flags().StringP("last", "l", "", "List last n packages")
+
+	rootCmd.AddCommand(listNewestCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listPending.go
+++ b/completers/linux/eopkg_completer/cmd/listPending.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listPendingCmd = &cobra.Command{
+	Use:     "list-pending",
+	Short:   "List pending packages",
+	Aliases: []string{"lp"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listPendingCmd).Standalone()
+
+	rootCmd.AddCommand(listPendingCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listRepo.go
+++ b/completers/linux/eopkg_completer/cmd/listRepo.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listRepoCmd = &cobra.Command{
+	Use:     "list-repo",
+	Short:   "List repositories",
+	Aliases: []string{"lr"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listRepoCmd).Standalone()
+
+	rootCmd.AddCommand(listRepoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listSources.go
+++ b/completers/linux/eopkg_completer/cmd/listSources.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listSourcesCmd = &cobra.Command{
+	Use:     "list-sources",
+	Short:   "List available sources",
+	Aliases: []string{"ls"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listSourcesCmd).Standalone()
+
+	listSourcesCmd.Flags().BoolP("long", "l", false, "Show in long format")
+
+	rootCmd.AddCommand(listSourcesCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/listUpgrades.go
+++ b/completers/linux/eopkg_completer/cmd/listUpgrades.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var listUpgradesCmd = &cobra.Command{
+	Use:     "list-upgrades",
+	Short:   "List packages to be upgraded",
+	Aliases: []string{"lu"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(listUpgradesCmd).Standalone()
+
+	listUpgradesCmd.Flags().Bool("ignore-build-no", false, "Do not take build no into account")
+	listUpgradesCmd.Flags().BoolP("long", "l", false, "Show in long format")
+	listUpgradesCmd.Flags().StringP("component", "c", "", "List upgrades under given component")
+	listUpgradesCmd.Flags().BoolP("install-info", "i", false, "Show detailed install info")
+
+	rootCmd.AddCommand(listUpgradesCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/rebuildDb.go
+++ b/completers/linux/eopkg_completer/cmd/rebuildDb.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rebuildDbCmd = &cobra.Command{
+	Use:     "rebuild-db",
+	Short:   "Rebuild the eopkg database",
+	Aliases: []string{"rdb"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(rebuildDbCmd).Standalone()
+
+	rebuildDbCmd.Flags().BoolP("files", "f", false, "Rebuild files database")
+
+	rootCmd.AddCommand(rebuildDbCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/remove.go
+++ b/completers/linux/eopkg_completer/cmd/remove.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:     "remove",
+	Short:   "Remove packages",
+	Aliases: []string{"rm"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(removeCmd).Standalone()
+
+	removeCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	removeCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+	removeCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	removeCmd.Flags().BoolP("dry-run", "n", false, "Do not perform any action, just show what would be done")
+	removeCmd.Flags().Bool("purge", false, "Remove package and purge")
+	removeCmd.Flags().StringP("component", "c", "", "Remove component's packages")
+
+	rootCmd.AddCommand(removeCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/removeOrphans.go
+++ b/completers/linux/eopkg_completer/cmd/removeOrphans.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var removeOrphansCmd = &cobra.Command{
+	Use:     "remove-orphans",
+	Short:   "Remove orphaned packages",
+	Aliases: []string{"rmo"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(removeOrphansCmd).Standalone()
+
+	removeOrphansCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	removeOrphansCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+	removeOrphansCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	removeOrphansCmd.Flags().BoolP("dry-run", "n", false, "Do not perform any action, just show what would be done")
+	removeOrphansCmd.Flags().Bool("purge", false, "Remove package and purge")
+
+	rootCmd.AddCommand(removeOrphansCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/removeRepo.go
+++ b/completers/linux/eopkg_completer/cmd/removeRepo.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var removeRepoCmd = &cobra.Command{
+	Use:     "remove-repo",
+	Short:   "Remove a repository",
+	Aliases: []string{"rr"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(removeRepoCmd).Standalone()
+
+	rootCmd.AddCommand(removeRepoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/root.go
+++ b/completers/linux/eopkg_completer/cmd/root.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "eopkg",
+	Short: "Solus package manager",
+	Long:  "https://help.getsol.us/docs/user/package-management/basics/",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().StringP("destdir", "D", "", "Change the system root for eopkg run operations")
+	rootCmd.PersistentFlags().BoolP("yes-all", "y", false, "Assume yes for all yes/no queries")
+	rootCmd.PersistentFlags().StringP("username", "u", "", "Set username")
+	rootCmd.PersistentFlags().StringP("password", "p", "", "Set password")
+	rootCmd.PersistentFlags().StringP("bandwidth-limit", "L", "", "Keep bandwidth usage under specified KB/s")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Detailed output")
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Show debug output")
+	rootCmd.PersistentFlags().Bool("no-color", false, "Suppress all coloring of output")
+	rootCmd.PersistentFlags().IntP("retry-attempts", "r", 0, "Set the max number of retry attempts in case of connection timeouts")
+	rootCmd.PersistentFlags().Bool("version", false, "Show program version")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Show help message")
+}

--- a/completers/linux/eopkg_completer/cmd/search.go
+++ b/completers/linux/eopkg_completer/cmd/search.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var searchCmd = &cobra.Command{
+	Use:     "search",
+	Short:   "Search packages",
+	Aliases: []string{"sr"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(searchCmd).Standalone()
+
+	searchCmd.Flags().StringP("language", "l", "", "Summary and description language")
+	searchCmd.Flags().StringP("repository", "r", "", "Name of the repository to search")
+	searchCmd.Flags().Bool("installdb", false, "Search in installdb")
+	searchCmd.Flags().Bool("sourcedb", false, "Search in sourcedb")
+	searchCmd.Flags().Bool("name", false, "Search in package name")
+	searchCmd.Flags().Bool("summary", false, "Search in package summary")
+	searchCmd.Flags().Bool("description", false, "Search in package description")
+
+	rootCmd.AddCommand(searchCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/searchFile.go
+++ b/completers/linux/eopkg_completer/cmd/searchFile.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var searchFileCmd = &cobra.Command{
+	Use:     "search-file",
+	Short:   "Search for a file in installed packages",
+	Aliases: []string{"sf"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(searchFileCmd).Standalone()
+
+	searchFileCmd.Flags().BoolP("long", "l", false, "Show in long format")
+	searchFileCmd.Flags().BoolP("quiet", "q", false, "Show only package name")
+
+	rootCmd.AddCommand(searchFileCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/updateRepo.go
+++ b/completers/linux/eopkg_completer/cmd/updateRepo.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var updateRepoCmd = &cobra.Command{
+	Use:     "update-repo",
+	Short:   "Update repository databases",
+	Aliases: []string{"ur"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(updateRepoCmd).Standalone()
+
+	updateRepoCmd.Flags().BoolP("force", "f", false, "Force updating repos")
+
+	rootCmd.AddCommand(updateRepoCmd)
+}

--- a/completers/linux/eopkg_completer/cmd/upgrade.go
+++ b/completers/linux/eopkg_completer/cmd/upgrade.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:     "upgrade",
+	Short:   "Upgrade packages",
+	Aliases: []string{"up"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(upgradeCmd).Standalone()
+
+	upgradeCmd.Flags().Bool("ignore-dependency", false, "Do not take dependency info into account")
+	upgradeCmd.Flags().Bool("ignore-comar", false, "Bypass COMAR configuration agent")
+	upgradeCmd.Flags().Bool("ignore-safety", false, "Bypass safety switch")
+	upgradeCmd.Flags().BoolP("dry-run", "n", false, "Do not perform any action, just show what would be done")
+	upgradeCmd.Flags().Bool("ignore-build-no", false, "Do not take build no into account")
+	upgradeCmd.Flags().Bool("security-only", false, "Security related upgrades only")
+	upgradeCmd.Flags().BoolP("bypass-update-repo", "b", false, "Do not update repositories")
+	upgradeCmd.Flags().Bool("ignore-file-conflicts", false, "Ignore file conflicts")
+	upgradeCmd.Flags().Bool("ignore-package-conflicts", false, "Ignore package conflicts")
+	upgradeCmd.Flags().StringP("component", "c", "", "Upgrade component's packages")
+	upgradeCmd.Flags().StringP("repository", "r", "", "Name of the repository")
+	upgradeCmd.Flags().Bool("fetch-only", false, "Fetch upgrades but do not install")
+	upgradeCmd.Flags().String("exclude", "", "Packages to exclude from upgrade")
+	upgradeCmd.Flags().String("exclude-from", "", "File containing packages to exclude")
+
+	rootCmd.AddCommand(upgradeCmd)
+}

--- a/completers/linux/eopkg_completer/main.go
+++ b/completers/linux/eopkg_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/linux/eopkg_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -80,6 +80,14 @@ Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
 carapace _carapace | Out-String | Invoke-Expression
 ```
 
+> **Note:** The `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` line is **required**.
+> The default `Complete` function (used by PSReadLine's `Emacs` edit mode) will display raw ANSI escape codes
+> (e.g. `^[[21;22;23;24;25;29m^[[39;49m`) in the prompt instead of styled completions.
+>
+> If you use `Set-PSReadLineOption -EditMode Emacs`, make sure it is placed **before** the
+> `Set-PSReadlineKeyHandler` line above, as it resets key bindings and would override the `Tab` binding
+> back to `Complete`.
+
 ![](./setup-powershell.png)
 
 ## Tcsh


### PR DESCRIPTION
## Summary

Adds shell completions for [`osc`](https://github.com/gtema/openstack), an OpenStack command line interface written in Rust.

### Covered services and resources

- **api** - Direct API requests
- **auth** - Authentication (login, show)
- **block-storage** - Volume, Snapshot, Backup, Volume Type
- **catalog** - Service catalog
- **completion** - Shell completion generation
- **compute** - Server, Flavor, Keypair, Aggregate, Availability Zone, Hypervisor, Quota Set, Server Group
- **container-infrastructure** - Cluster, Cluster Template
- **dns** - Zone, Recordset
- **identity** - Project, User, Group, Role, Domain, Region, Application Credential
- **image** - Image, Schema
- **load-balancer** - Load Balancer, Listener, Pool, Member, Health Monitor
- **network** - Network, Subnet, Port, Router, Floating IP, Security Group, Security Group Rule
- **object-store** - Account, Container, Object
- **placement** - Resource Provider, Resource Class, Allocation

Global connection options (`--os-cloud`, `--os-project-id`, etc.) and output options (`-o`, `-f`, `-v`, etc.) are included.

Each subresource includes CRUD operations (list, show, create, delete, set).

Fixes #2975