### PR TITLE
ansible: prefer zsh bridge

### DIFF
--- a/cmd/carapace/cmd/completers/bridges.go
+++ b/cmd/carapace/cmd/completers/bridges.go
@@ -19,52 +19,52 @@ func knownbridges() map[string]*completer.Completer {
 		"ansible": {
 			Description: "Define and run a single task ‘playbook’ against a set of hosts",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-config": {
 			Description: "View ansible configuration",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-config.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-console": {
 			Description: "REPL console for executing Ansible tasks",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-console.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-creator": {
 			Description: "The fastest way to generate all your ansible content",
 			Url:         "https://docs.ansible.com/projects/creator/",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-doc": {
 			Description: "Ansible plugin documentation tool",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-doc.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-galaxy": {
 			Description: "Perform various Role and Collection related operations",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-galaxy.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-inventory": {
 			Description: "Show Ansible inventory information",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-inventory.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-playbook": {
 			Description: "Runs Ansible playbooks, executing the defined tasks on the targeted hosts",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-playbook.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-pull": {
 			Description: "Pulls playbooks from a VCS repo and executes them on target host",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-pull.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"ansible-vault": {
 			Description: "encryption/decryption utility for Ansible data files",
 			Url:         "https://docs.ansible.com/projects/ansible/latest/cli/ansible-vault.html",
-			Variant:     "argcomplete",
+			Variant:     "zsh",
 		},
 		"apko": {
 			Description: "Build OCI images from APK packages directly without Dockerfile",


### PR DESCRIPTION
## Summary
- switch the built-in Ansible bridge metadata from argcomplete to zsh for the Ansible command family
- keeps Ansible completions on the bridge that is known to work when zsh completions are enabled

Refs #3363

## Validation
- `go test ./cmd/carapace ./cmd/carapace/cmd/completers`
- `go run ./cmd/carapace --list ansible`
- `git diff --check`