### PR TITLE
feat: add completer for mise

### DIFF
--- a/completers/mise/cmd/root.go
+++ b/completers/mise/cmd/root.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mise",
+	Short: "mise dev tools",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+}

--- a/completers/mise/completer.go
+++ b/completers/mise/completer.go
@@ -1,0 +1,26 @@
+package mise
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/mise"
+	"github.com/carapace-sh/carapace/pkg/style"
+)
+
+var completer = carapace.Gen(new(Cmd))
+
+type Cmd struct{}
+
+func (c *Cmd) Execute(args ...string) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionCommands(
+			"activate", "alias", "bin-paths", "config", "current", "deactivate", "doctor", "env", "exec", "generate", "hook-env", "install", "ls", "ls-remote", "outdated", "plugins", "prune", "quite", "registry", "run", "self-update", "settings", "shell", "tasks", "trust", "uninstall", "use", "version", "watch", "where", "which",
+		).Invoke(c).ToAction().Usage("manage tools").Style(style.Blue)
+	}).PositionalAny(carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		switch c.Args[0] {
+		case "use", "install", "uninstall", "shell", "run", "tasks", "where", "which", "exec":
+			return mise.ActionToolVersions()
+		default:
+			return carapace.ActionValues()
+		}
+	}))
+}


### PR DESCRIPTION
Fixes #2733

Added command completion for `mise`, a developer tool version manager and task runner. 

Supported subcommands and dynamic tool version suggestions are included.

---
*This PR was autonomously generated by [Pangea 3](https://github.com/sebmuehlbauer) — an AI-powered development system.*