### PR TITLE
Add iwctl completer

### DIFF
--- a/completers/linux/iwctl_completer/cmd/actions/iwctl.go
+++ b/completers/linux/iwctl_completer/cmd/actions/iwctl.go
@@ -1,0 +1,52 @@
+package actions
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+func ActionStations() carapace.Action {
+	return actionFromList("station", "list")
+}
+
+func ActionDevices() carapace.Action {
+	return actionFromList("device", "list")
+}
+
+func ActionAdapters() carapace.Action {
+	return actionFromList("adapter", "list")
+}
+
+func ActionKnownNetworks() carapace.Action {
+	return actionFromList("known-networks", "list")
+}
+
+func ActionNetworks(station string) carapace.Action {
+	if station == "" {
+		return carapace.ActionValues()
+	}
+	return carapace.ActionExecCommand("iwctl", "station", station, "get-networks")(func(output []byte) carapace.Action {
+		return valuesFromTable(output)
+	})
+}
+
+func actionFromList(args ...string) carapace.Action {
+	return carapace.ActionExecCommand("iwctl", args...)(func(output []byte) carapace.Action {
+		return valuesFromTable(output)
+	})
+}
+
+func valuesFromTable(output []byte) carapace.Action {
+	lines := strings.Split(string(output), "\n")
+	values := make([]string, 0, len(lines)*2)
+	for _, line := range lines {
+		line = strings.TrimSpace(strings.Trim(line, "-* "))
+		fields := strings.Fields(line)
+		if len(fields) == 0 || strings.HasPrefix(fields[0], "Name") || strings.HasPrefix(fields[0], "---") {
+			continue
+		}
+		values = append(values, fields[0], strings.Join(fields[1:], " "))
+	}
+	return carapace.ActionValuesDescribed(values...)
+}

--- a/completers/linux/iwctl_completer/cmd/root.go
+++ b/completers/linux/iwctl_completer/cmd/root.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/linux/iwctl_completer/cmd/actions"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "iwctl",
+	Short: "Interactive wireless daemon client",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error { return rootCmd.Execute() }
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().BoolP("version", "v", false, "show version")
+	rootCmd.Flags().BoolP("dont-ask", "P", false, "do not ask for missing passwords")
+	rootCmd.Flags().BoolP("passphrase", "p", false, "passphrase for network operations")
+
+	rootCmd.AddCommand(
+		adapterCmd(),
+		deviceCmd(),
+		stationCmd(),
+		knownNetworksCmd(),
+		apCmd(),
+	)
+}
+
+func adapterCmd() *cobra.Command {
+	cmd := command("adapter", "Manage wireless adapters")
+	cmd.AddCommand(
+		commandWithCompletion("list", "List adapters", nil),
+		commandWithCompletion("show", "Show adapter details", actions.ActionAdapters),
+	)
+	return cmd
+}
+
+func deviceCmd() *cobra.Command {
+	cmd := command("device", "Manage wireless devices")
+	cmd.AddCommand(
+		commandWithCompletion("list", "List devices", nil),
+		commandWithCompletion("show", "Show device details", actions.ActionDevices),
+		commandWithCompletion("set-property", "Set device property", actions.ActionDevices),
+	)
+	return cmd
+}
+
+func stationCmd() *cobra.Command {
+	cmd := command("station", "Manage Wi-Fi stations")
+	cmd.AddCommand(
+		commandWithCompletion("list", "List stations", nil),
+		commandWithCompletion("show", "Show station details", actions.ActionStations),
+		commandWithCompletion("scan", "Scan for networks", actions.ActionStations),
+		commandWithCompletion("get-networks", "List visible networks", actions.ActionStations),
+		commandWithCompletion("disconnect", "Disconnect station", actions.ActionStations),
+		connectCmd(),
+	)
+	return cmd
+}
+
+func connectCmd() *cobra.Command {
+	cmd := command("connect", "Connect station to a network")
+	carapace.Gen(cmd).PositionalCompletion(
+		actions.ActionStations(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if len(c.Args) == 0 {
+				return carapace.ActionValues()
+			}
+			return actions.ActionNetworks(c.Args[0])
+		}),
+	)
+	return cmd
+}
+
+func knownNetworksCmd() *cobra.Command {
+	cmd := command("known-networks", "Manage known networks")
+	cmd.AddCommand(
+		commandWithCompletion("list", "List known networks", nil),
+		commandWithCompletion("forget", "Forget a known network", actions.ActionKnownNetworks),
+	)
+	return cmd
+}
+
+func apCmd() *cobra.Command {
+	cmd := command("ap", "Manage access point mode")
+	cmd.AddCommand(
+		commandWithCompletion("start", "Start access point mode", actions.ActionDevices),
+		commandWithCompletion("stop", "Stop access point mode", actions.ActionDevices),
+	)
+	return cmd
+}
+
+func command(use, short string) *cobra.Command {
+	cmd := &cobra.Command{Use: use, Short: short, Run: func(cmd *cobra.Command, args []string) {}}
+	carapace.Gen(cmd).Standalone()
+	return cmd
+}
+
+func commandWithCompletion(use, short string, completion func() carapace.Action) *cobra.Command {
+	cmd := command(use, short)
+	if completion != nil {
+		carapace.Gen(cmd).PositionalAnyCompletion(completion().FilterArgs())
+	}
+	return cmd
+}

--- a/completers/linux/iwctl_completer/main.go
+++ b/completers/linux/iwctl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/linux/iwctl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
- add a Linux `iwctl` completer for iwd's wireless client
- cover adapter, device, station, known-network, and access-point command groups
- complete adapters/devices/stations/known networks from `iwctl` list commands and visible networks for `station connect`

Refs #3355

## Validation
- `go test ./completers/linux/iwctl_completer/...`
- `go generate ./cmd/...`
- `go test ./cmd/carapace ./completers/linux/iwctl_completer/...`
- `git diff --check`