### PR TITLE
Add mise completer

### DIFF
--- a/completers/common/mise_completer/cmd/activate.go
+++ b/completers/common/mise_completer/cmd/activate.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var activateCmd = &cobra.Command{
+	Use:   "activate [shell]",
+	Short: "Initialize mise in the current shell session",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(activateCmd).Standalone()
+	activateCmd.Flags().Bool("shims", false, "Use shims instead of shell functions")
+	rootCmd.AddCommand(activateCmd)
+
+	carapace.Gen(activateCmd).PositionalCompletion(
+		carapace.ActionValues("bash", "elvish", "fish", "nu", "xonsh", "zsh"),
+	)
+}

--- a/completers/common/mise_completer/cmd/install.go
+++ b/completers/common/mise_completer/cmd/install.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var installCmd = &cobra.Command{
+	Use:     "install [tool@version]...",
+	Aliases: []string{"i"},
+	Short:   "Install tools from config or arguments",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(installCmd).Standalone()
+	installCmd.Flags().BoolP("force", "f", false, "Force reinstall")
+	installCmd.Flags().Bool("jobs", false, "Number of jobs to run in parallel")
+	rootCmd.AddCommand(installCmd)
+}

--- a/completers/common/mise_completer/cmd/root.go
+++ b/completers/common/mise_completer/cmd/root.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/mise"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mise",
+	Short: "Polyglot runtime manager and task runner",
+	Long:  "https://mise.jdx.dev/",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().String("cd", "", "Change to this directory before running mise")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to mise config file")
+	rootCmd.PersistentFlags().StringP("env", "E", "", "Set environment")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print help")
+	rootCmd.PersistentFlags().String("log-level", "", "Set the log level")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-error output")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Show extra output")
+	rootCmd.PersistentFlags().BoolP("version", "V", false, "Print version")
+	rootCmd.Flags().Bool("yes", false, "Automatically answer yes to prompts")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"cd":        carapace.ActionDirectories(),
+		"config":    carapace.ActionFiles(".toml"),
+		"log-level": carapace.ActionValues("trace", "debug", "info", "warn", "error"),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		mise.ActionTasks().FilterArgs(),
+	)
+}

--- a/completers/common/mise_completer/cmd/run.go
+++ b/completers/common/mise_completer/cmd/run.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/mise"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:     "run [task]",
+	Aliases: []string{"r"},
+	Short:   "Run a mise task",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(runCmd).Standalone()
+	runCmd.Flags().BoolP("force", "f", false, "Force run even if dependencies are not needed")
+	runCmd.Flags().StringP("jobs", "j", "", "Number of tasks to run in parallel")
+	rootCmd.AddCommand(runCmd)
+
+	carapace.Gen(runCmd).PositionalCompletion(
+		mise.ActionTasks(),
+	)
+}

--- a/completers/common/mise_completer/cmd/simple.go
+++ b/completers/common/mise_completer/cmd/simple.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+func addSimpleCommand(use, short string, aliases ...string) {
+	cmd := &cobra.Command{Use: use, Short: short, Aliases: aliases, Run: func(cmd *cobra.Command, args []string) {}}
+	carapace.Gen(cmd).Standalone()
+	rootCmd.AddCommand(cmd)
+}
+
+func init() {
+	addSimpleCommand("alias", "Manage aliases")
+	addSimpleCommand("backends", "Manage tool backends")
+	addSimpleCommand("cache", "Manage mise cache")
+	addSimpleCommand("completion [shell]", "Generate shell completions")
+	addSimpleCommand("config", "Manage config files")
+	addSimpleCommand("current [tool]", "Show current tool versions")
+	addSimpleCommand("doctor", "Check mise installation for problems")
+	addSimpleCommand("exec [tool@version] -- [command]", "Execute a command with tools installed")
+	addSimpleCommand("generate", "Generate mise helper files")
+	addSimpleCommand("latest [tool]", "Show latest available version for a tool")
+	addSimpleCommand("list [tool]", "List installed versions", "ls")
+	addSimpleCommand("ls-remote [tool]", "List remote versions")
+	addSimpleCommand("outdated", "Show outdated tools")
+	addSimpleCommand("plugins", "Manage plugins")
+	addSimpleCommand("prune", "Remove unused versions")
+	addSimpleCommand("registry", "List available tools")
+	addSimpleCommand("reshim", "Rebuild shims")
+	addSimpleCommand("self-update", "Update mise itself")
+	addSimpleCommand("settings", "Manage settings")
+	addSimpleCommand("sync", "Sync tool versions")
+	addSimpleCommand("trust [config]", "Trust a mise config")
+	addSimpleCommand("uninstall [tool@version]...", "Uninstall tool versions", "remove", "rm")
+	addSimpleCommand("upgrade [tool]...", "Upgrade tools")
+	addSimpleCommand("where [tool]", "Show install path for a tool")
+	addSimpleCommand("which [bin]", "Show binary path")
+}

--- a/completers/common/mise_completer/cmd/tasks.go
+++ b/completers/common/mise_completer/cmd/tasks.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var tasksCmd = &cobra.Command{
+	Use:     "tasks",
+	Aliases: []string{"t"},
+	Short:   "List available tasks",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(tasksCmd).Standalone()
+	tasksCmd.Flags().Bool("json", false, "Output in JSON format")
+	tasksCmd.Flags().Bool("extended", false, "Show extended task information")
+	rootCmd.AddCommand(tasksCmd)
+}

--- a/completers/common/mise_completer/cmd/use.go
+++ b/completers/common/mise_completer/cmd/use.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var useCmd = &cobra.Command{
+	Use:   "use [tool@version]...",
+	Short: "Add tool versions to mise config",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(useCmd).Standalone()
+	useCmd.Flags().BoolP("global", "g", false, "Use the global config")
+	useCmd.Flags().BoolP("path", "p", false, "Use .mise.toml in the current directory")
+	useCmd.Flags().Bool("pin", false, "Save exact versions")
+	useCmd.Flags().Bool("fuzzy", false, "Save fuzzy versions")
+	rootCmd.AddCommand(useCmd)
+}

--- a/completers/common/mise_completer/main.go
+++ b/completers/common/mise_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/mise_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/mise/mise.go
+++ b/pkg/actions/tools/mise/mise.go
@@ -1,0 +1,2 @@
+// package mise contains mise related actions
+package mise

--- a/pkg/actions/tools/mise/tasks.go
+++ b/pkg/actions/tools/mise/tasks.go
@@ -1,0 +1,37 @@
+package mise
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/carapace-sh/carapace"
+)
+
+type task struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ActionTasks completes mise tasks.
+//
+//	build (Build the project)
+//	test (Run tests)
+func ActionTasks() carapace.Action {
+	return carapace.ActionExecCommand("mise", "tasks", "--json")(func(output []byte) carapace.Action {
+		var tasks []task
+		if err := json.Unmarshal(output, &tasks); err != nil {
+			return carapace.ActionMessage(err.Error())
+		}
+
+		sort.SliceStable(tasks, func(i, j int) bool { return tasks[i].Name < tasks[j].Name })
+
+		vals := make([]string, 0, len(tasks)*2)
+		for _, task := range tasks {
+			if task.Name == "" {
+				continue
+			}
+			vals = append(vals, task.Name, task.Description)
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}


### PR DESCRIPTION
Refs #2733

Adds a new `mise` completer.

Coverage included:
- Root persistent flags and common flag value completions
- Core commands like `activate`, `install`, `use`, `run`, `tasks`, `list`, `ls-remote`, `plugins`, `registry`, `trust`, `where`, `which`, etc.
- Shell completion values for `mise activate`
- Task name completion via `mise tasks --json` for root positional tasks and `mise run`

Validation:
- `gofmt -w completers/common/mise_completer pkg/actions/tools/mise`
- `go test ./completers/common/mise_completer ./pkg/actions/tools/mise`

Notes:
- `mise` is not installed locally on this machine, so dynamic task completion is validated at compile/package level rather than with live command output.