### PR TITLE
Add OpenRC completers

### DIFF
--- a/completers/common/openrc_completer/cmd/root.go
+++ b/completers/common/openrc_completer/cmd/root.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "openrc",
+	Short: "dependency based init system",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().BoolP("no-stop", "n", false, "do not stop any services")
+	rootCmd.Flags().BoolP("override", "o", false, "override the inactive runlevel warning")
+	rootCmd.Flags().BoolP("quiet", "q", false, "suppress non-error output")
+	rootCmd.Flags().StringP("runlevel", "r", "", "change to the specified runlevel")
+	rootCmd.Flags().BoolP("service", "s", false, "run a single service")
+	rootCmd.Flags().BoolP("sys", "S", false, "output the system type")
+	rootCmd.Flags().BoolP("verbose", "v", false, "show extra output")
+	rootCmd.Flags().BoolP("version", "V", false, "show version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"runlevel": actionRunlevels(),
+	})
+}
+
+func actionRunlevels() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"boot", "system boot runlevel",
+		"default", "default runlevel",
+		"nonetwork", "runlevel without networking",
+		"shutdown", "system shutdown runlevel",
+		"single", "single-user runlevel",
+		"sysinit", "system initialization runlevel",
+	)
+}

--- a/completers/common/openrc_completer/main.go
+++ b/completers/common/openrc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/openrc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-service_completer/cmd/root.go
+++ b/completers/common/rc-service_completer/cmd/root.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-service",
+	Short: "locate and run OpenRC services",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error { return rootCmd.Execute() }
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("debug", "d", false, "run the service script with shell tracing")
+	rootCmd.Flags().BoolP("exists", "e", false, "test whether the service exists")
+	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().BoolP("ifcrashed", "C", false, "run command only if service crashed")
+	rootCmd.Flags().BoolP("ifexists", "i", false, "run command only if service exists")
+	rootCmd.Flags().BoolP("ifinactive", "N", false, "run command only if service is inactive")
+	rootCmd.Flags().BoolP("ifnotstarted", "n", false, "run command only if service is not started")
+	rootCmd.Flags().BoolP("ifstarted", "s", false, "run command only if service is started")
+	rootCmd.Flags().BoolP("list", "l", false, "list all available services")
+	rootCmd.Flags().BoolP("resolve", "r", false, "resolve the service path")
+	rootCmd.Flags().BoolP("version", "V", false, "show version")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		actionServices(),
+		actionServiceCommands(),
+	)
+}
+
+func actionServices() carapace.Action {
+	return carapace.ActionExecCommand("rc-service", "--list")(func(output []byte) carapace.Action {
+		return carapace.ActionValues(strings.Fields(string(output))...)
+	})
+}
+
+func actionServiceCommands() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"start", "start the service",
+		"stop", "stop the service",
+		"restart", "restart the service",
+		"status", "show service status",
+		"zap", "reset crashed service state",
+	)
+}

--- a/completers/common/rc-service_completer/main.go
+++ b/completers/common/rc-service_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-service_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-status_completer/cmd/root.go
+++ b/completers/common/rc-status_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-status",
+	Short: "show OpenRC service status",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error { return rootCmd.Execute() }
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("all", "a", false, "show all runlevels")
+	rootCmd.Flags().BoolP("crashed", "c", false, "show crashed services")
+	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().BoolP("list", "l", false, "list runlevels")
+	rootCmd.Flags().StringP("runlevel", "r", "", "show services in runlevel")
+	rootCmd.Flags().BoolP("servicelist", "s", false, "show service list only")
+	rootCmd.Flags().BoolP("unused", "u", false, "show services not assigned to any runlevel")
+	rootCmd.Flags().BoolP("version", "V", false, "show version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{"runlevel": actionRunlevels()})
+	carapace.Gen(rootCmd).PositionalAnyCompletion(actionRunlevels())
+}
+
+func actionRunlevels() carapace.Action {
+	return carapace.ActionValues("boot", "default", "nonetwork", "shutdown", "single", "sysinit")
+}

--- a/completers/common/rc-status_completer/main.go
+++ b/completers/common/rc-status_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-status_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-update_completer/cmd/root.go
+++ b/completers/common/rc-update_completer/cmd/root.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-update",
+	Short: "add and remove OpenRC services from runlevels",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error { return rootCmd.Execute() }
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("all", "a", false, "process all runlevels")
+	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().BoolP("stack", "s", false, "stack runlevels instead of replacing")
+	rootCmd.Flags().BoolP("update", "u", false, "force dependency tree update")
+	rootCmd.Flags().BoolP("verbose", "v", false, "show extra output")
+	rootCmd.Flags().BoolP("version", "V", false, "show version")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValuesDescribed(
+			"add", "add a service to a runlevel",
+			"del", "remove a service from a runlevel",
+			"delete", "remove a service from a runlevel",
+			"show", "show services and runlevels",
+		),
+		actionServices(),
+		actionRunlevels(),
+	)
+}
+
+func actionServices() carapace.Action {
+	return carapace.ActionExecCommand("rc-service", "--list")(func(output []byte) carapace.Action {
+		return carapace.ActionValues(strings.Fields(string(output))...)
+	})
+}
+
+func actionRunlevels() carapace.Action {
+	return carapace.ActionValues("boot", "default", "nonetwork", "shutdown", "single", "sysinit")
+}

--- a/completers/common/rc-update_completer/main.go
+++ b/completers/common/rc-update_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-update_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Refs #3362

## Summary
- add standalone completers for `openrc`, `rc-status`, `rc-service`, and `rc-update`
- cover common OpenRC flags and runlevel completions
- complete services dynamically from `rc-service --list` for service-oriented commands

## Validation
- `go test ./completers/common/openrc_completer/... ./completers/common/rc-status_completer/... ./completers/common/rc-service_completer/... ./completers/common/rc-update_completer/...`
- `go generate ./cmd/...`
- `go test ./cmd/carapace ./completers/common/openrc_completer/... ./completers/common/rc-status_completer/... ./completers/common/rc-service_completer/... ./completers/common/rc-update_completer/...`
- `go run ./cmd/carapace --list --names | grep -E '^(openrc|rc-status|rc-service|rc-update)$'`
- `git diff --check`
