### PR TITLE
git: complete checkout changed files

### DIFF
--- a/completers/common/git_completer/cmd/checkout.go
+++ b/completers/common/git_completer/cmd/checkout.go
@@ -65,7 +65,10 @@ func init() {
 			if strings.HasPrefix(c.Value, ".") {
 				return git.ActionRefDiffs()
 			}
-			return git.ActionRefs(git.RefOption{}.Default())
+			return carapace.Batch(
+				git.ActionRefs(git.RefOption{}.Default()),
+				git.ActionRefDiffs(),
+			).ToA()
 		}),
 	)
 


### PR DESCRIPTION
## Summary
- include changed working-tree files in first-argument `git checkout` completion
- keeps existing branch/ref completion while also offering modified paths, matching `git checkout <path>` behavior

Refs #3310

## Validation
- `go test ./completers/common/git_completer/... ./cmd/carapace`
- `git diff --check`