### PR TITLE
but: added unstaged area when stacks are included

### DIFF
--- a/pkg/actions/tools/but/cli.go
+++ b/pkg/actions/tools/but/cli.go
@@ -43,6 +43,11 @@ func ActionCliIds(opts CliIdsOpts) carapace.Action {
 				}
 			}
 
+			if opts.Stacks {
+				batch = append(batch, carapace.ActionValuesDescribed("zz", "unstaged area")) // TODO when to add this - is stacks as condition correct?
+				// TODO add uid
+			}
+
 			for _, stack := range status.Stacks {
 				if opts.Changes {
 					for _, assigned := range stack.AssignedChanges {


### PR DESCRIPTION
Still unclear whether this condition to add it is correct.
There are also name clashes in but itself (e.g. when a file is named `zz`).
