### PR TITLE
nh: initial completer

### DIFF
--- a/completers/common/nh_completer/cmd/clean.go
+++ b/completers/common/nh_completer/cmd/clean.go
@@ -18,12 +18,12 @@ func init() {
 }
 
 func addCleanFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
+	cmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
 	cmd.Flags().StringP("keep", "k", "1", "At least keep this number of generations")
 	cmd.Flags().StringP("keep-since", "K", "0h", "At least keep gcroots and generations in this time range since now")
-	cmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
-	cmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
+	cmd.Flags().String("max", "", "Pass --max to nix store gc")
 	cmd.Flags().Bool("no-gc", false, "Don't run nix store --gc")
 	cmd.Flags().Bool("no-gcroots", false, "Don't clean gcroots")
 	cmd.Flags().Bool("optimise", false, "Run nix-store --optimise after gc")
-	cmd.Flags().String("max", "", "Pass --max to nix store gc")
 }

--- a/completers/common/nh_completer/cmd/clean.go
+++ b/completers/common/nh_completer/cmd/clean.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var cleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Enhanced nix cleanup",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(cleanCmd).Standalone()
+
+	rootCmd.AddCommand(cleanCmd)
+}
+
+func addCleanFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("keep", "k", "1", "At least keep this number of generations")
+	cmd.Flags().StringP("keep-since", "K", "0h", "At least keep gcroots and generations in this time range since now")
+	cmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
+	cmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
+	cmd.Flags().Bool("no-gc", false, "Don't run nix store --gc")
+	cmd.Flags().Bool("no-gcroots", false, "Don't clean gcroots")
+	cmd.Flags().Bool("optimise", false, "Run nix-store --optimise after gc")
+	cmd.Flags().String("max", "", "Pass --max to nix store gc")
+}

--- a/completers/common/nh_completer/cmd/clean_all.go
+++ b/completers/common/nh_completer/cmd/clean_all.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var clean_allCmd = &cobra.Command{
+	Use:   "all",
+	Short: "Clean all profiles",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(clean_allCmd).Standalone()
+
+	addCleanFlags(clean_allCmd)
+
+	cleanCmd.AddCommand(clean_allCmd)
+}

--- a/completers/common/nh_completer/cmd/clean_profile.go
+++ b/completers/common/nh_completer/cmd/clean_profile.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var clean_profileCmd = &cobra.Command{
+	Use:   "profile [profile]",
+	Short: "Clean a specific profile",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(clean_profileCmd).Standalone()
+
+	addCleanFlags(clean_profileCmd)
+
+	carapace.Gen(clean_profileCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+
+	cleanCmd.AddCommand(clean_profileCmd)
+}

--- a/completers/common/nh_completer/cmd/clean_user.go
+++ b/completers/common/nh_completer/cmd/clean_user.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var clean_userCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Clean the current user's profiles",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(clean_userCmd).Standalone()
+
+	addCleanFlags(clean_userCmd)
+
+	cleanCmd.AddCommand(clean_userCmd)
+}

--- a/completers/common/nh_completer/cmd/common.go
+++ b/completers/common/nh_completer/cmd/common.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+func addCommonRebuildFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
+	cmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
+	cmd.Flags().Bool("no-nom", false, "Don't use nix-output-monitor for the build process")
+	cmd.Flags().StringP("out-link", "o", "", "Path to save the result link")
+	cmd.Flags().StringP("diff", "d", "auto", "Whether to display a package diff")
+
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"diff":     carapace.ActionValues("auto", "always", "never"),
+		"out-link": carapace.ActionFiles(),
+	})
+
+	addNixBuildPassthroughFlags(cmd)
+}
+
+func addNixBuildPassthroughFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("max-jobs", "j", "", "Number of concurrent jobs Nix should run")
+	cmd.Flags().String("cores", "", "Number of cores Nix should utilize")
+	cmd.Flags().String("log-format", "", "Logging format used by Nix")
+	cmd.Flags().BoolP("keep-going", "k", false, "Continue building despite encountering errors")
+	cmd.Flags().BoolP("keep-failed", "K", false, "Keep build outputs from failed builds")
+	cmd.Flags().Bool("fallback", false, "Attempt to build locally if substituters fail")
+	cmd.Flags().Bool("repair", false, "Repair corrupted store paths")
+	cmd.Flags().String("builders", "", "Explicitly define remote builders")
+	cmd.Flags().StringArrayP("include", "I", nil, "Paths to include")
+	cmd.Flags().BoolP("print-build-logs", "L", false, "Print build logs directly to stdout")
+	cmd.Flags().BoolP("show-trace", "t", false, "Display tracebacks on errors")
+	cmd.Flags().Bool("accept-flake-config", false, "Accept configuration from flakes")
+	cmd.Flags().Bool("refresh", false, "Refresh flakes to the latest revision")
+	cmd.Flags().Bool("impure", false, "Allow impure builds")
+	cmd.Flags().Bool("offline", false, "Build without internet access")
+	cmd.Flags().Bool("no-net", false, "Prohibit network usage")
+	cmd.Flags().Bool("recreate-lock-file", false, "Recreate the flake.lock file entirely")
+	cmd.Flags().Bool("no-update-lock-file", false, "Do not update the flake.lock file")
+	cmd.Flags().Bool("no-write-lock-file", false, "Do not write a lock file")
+	cmd.Flags().Bool("no-use-registries", false, "Do not use registries")
+	cmd.Flags().Bool("no-registries", false, "Do not use registries (deprecated)")
+	cmd.Flags().Bool("commit-lock-file", false, "Commit the lock file after updates")
+	cmd.Flags().BoolP("no-build-output", "Q", false, "Suppress build output")
+	cmd.Flags().Bool("use-substitutes", false, "Use substitutes when copying")
+	cmd.Flags().Bool("json", false, "Output results in JSON format")
+}
+
+func addUpdateFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolP("update", "u", false, "Update all flake inputs")
+	cmd.Flags().StringArrayP("update-input", "U", nil, "Update the specified flake input(s)")
+	cmd.MarkFlagsMutuallyExclusive("update", "update-input")
+}
+
+func addOsRebuildFlags(cmd *cobra.Command) {
+	addCommonRebuildFlags(cmd)
+	addUpdateFlags(cmd)
+	cmd.Flags().StringP("hostname", "H", "", "Select this hostname from nixosConfigurations")
+	cmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
+	cmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
+	cmd.Flags().Bool("install-bootloader", false, "Install bootloader for switch and boot commands")
+	cmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
+	cmd.Flags().String("target-host", "", "Deploy the built configuration to a different host over SSH")
+	cmd.Flags().String("build-host", "", "Build the configuration on a different host over SSH")
+	cmd.Flags().Bool("no-validate", false, "Skip pre-activation system validation checks")
+}

--- a/completers/common/nh_completer/cmd/common/common.go
+++ b/completers/common/nh_completer/cmd/common/common.go
@@ -1,11 +1,11 @@
-package cmd
+package common
 
 import (
 	"github.com/carapace-sh/carapace"
 	"github.com/spf13/cobra"
 )
 
-func addCommonRebuildFlags(cmd *cobra.Command) {
+func AddCommonRebuildFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
 	cmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
 	cmd.Flags().Bool("no-nom", false, "Don't use nix-output-monitor for the build process")
@@ -17,10 +17,10 @@ func addCommonRebuildFlags(cmd *cobra.Command) {
 		"out-link": carapace.ActionFiles(),
 	})
 
-	addNixBuildPassthroughFlags(cmd)
+	AddNixBuildPassthroughFlags(cmd)
 }
 
-func addNixBuildPassthroughFlags(cmd *cobra.Command) {
+func AddNixBuildPassthroughFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("max-jobs", "j", "", "Number of concurrent jobs Nix should run")
 	cmd.Flags().String("cores", "", "Number of cores Nix should utilize")
 	cmd.Flags().String("log-format", "", "Logging format used by Nix")
@@ -48,15 +48,15 @@ func addNixBuildPassthroughFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("json", false, "Output results in JSON format")
 }
 
-func addUpdateFlags(cmd *cobra.Command) {
+func AddUpdateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("update", "u", false, "Update all flake inputs")
 	cmd.Flags().StringArrayP("update-input", "U", nil, "Update the specified flake input(s)")
 	cmd.MarkFlagsMutuallyExclusive("update", "update-input")
 }
 
-func addOsRebuildFlags(cmd *cobra.Command) {
-	addCommonRebuildFlags(cmd)
-	addUpdateFlags(cmd)
+func AddOsRebuildFlags(cmd *cobra.Command) {
+	AddCommonRebuildFlags(cmd)
+	AddUpdateFlags(cmd)
 	cmd.Flags().StringP("hostname", "H", "", "Select this hostname from nixosConfigurations")
 	cmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
 	cmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")

--- a/completers/common/nh_completer/cmd/darwin.go
+++ b/completers/common/nh_completer/cmd/darwin.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var darwinCmd = &cobra.Command{
+	Use:   "darwin",
+	Short: "Nix-darwin functionality",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(darwinCmd).Standalone()
+
+	rootCmd.AddCommand(darwinCmd)
+}
+
+func addDarwinRebuildFlags(cmd *cobra.Command) {
+	addCommonRebuildFlags(cmd)
+	addUpdateFlags(cmd)
+	cmd.Flags().StringP("hostname", "H", "", "Select this hostname from darwinConfigurations")
+	cmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
+	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
+	cmd.Flags().String("build-host", "", "Build the configuration on a different host over SSH")
+}

--- a/completers/common/nh_completer/cmd/darwin.go
+++ b/completers/common/nh_completer/cmd/darwin.go
@@ -21,8 +21,8 @@ func init() {
 func addDarwinRebuildFlags(cmd *cobra.Command) {
 	common.AddCommonRebuildFlags(cmd)
 	common.AddUpdateFlags(cmd)
-	cmd.Flags().StringP("hostname", "H", "", "Select this hostname from darwinConfigurations")
-	cmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
-	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
 	cmd.Flags().String("build-host", "", "Build the configuration on a different host over SSH")
+	cmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
+	cmd.Flags().StringP("hostname", "H", "", "Select this hostname from darwinConfigurations")
+	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
 }

--- a/completers/common/nh_completer/cmd/darwin.go
+++ b/completers/common/nh_completer/cmd/darwin.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -18,8 +19,8 @@ func init() {
 }
 
 func addDarwinRebuildFlags(cmd *cobra.Command) {
-	addCommonRebuildFlags(cmd)
-	addUpdateFlags(cmd)
+	common.AddCommonRebuildFlags(cmd)
+	common.AddUpdateFlags(cmd)
 	cmd.Flags().StringP("hostname", "H", "", "Select this hostname from darwinConfigurations")
 	cmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
 	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")

--- a/completers/common/nh_completer/cmd/darwin_build.go
+++ b/completers/common/nh_completer/cmd/darwin_build.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var darwin_buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build a nix-darwin configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(darwin_buildCmd).Standalone()
+
+	addDarwinRebuildFlags(darwin_buildCmd)
+
+	darwinCmd.AddCommand(darwin_buildCmd)
+}

--- a/completers/common/nh_completer/cmd/darwin_repl.go
+++ b/completers/common/nh_completer/cmd/darwin_repl.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var darwin_replCmd = &cobra.Command{
+	Use:   "repl",
+	Short: "Load a nix-darwin configuration in a Nix REPL",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(darwin_replCmd).Standalone()
+
+	darwin_replCmd.Flags().StringP("hostname", "H", "", "Select this hostname from darwinConfigurations")
+
+	darwinCmd.AddCommand(darwin_replCmd)
+}

--- a/completers/common/nh_completer/cmd/darwin_switch.go
+++ b/completers/common/nh_completer/cmd/darwin_switch.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var darwin_switchCmd = &cobra.Command{
+	Use:   "switch",
+	Short: "Build and activate a nix-darwin configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(darwin_switchCmd).Standalone()
+
+	addDarwinRebuildFlags(darwin_switchCmd)
+
+	darwinCmd.AddCommand(darwin_switchCmd)
+}

--- a/completers/common/nh_completer/cmd/home.go
+++ b/completers/common/nh_completer/cmd/home.go
@@ -21,10 +21,10 @@ func init() {
 func addHomeRebuildFlags(cmd *cobra.Command) {
 	common.AddCommonRebuildFlags(cmd)
 	common.AddUpdateFlags(cmd)
-	cmd.Flags().StringP("configuration", "c", "", "Name of the flake homeConfigurations attribute")
-	cmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
-	cmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
 	cmd.Flags().StringP("backup-extension", "b", "", "Move existing files by backing up with this file extension")
-	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
 	cmd.Flags().String("build-host", "", "Build the configuration on a different host over SSH")
+	cmd.Flags().StringP("configuration", "c", "", "Name of the flake homeConfigurations attribute")
+	cmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
+	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
+	cmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
 }

--- a/completers/common/nh_completer/cmd/home.go
+++ b/completers/common/nh_completer/cmd/home.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var homeCmd = &cobra.Command{
+	Use:   "home",
+	Short: "Home-manager functionality",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(homeCmd).Standalone()
+
+	rootCmd.AddCommand(homeCmd)
+}
+
+func addHomeRebuildFlags(cmd *cobra.Command) {
+	addCommonRebuildFlags(cmd)
+	addUpdateFlags(cmd)
+	cmd.Flags().StringP("configuration", "c", "", "Name of the flake homeConfigurations attribute")
+	cmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
+	cmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
+	cmd.Flags().StringP("backup-extension", "b", "", "Move existing files by backing up with this file extension")
+	cmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
+	cmd.Flags().String("build-host", "", "Build the configuration on a different host over SSH")
+}

--- a/completers/common/nh_completer/cmd/home.go
+++ b/completers/common/nh_completer/cmd/home.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -18,8 +19,8 @@ func init() {
 }
 
 func addHomeRebuildFlags(cmd *cobra.Command) {
-	addCommonRebuildFlags(cmd)
-	addUpdateFlags(cmd)
+	common.AddCommonRebuildFlags(cmd)
+	common.AddUpdateFlags(cmd)
 	cmd.Flags().StringP("configuration", "c", "", "Name of the flake homeConfigurations attribute")
 	cmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
 	cmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")

--- a/completers/common/nh_completer/cmd/home_build.go
+++ b/completers/common/nh_completer/cmd/home_build.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var home_buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build a home-manager configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(home_buildCmd).Standalone()
+
+	addHomeRebuildFlags(home_buildCmd)
+
+	homeCmd.AddCommand(home_buildCmd)
+}

--- a/completers/common/nh_completer/cmd/home_repl.go
+++ b/completers/common/nh_completer/cmd/home_repl.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var home_replCmd = &cobra.Command{
+	Use:   "repl",
+	Short: "Load a home-manager configuration in a Nix REPL",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(home_replCmd).Standalone()
+
+	home_replCmd.Flags().StringP("configuration", "c", "", "Name of the flake homeConfigurations attribute")
+
+	homeCmd.AddCommand(home_replCmd)
+}

--- a/completers/common/nh_completer/cmd/home_switch.go
+++ b/completers/common/nh_completer/cmd/home_switch.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var home_switchCmd = &cobra.Command{
+	Use:   "switch",
+	Short: "Build and activate a home-manager configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(home_switchCmd).Standalone()
+
+	addHomeRebuildFlags(home_switchCmd)
+
+	homeCmd.AddCommand(home_switchCmd)
+}

--- a/completers/common/nh_completer/cmd/os.go
+++ b/completers/common/nh_completer/cmd/os.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var osCmd = &cobra.Command{
+	Use:   "os",
+	Short: "NixOS functionality",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(osCmd).Standalone()
+
+	rootCmd.AddCommand(osCmd)
+}

--- a/completers/common/nh_completer/cmd/osTest.go
+++ b/completers/common/nh_completer/cmd/osTest.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Build and activate the new configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_testCmd).Standalone()
+
+	addOsRebuildFlags(os_testCmd)
+	os_testCmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
+
+	osCmd.AddCommand(os_testCmd)
+}

--- a/completers/common/nh_completer/cmd/os_boot.go
+++ b/completers/common/nh_completer/cmd/os_boot.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var os_bootCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_bootCmd).Standalone()
 
-	addOsRebuildFlags(os_bootCmd)
+	common.AddOsRebuildFlags(os_bootCmd)
 	os_bootCmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
 
 	osCmd.AddCommand(os_bootCmd)

--- a/completers/common/nh_completer/cmd/os_boot.go
+++ b/completers/common/nh_completer/cmd/os_boot.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_bootCmd = &cobra.Command{
+	Use:   "boot",
+	Short: "Build the new configuration and make it the boot default",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_bootCmd).Standalone()
+
+	addOsRebuildFlags(os_bootCmd)
+	os_bootCmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
+
+	osCmd.AddCommand(os_bootCmd)
+}

--- a/completers/common/nh_completer/cmd/os_build.go
+++ b/completers/common/nh_completer/cmd/os_build.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var os_buildCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_buildCmd).Standalone()
 
-	addOsRebuildFlags(os_buildCmd)
+	common.AddOsRebuildFlags(os_buildCmd)
 
 	osCmd.AddCommand(os_buildCmd)
 }

--- a/completers/common/nh_completer/cmd/os_build.go
+++ b/completers/common/nh_completer/cmd/os_build.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_buildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Build the new configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_buildCmd).Standalone()
+
+	addOsRebuildFlags(os_buildCmd)
+
+	osCmd.AddCommand(os_buildCmd)
+}

--- a/completers/common/nh_completer/cmd/os_buildImage.go
+++ b/completers/common/nh_completer/cmd/os_buildImage.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_buildImageCmd = &cobra.Command{
+	Use:   "build-image",
+	Short: "Build a NixOS disk-image variant",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_buildImageCmd).Standalone()
+
+	addOsRebuildFlags(os_buildImageCmd)
+	os_buildImageCmd.Flags().String("image-variant", "", "Image variant")
+
+	osCmd.AddCommand(os_buildImageCmd)
+}

--- a/completers/common/nh_completer/cmd/os_buildImage.go
+++ b/completers/common/nh_completer/cmd/os_buildImage.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var os_buildImageCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_buildImageCmd).Standalone()
 
-	addOsRebuildFlags(os_buildImageCmd)
+	common.AddOsRebuildFlags(os_buildImageCmd)
 	os_buildImageCmd.Flags().String("image-variant", "", "Image variant")
 
 	osCmd.AddCommand(os_buildImageCmd)

--- a/completers/common/nh_completer/cmd/os_buildVm.go
+++ b/completers/common/nh_completer/cmd/os_buildVm.go
@@ -16,8 +16,8 @@ func init() {
 	carapace.Gen(os_buildVmCmd).Standalone()
 
 	common.AddOsRebuildFlags(os_buildVmCmd)
-	os_buildVmCmd.Flags().BoolP("with-bootloader", "B", false, "Build with bootloader")
 	os_buildVmCmd.Flags().BoolP("run", "r", false, "Run the VM immediately after building")
+	os_buildVmCmd.Flags().BoolP("with-bootloader", "B", false, "Build with bootloader")
 
 	osCmd.AddCommand(os_buildVmCmd)
 }

--- a/completers/common/nh_completer/cmd/os_buildVm.go
+++ b/completers/common/nh_completer/cmd/os_buildVm.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_buildVmCmd = &cobra.Command{
+	Use:   "build-vm",
+	Short: "Build a NixOS VM image",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_buildVmCmd).Standalone()
+
+	addOsRebuildFlags(os_buildVmCmd)
+	os_buildVmCmd.Flags().BoolP("with-bootloader", "B", false, "Build with bootloader")
+	os_buildVmCmd.Flags().BoolP("run", "r", false, "Run the VM immediately after building")
+
+	osCmd.AddCommand(os_buildVmCmd)
+}

--- a/completers/common/nh_completer/cmd/os_buildVm.go
+++ b/completers/common/nh_completer/cmd/os_buildVm.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var os_buildVmCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_buildVmCmd).Standalone()
 
-	addOsRebuildFlags(os_buildVmCmd)
+	common.AddOsRebuildFlags(os_buildVmCmd)
 	os_buildVmCmd.Flags().BoolP("with-bootloader", "B", false, "Build with bootloader")
 	os_buildVmCmd.Flags().BoolP("run", "r", false, "Run the VM immediately after building")
 

--- a/completers/common/nh_completer/cmd/os_info.go
+++ b/completers/common/nh_completer/cmd/os_info.go
@@ -14,8 +14,8 @@ var os_infoCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_infoCmd).Standalone()
 
-	os_infoCmd.Flags().StringP("profile", "P", "/nix/var/nix/profiles/system", "Path to Nix profiles directory")
 	os_infoCmd.Flags().String("fields", "", "Comma-delimited list of field(s) to display")
+	os_infoCmd.Flags().StringP("profile", "P", "/nix/var/nix/profiles/system", "Path to Nix profiles directory")
 
 	carapace.Gen(os_infoCmd).FlagCompletion(carapace.ActionMap{
 		"fields":  carapace.ActionValues("id", "date", "nver", "kernel", "confRev", "spec", "size").UniqueList(","),

--- a/completers/common/nh_completer/cmd/os_info.go
+++ b/completers/common/nh_completer/cmd/os_info.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "List available generations from profile path",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_infoCmd).Standalone()
+
+	os_infoCmd.Flags().StringP("profile", "P", "/nix/var/nix/profiles/system", "Path to Nix profiles directory")
+	os_infoCmd.Flags().String("fields", "", "Comma-delimited list of field(s) to display")
+
+	carapace.Gen(os_infoCmd).FlagCompletion(carapace.ActionMap{
+		"fields":  carapace.ActionValues("id", "date", "nver", "kernel", "confRev", "spec", "size").UniqueList(","),
+		"profile": carapace.ActionFiles(),
+	})
+
+	osCmd.AddCommand(os_infoCmd)
+}

--- a/completers/common/nh_completer/cmd/os_repl.go
+++ b/completers/common/nh_completer/cmd/os_repl.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_replCmd = &cobra.Command{
+	Use:   "repl",
+	Short: "Load system in a repl",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_replCmd).Standalone()
+
+	os_replCmd.Flags().StringP("hostname", "H", "", "Select this hostname from nixosConfigurations")
+
+	osCmd.AddCommand(os_replCmd)
+}

--- a/completers/common/nh_completer/cmd/os_rollback.go
+++ b/completers/common/nh_completer/cmd/os_rollback.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_rollbackCmd = &cobra.Command{
+	Use:   "rollback",
+	Short: "Rollback to a previous generation",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_rollbackCmd).Standalone()
+
+	os_rollbackCmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
+	os_rollbackCmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
+	os_rollbackCmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
+	os_rollbackCmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
+	os_rollbackCmd.Flags().StringP("to", "t", "", "Rollback to a specific generation number")
+	os_rollbackCmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
+	os_rollbackCmd.Flags().StringP("diff", "d", "auto", "Whether to display a package diff")
+
+	carapace.Gen(os_rollbackCmd).FlagCompletion(carapace.ActionMap{
+		"diff": carapace.ActionValues("auto", "always", "never"),
+	})
+
+	osCmd.AddCommand(os_rollbackCmd)
+}

--- a/completers/common/nh_completer/cmd/os_rollback.go
+++ b/completers/common/nh_completer/cmd/os_rollback.go
@@ -14,13 +14,13 @@ var os_rollbackCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_rollbackCmd).Standalone()
 
-	os_rollbackCmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
 	os_rollbackCmd.Flags().BoolP("ask", "a", false, "Ask for confirmation")
-	os_rollbackCmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
-	os_rollbackCmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
-	os_rollbackCmd.Flags().StringP("to", "t", "", "Rollback to a specific generation number")
 	os_rollbackCmd.Flags().BoolP("bypass-root-check", "R", false, "Don't panic if calling nh as root")
 	os_rollbackCmd.Flags().StringP("diff", "d", "auto", "Whether to display a package diff")
+	os_rollbackCmd.Flags().BoolP("dry", "n", false, "Only print actions, without performing them")
+	os_rollbackCmd.Flags().BoolP("no-specialisation", "S", false, "Ignore specialisations")
+	os_rollbackCmd.Flags().StringP("specialisation", "s", "", "Explicitly select some specialisation")
+	os_rollbackCmd.Flags().StringP("to", "t", "", "Rollback to a specific generation number")
 
 	carapace.Gen(os_rollbackCmd).FlagCompletion(carapace.ActionMap{
 		"diff": carapace.ActionValues("auto", "always", "never"),

--- a/completers/common/nh_completer/cmd/os_switch.go
+++ b/completers/common/nh_completer/cmd/os_switch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var os_switchCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_switchCmd).Standalone()
 
-	addOsRebuildFlags(os_switchCmd)
+	common.AddOsRebuildFlags(os_switchCmd)
 	os_switchCmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
 
 	osCmd.AddCommand(os_switchCmd)

--- a/completers/common/nh_completer/cmd/os_switch.go
+++ b/completers/common/nh_completer/cmd/os_switch.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var os_switchCmd = &cobra.Command{
+	Use:   "switch",
+	Short: "Build and activate the new configuration, and make it the boot default",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(os_switchCmd).Standalone()
+
+	addOsRebuildFlags(os_switchCmd)
+	os_switchCmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
+
+	osCmd.AddCommand(os_switchCmd)
+}

--- a/completers/common/nh_completer/cmd/os_test_.go
+++ b/completers/common/nh_completer/cmd/os_test_.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +15,7 @@ var os_testCmd = &cobra.Command{
 func init() {
 	carapace.Gen(os_testCmd).Standalone()
 
-	addOsRebuildFlags(os_testCmd)
+	common.AddOsRebuildFlags(os_testCmd)
 	os_testCmd.Flags().Bool("show-activation-logs", false, "Show activation logs")
 
 	osCmd.AddCommand(os_testCmd)

--- a/completers/common/nh_completer/cmd/root.go
+++ b/completers/common/nh_completer/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "nh",
+	Short: "Yet another nix helper",
+	Long:  "https://github.com/nix-community/nh",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().CountP("verbose", "v", "Increase logging verbosity")
+	rootCmd.PersistentFlags().StringP("elevation-strategy", "e", "", "Choose the privilege elevation strategy")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"elevation-strategy": carapace.ActionValues("none", "auto", "passwordless"),
+	})
+}

--- a/completers/common/nh_completer/cmd/search.go
+++ b/completers/common/nh_completer/cmd/search.go
@@ -14,10 +14,10 @@ var searchCmd = &cobra.Command{
 func init() {
 	carapace.Gen(searchCmd).Standalone()
 
-	searchCmd.Flags().StringP("limit", "l", "30", "Number of search results to display")
 	searchCmd.Flags().StringP("channel", "c", "nixos-unstable", "Name of the channel to query")
-	searchCmd.Flags().BoolP("platforms", "P", false, "Show supported platforms for each package")
 	searchCmd.Flags().BoolP("json", "j", false, "Output results as JSON")
+	searchCmd.Flags().StringP("limit", "l", "30", "Number of search results to display")
+	searchCmd.Flags().BoolP("platforms", "P", false, "Show supported platforms for each package")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/completers/common/nh_completer/cmd/search.go
+++ b/completers/common/nh_completer/cmd/search.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Search packages by querying search.nixos.org",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(searchCmd).Standalone()
+
+	searchCmd.Flags().StringP("limit", "l", "30", "Number of search results to display")
+	searchCmd.Flags().StringP("channel", "c", "nixos-unstable", "Name of the channel to query")
+	searchCmd.Flags().BoolP("platforms", "P", false, "Show supported platforms for each package")
+	searchCmd.Flags().BoolP("json", "j", false, "Output results as JSON")
+
+	rootCmd.AddCommand(searchCmd)
+}

--- a/completers/common/nh_completer/main.go
+++ b/completers/common/nh_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/nh_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Initial shell completion for [nh](https://github.com/nix-community/nh), a Nix CLI helper.

Covers subcommands: os, home, darwin, search, clean.

os subcommands: switch, boot, test, build, repl, info, rollback, build-vm, build-image
home subcommands: switch, build, repl
darwin subcommands: switch, build, repl
clean subcommands: all, user, profile

Closes #3342

This contribution was developed with AI assistance (Claude Code).