### PR TITLE
Update nixos-rebuild completer

### DIFF
--- a/completers/common/nixos-rebuild_completer/cmd/root.go
+++ b/completers/common/nixos-rebuild_completer/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("impure", false, "Use impure nix evaluation")
 
 	rootCmd.MarkFlagsMutuallyExclusive("no-reexec", "no-build-nix") // aliases
-	rootCmd.MarkFlagsMutuallyExclusive("offline", "no-net") // aliases
+	rootCmd.MarkFlagsMutuallyExclusive("offline", "no-net")         // aliases
 	rootCmd.MarkFlagsMutuallyExclusive("no-build-output", "verbose", "quiet")
 
 	rootCmd.Flag("option").Nargs = 2


### PR DESCRIPTION
This PR addresses some of the changes that have been made to the available flags for `nixos-rebuild`.

It also fixes a small mistake resulting in the incorrect completion `--Q`.