### PR TITLE
pixi: Enhance path completion for global install and add extensions discovery

### DIFF
--- a/completers/common/pixi_completer/cmd/global_add.go
+++ b/completers/common/pixi_completer/cmd/global_add.go
@@ -39,6 +39,7 @@ func init() {
 	carapace.Gen(global_addCmd).FlagCompletion(carapace.ActionMap{
 		"auth-file":             carapace.ActionFiles(),
 		"environment":           pixi.ActionGlobalEnvironments(),
+		"path":                  carapace.ActionFiles(),
 		"pinning-strategy":      carapace.ActionValues("semver", "minor", "major", "latest-up", "exact-version", "no-pin"),
 		"pypi-keyring-provider": carapace.ActionValues("disabled", "subprocess"),
 	})

--- a/completers/common/pixi_completer/cmd/global_install.go
+++ b/completers/common/pixi_completer/cmd/global_install.go
@@ -45,6 +45,7 @@ func init() {
 	carapace.Gen(global_installCmd).FlagCompletion(carapace.ActionMap{
 		"auth-file":             carapace.ActionFiles(),
 		"environment":           pixi.ActionGlobalEnvironments(),
+		"path":                  carapace.ActionFiles(),
 		"pinning-strategy":      carapace.ActionValues("semver", "minor", "major", "latest-up", "exact-version", "no-pin"),
 		"pypi-keyring-provider": carapace.ActionValues("disabled", "subprocess"),
 	})

--- a/completers/common/pixi_completer/cmd/root.go
+++ b/completers/common/pixi_completer/cmd/root.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -30,6 +34,33 @@ func init() {
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"color": carapace.ActionValues("always", "never", "auto"),
+	})
+
+	carapace.Gen(rootCmd).PreRun(func(cmd *cobra.Command, args []string) {
+		if output, err := (carapace.Context{}).Command("pixi", "--list").Output(); err == nil {
+			re := regexp.MustCompile(`^    (?P<command>[^ ]+) +\((?P<description>via pixi-[^)]+)\)$`)
+			for _, line := range strings.Split(string(output), "\n") {
+				line = strings.TrimSuffix(line, "\r")
+				if matches := re.FindStringSubmatch(line); matches != nil {
+					if _, _, err := rootCmd.Find([]string{matches[1]}); err == nil {
+						continue
+					}
+
+					pluginCmd := &cobra.Command{
+						Use:                matches[1],
+						Short:              matches[2],
+						Run:                func(cmd *cobra.Command, args []string) {},
+						DisableFlagParsing: true,
+					}
+
+					carapace.Gen(pluginCmd).PositionalAnyCompletion(
+						bridge.ActionCarapaceBin("pixi-" + matches[1]),
+					)
+
+					rootCmd.AddCommand(pluginCmd)
+				}
+			}
+		}
 	})
 
 	carapace.Gen(rootCmd).PreInvoke(func(cmd *cobra.Command, flag *pflag.Flag, action carapace.Action) carapace.Action {

--- a/completers/common/pixi_completer/cmd/root.go
+++ b/completers/common/pixi_completer/cmd/root.go
@@ -46,18 +46,18 @@ func init() {
 						continue
 					}
 
-					pluginCmd := &cobra.Command{
+					extensionCmd := &cobra.Command{
 						Use:                matches[1],
 						Short:              matches[2],
 						Run:                func(cmd *cobra.Command, args []string) {},
 						DisableFlagParsing: true,
 					}
 
-					carapace.Gen(pluginCmd).PositionalAnyCompletion(
+					carapace.Gen(extensionCmd).PositionalAnyCompletion(
 						bridge.ActionCarapaceBin("pixi-" + matches[1]),
 					)
 
-					rootCmd.AddCommand(pluginCmd)
+					rootCmd.AddCommand(extensionCmd)
 				}
 			}
 		}

--- a/completers/common/pixi_completer/cmd/root.go
+++ b/completers/common/pixi_completer/cmd/root.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -30,6 +34,32 @@ func init() {
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"color": carapace.ActionValues("always", "never", "auto"),
+	})
+
+	carapace.Gen(rootCmd).PreRun(func(cmd *cobra.Command, args []string) {
+		if output, err := (carapace.Context{}).Command("pixi", "--list").Output(); err == nil {
+			re := regexp.MustCompile(`^    (?P<command>[^ ]+) +\((?P<description>via pixi-[^)]+)\)$`)
+			for _, line := range strings.Split(string(output), "\n") {
+				if matches := re.FindStringSubmatch(line); matches != nil {
+					if _, _, err := rootCmd.Find([]string{matches[1]}); err == nil {
+						continue
+					}
+
+					pluginCmd := &cobra.Command{
+						Use:                matches[1],
+						Short:              matches[2],
+						Run:                func(cmd *cobra.Command, args []string) {},
+						DisableFlagParsing: true,
+					}
+
+					carapace.Gen(pluginCmd).PositionalAnyCompletion(
+						bridge.ActionCarapaceBin("pixi-" + matches[1]),
+					)
+
+					rootCmd.AddCommand(pluginCmd)
+				}
+			}
+		}
 	})
 
 	carapace.Gen(rootCmd).PreInvoke(func(cmd *cobra.Command, flag *pflag.Flag, action carapace.Action) carapace.Action {


### PR DESCRIPTION
Fixed the `--path` option for the `pixi global install` and `pixi global add` subcommands by adding file path completion.

Added extension discovery to the main `pixi` command. `pixi` can searches the system `PATH` for executables prefixed with `pixi-` and treats them as subcommands, like `git` or `cargo`. All available subcommands can be listed via `pixi --list`, where those provided by extensions are displayed in the format `(via pixi-*)`. These can therefore be identified using regex

Additionally, via `bridge.ActionCarapaceBin`. This allows any `pixi-*` extension that supports carapace, or any user-defined spec to provide proper command completion for its corresponding subcommands.

The above features were implemented using Codex. I have already tested them to ensure they work correctly.