### PR TITLE
Make paru new flags available globally

### DIFF
--- a/completers/linux/paru_completer/cmd/root.go
+++ b/completers/linux/paru_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/linux/paru_completer/cmd/common"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/paru"
 	"github.com/carapace-sh/carapace-bin/pkg/util/embed"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ func init() {
 	rootCmd.Flags().Bool("gendb", false, "Generates development package DB used for updating")
 	rootCmd.Flags().BoolP("help", "h", false, "show help")
 	rootCmd.Flags().BoolP("version", "V", false, "show version")
+	common.AddNewFlags(rootCmd)
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {


### PR DESCRIPTION
Refs #2963

Makes paru's shared/new flags available on the root command as well as subcommands.

This lets completions resolve flags like `--sudoflags` before an operation flag/subcommand is present, matching paru usage such as:

```sh
paru --sudoflags "-S" -Q
```

The existing subcommand-specific flag behavior is preserved by reusing the shared `common.AddNewFlags` helper on the root command.

Validation:
- `gofmt`
- `go test ./completers/linux/paru_completer/...`
- `go generate ./cmd/...`
- `go test ./cmd/carapace ./completers/linux/paru_completer/...`
- `git diff --check`