### PR TITLE
Add kcl completer

### DIFF
--- a/completers/common/kcl_completer/cmd/root.go
+++ b/completers/common/kcl_completer/cmd/root.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "kcl",
+	Short: "KCL command line interface",
+	Long:  "https://www.kcl-lang.io/docs/tools/cli/kcl/overview",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error { return rootCmd.Execute() }
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "help for kcl")
+	rootCmd.Flags().BoolP("version", "v", false, "version for kcl")
+
+	commands := map[string]string{
+		"clean":      "KCL clean tool",
+		"completion": "Generate the autocompletion script for the specified shell",
+		"doc":        "KCL document tool",
+		"fmt":        "KCL format tool",
+		"help":       "Help about any command",
+		"import":     "KCL import tool",
+		"lint":       "Lint KCL codes",
+		"mod":        "KCL module management",
+		"play":       "Open the KCL playground in the browser",
+		"registry":   "KCL registry management",
+		"run":        "Run KCL codes",
+		"server":     "Run a KCL server",
+		"test":       "KCL test tool",
+		"version":    "Show version of the KCL CLI",
+		"vet":        "KCL validation tool",
+	}
+	for name, desc := range commands {
+		cmd := &cobra.Command{Use: name, Short: desc, DisableFlagParsing: true, Run: func(cmd *cobra.Command, args []string) {}}
+		carapace.Gen(cmd).PositionalAnyCompletion(bridge.ActionCarapaceBin("kcl", name))
+		rootCmd.AddCommand(cmd)
+	}
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValuesDescribed(
+			"clean", commands["clean"],
+			"completion", commands["completion"],
+			"doc", commands["doc"],
+			"fmt", commands["fmt"],
+			"help", commands["help"],
+			"import", commands["import"],
+			"lint", commands["lint"],
+			"mod", commands["mod"],
+			"play", commands["play"],
+			"registry", commands["registry"],
+			"run", commands["run"],
+			"server", commands["server"],
+			"test", commands["test"],
+			"version", commands["version"],
+			"vet", commands["vet"],
+		).StyleF(style.ForKeyword),
+	)
+}

--- a/completers/common/kcl_completer/main.go
+++ b/completers/common/kcl_completer/main.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/kcl_completer/cmd"
+
+func main() { cmd.Execute() }


### PR DESCRIPTION
Refs #3242

Adds a new `kcl` completer for the KCL CLI.

Coverage includes:
- top-level command completions from the documented `kcl help` output
- descriptions for `clean`, `completion`, `doc`, `fmt`, `import`, `lint`, `mod`, `play`, `registry`, `run`, `server`, `test`, `version`, and `vet`
- Cobra bridge delegation for subcommand flags/positionals
- root `--help` and `--version` flags

Validation:
- `gofmt`
- `go generate ./cmd/...`
- `go test ./cmd/carapace ./completers/common/kcl_completer/...`
- `git diff --check`
- `go run ./cmd/carapace --list --names | grep '^kcl$'`