### PR TITLE
git rebase: enable branch suggestions for both arguments

### DIFF
--- a/completers/common/git_completer/cmd/rebase.go
+++ b/completers/common/git_completer/cmd/rebase.go
@@ -70,16 +70,19 @@ func init() {
 		"whitespace": git.ActionWhitespaceModes(),
 	})
 
+	rebaseRefAction := carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if !rebaseCmd.Flag("continue").Changed &&
+			!rebaseCmd.Flag("abort").Changed &&
+			!rebaseCmd.Flag("skip").Changed &&
+			!rebaseCmd.Flag("edit-todo").Changed {
+			return git.ActionRefs(git.RefOption{}.Default())
+		} else {
+			return carapace.ActionValues()
+		}
+	})
+
 	carapace.Gen(rebaseCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if !rebaseCmd.Flag("continue").Changed &&
-				!rebaseCmd.Flag("abort").Changed &&
-				!rebaseCmd.Flag("skip").Changed &&
-				!rebaseCmd.Flag("edit-todo").Changed {
-				return git.ActionRefs(git.RefOption{}.Default())
-			} else {
-				return carapace.ActionValues()
-			}
-		}),
+		rebaseRefAction,
+		rebaseRefAction,
 	)
 }


### PR DESCRIPTION
Fixes #3358

The rebase completer was only suggesting branches for the first positional argument. Extracted the callback into a variable and reused it for both positions.