### PR TITLE
nix: complete installables from flakes

### DIFF
--- a/pkg/actions/tools/nix/flake.go
+++ b/pkg/actions/tools/nix/flake.go
@@ -124,7 +124,10 @@ func ActionFlakeRefs() carapace.Action {
 	return carapace.ActionMultiPartsN("#", 2, func(c carapace.Context) carapace.Action {
 		switch len(c.Parts) {
 		case 0:
-			return ActionFlakes().Suffix("#")
+			return carapace.Batch(
+				carapace.ActionValues(".").Style(style.Blue),
+				ActionFlakes(),
+			).ToA().Suffix("#")
 		default:
 			return ActionFlakeAttributes(c.Parts[0])
 		}

--- a/pkg/actions/tools/nix/installables.go
+++ b/pkg/actions/tools/nix/installables.go
@@ -1,46 +1,11 @@
 package nix
 
-import (
-	"strings"
+import "github.com/carapace-sh/carapace"
 
-	"github.com/carapace-sh/carapace"
-)
-
-// ActionInstallables completes nix packages and flakes
+// ActionInstallables completes nix flake installables.
 //
-// An installable nix derivation can either be a nix package (legacyPackages)
-// or a nixosModules output of a flake. There is no completion support implemented
-// for flake outputs due to the processing time required, so ActionInstallables
-// completes packages from the global/system/user channels available and flake names from the
-// global/system/user registry
+// Installable completion intentionally relies on the flake registry rather than
+// legacy nix channels so it works on flake-based systems with channels disabled.
 func ActionInstallables() carapace.Action {
-	return carapace.ActionMultiParts("#", func(c carapace.Context) carapace.Action {
-		switch len(c.Parts) {
-		case 0:
-			return carapace.Batch(
-				ActionFlakes(),
-				carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
-					switch len(c.Parts) {
-					case 0:
-						return ActionLocalChannels().Suffix("#")
-					case 1:
-						return carapace.ActionMessage("TODO: support branch completion") // TODO support branch completion
-					default:
-						return carapace.ActionValues()
-					}
-				}),
-			).ToA()
-
-		case 1:
-			switch c.Parts[0] {
-			case ".":
-				return ActionFlakeAttributes(".")
-			default:
-				return ActionPackages(strings.SplitN(c.Parts[0], "/", 2)[0])
-			}
-
-		default:
-			return carapace.ActionValues()
-		}
-	})
+	return ActionFlakeRefs()
 }


### PR DESCRIPTION
## Summary
- make Nix installable completion use flake references instead of legacy channel package lookup
- include the local flake (`.#`) alongside registry flakes for installable completion
- avoids invoking `nix-channel --list` for `nix run`/installable completions on flake-based systems with channels disabled

Refs #3343

## Validation
- `go test ./pkg/actions/tools/nix ./completers/common/nix_completer/...`
- `go test ./cmd/carapace ./completers/common/nix_completer/...`
- `git diff --check`