### PR TITLE
added 7z completer (p7zip)

### DIFF
--- a/completers/common/7z_completer/cmd/a.go
+++ b/completers/common/7z_completer/cmd/a.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var aCmd = &cobra.Command{
+	Use:   "a",
+	Short: "Add files to archive",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(aCmd).Standalone()
+
+	addCommonFlags(aCmd)
+	addCommonFlagCompletions(aCmd)
+	rootCmd.AddCommand(aCmd)
+
+	carapace.Gen(aCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+
+	carapace.Gen(aCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/a.go
+++ b/completers/common/7z_completer/cmd/a.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(aCmd)
 	rootCmd.AddCommand(aCmd)
 
-	carapace.Gen(aCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(aCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/a.go
+++ b/completers/common/7z_completer/cmd/a.go
@@ -14,8 +14,6 @@ var aCmd = &cobra.Command{
 func init() {
 	carapace.Gen(aCmd).Standalone()
 
-	addCommonFlags(aCmd)
-	addCommonFlagCompletions(aCmd)
 	rootCmd.AddCommand(aCmd)
 
 	carapace.Gen(aCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/a.go
+++ b/completers/common/7z_completer/cmd/a.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(aCmd)
 
 	carapace.Gen(aCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/b.go
+++ b/completers/common/7z_completer/cmd/b.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bCmd = &cobra.Command{
+	Use:   "b",
+	Short: "Benchmark",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bCmd).Standalone()
+
+	addCommonFlags(bCmd)
+	addCommonFlagCompletions(bCmd)
+	rootCmd.AddCommand(bCmd)
+}

--- a/completers/common/7z_completer/cmd/b.go
+++ b/completers/common/7z_completer/cmd/b.go
@@ -14,7 +14,5 @@ var bCmd = &cobra.Command{
 func init() {
 	carapace.Gen(bCmd).Standalone()
 
-	addCommonFlags(bCmd)
-	addCommonFlagCompletions(bCmd)
 	rootCmd.AddCommand(bCmd)
 }

--- a/completers/common/7z_completer/cmd/d.go
+++ b/completers/common/7z_completer/cmd/d.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var dCmd = &cobra.Command{
+	Use:   "d",
+	Short: "Delete files from archive",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(dCmd).Standalone()
+
+	addCommonFlags(dCmd)
+	addCommonFlagCompletions(dCmd)
+	rootCmd.AddCommand(dCmd)
+
+	carapace.Gen(dCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+
+	carapace.Gen(dCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/d.go
+++ b/completers/common/7z_completer/cmd/d.go
@@ -14,8 +14,6 @@ var dCmd = &cobra.Command{
 func init() {
 	carapace.Gen(dCmd).Standalone()
 
-	addCommonFlags(dCmd)
-	addCommonFlagCompletions(dCmd)
 	rootCmd.AddCommand(dCmd)
 
 	carapace.Gen(dCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/d.go
+++ b/completers/common/7z_completer/cmd/d.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(dCmd)
 	rootCmd.AddCommand(dCmd)
 
-	carapace.Gen(dCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(dCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/d.go
+++ b/completers/common/7z_completer/cmd/d.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(dCmd)
 
 	carapace.Gen(dCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/e.go
+++ b/completers/common/7z_completer/cmd/e.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var eCmd = &cobra.Command{
+	Use:   "e",
+	Short: "Extract files from archive (without using directory names)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(eCmd).Standalone()
+
+	addCommonFlags(eCmd)
+	addCommonFlagCompletions(eCmd)
+	rootCmd.AddCommand(eCmd)
+
+	carapace.Gen(eCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+
+	carapace.Gen(eCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/e.go
+++ b/completers/common/7z_completer/cmd/e.go
@@ -14,8 +14,6 @@ var eCmd = &cobra.Command{
 func init() {
 	carapace.Gen(eCmd).Standalone()
 
-	addCommonFlags(eCmd)
-	addCommonFlagCompletions(eCmd)
 	rootCmd.AddCommand(eCmd)
 
 	carapace.Gen(eCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/e.go
+++ b/completers/common/7z_completer/cmd/e.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(eCmd)
 	rootCmd.AddCommand(eCmd)
 
-	carapace.Gen(eCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(eCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/e.go
+++ b/completers/common/7z_completer/cmd/e.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(eCmd)
 
 	carapace.Gen(eCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/h.go
+++ b/completers/common/7z_completer/cmd/h.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var hCmd = &cobra.Command{
+	Use:   "h",
+	Short: "Calculate hash values for files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(hCmd).Standalone()
+
+	addCommonFlags(hCmd)
+	addCommonFlagCompletions(hCmd)
+	rootCmd.AddCommand(hCmd)
+
+	carapace.Gen(hCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/h.go
+++ b/completers/common/7z_completer/cmd/h.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(hCmd)
 
 	carapace.Gen(hCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/h.go
+++ b/completers/common/7z_completer/cmd/h.go
@@ -14,8 +14,6 @@ var hCmd = &cobra.Command{
 func init() {
 	carapace.Gen(hCmd).Standalone()
 
-	addCommonFlags(hCmd)
-	addCommonFlagCompletions(hCmd)
 	rootCmd.AddCommand(hCmd)
 
 	carapace.Gen(hCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/i.go
+++ b/completers/common/7z_completer/cmd/i.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var iCmd = &cobra.Command{
+	Use:   "i",
+	Short: "Show information about supported formats",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(iCmd).Standalone()
+
+	rootCmd.AddCommand(iCmd)
+}

--- a/completers/common/7z_completer/cmd/l.go
+++ b/completers/common/7z_completer/cmd/l.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var lCmd = &cobra.Command{
+	Use:   "l",
+	Short: "List contents of archive",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(lCmd).Standalone()
+
+	addCommonFlags(lCmd)
+	addCommonFlagCompletions(lCmd)
+	rootCmd.AddCommand(lCmd)
+
+	carapace.Gen(lCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/l.go
+++ b/completers/common/7z_completer/cmd/l.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(lCmd)
 	rootCmd.AddCommand(lCmd)
 
-	carapace.Gen(lCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(lCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/l.go
+++ b/completers/common/7z_completer/cmd/l.go
@@ -21,4 +21,8 @@ func init() {
 	carapace.Gen(lCmd).PositionalCompletion(
 		carapace.ActionFiles(),
 	)
+
+	carapace.Gen(lCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
 }

--- a/completers/common/7z_completer/cmd/l.go
+++ b/completers/common/7z_completer/cmd/l.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(lCmd)
 
 	carapace.Gen(lCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/l.go
+++ b/completers/common/7z_completer/cmd/l.go
@@ -14,8 +14,6 @@ var lCmd = &cobra.Command{
 func init() {
 	carapace.Gen(lCmd).Standalone()
 
-	addCommonFlags(lCmd)
-	addCommonFlagCompletions(lCmd)
 	rootCmd.AddCommand(lCmd)
 
 	carapace.Gen(lCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/rn.go
+++ b/completers/common/7z_completer/cmd/rn.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rnCmd = &cobra.Command{
+	Use:   "rn",
+	Short: "Rename files in archive",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(rnCmd).Standalone()
+
+	addCommonFlags(rnCmd)
+	addCommonFlagCompletions(rnCmd)
+	rootCmd.AddCommand(rnCmd)
+
+	carapace.Gen(rnCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/rn.go
+++ b/completers/common/7z_completer/cmd/rn.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(rnCmd)
 	rootCmd.AddCommand(rnCmd)
 
-	carapace.Gen(rnCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(rnCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/rn.go
+++ b/completers/common/7z_completer/cmd/rn.go
@@ -21,4 +21,8 @@ func init() {
 	carapace.Gen(rnCmd).PositionalCompletion(
 		carapace.ActionFiles(),
 	)
+
+	carapace.Gen(rnCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
 }

--- a/completers/common/7z_completer/cmd/rn.go
+++ b/completers/common/7z_completer/cmd/rn.go
@@ -14,8 +14,6 @@ var rnCmd = &cobra.Command{
 func init() {
 	carapace.Gen(rnCmd).Standalone()
 
-	addCommonFlags(rnCmd)
-	addCommonFlagCompletions(rnCmd)
 	rootCmd.AddCommand(rnCmd)
 
 	carapace.Gen(rnCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/rn.go
+++ b/completers/common/7z_completer/cmd/rn.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(rnCmd)
 
 	carapace.Gen(rnCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/root.go
+++ b/completers/common/7z_completer/cmd/root.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "7z",
+	Short: "A file archiver with high compression ratio",
+	Long:  "https://linux.die.net/man/1/7z",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	addCommonFlags(rootCmd)
+	addCommonFlagCompletions(rootCmd)
+}
+
+// addCommonFlags registers switches shared across all 7z subcommands.
+func addCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolS("an", "an", false, "disable archive_name field")
+	cmd.Flags().StringS("ao", "ao", "", "set overwrite mode")
+	cmd.Flags().StringS("bb", "bb", "", "set output log level")
+	cmd.Flags().BoolS("bd", "bd", false, "disable progress indicator")
+	cmd.Flags().StringS("bs", "bs", "", "set output stream for output/error/progress")
+	cmd.Flags().BoolS("bt", "bt", false, "show execution time statistics")
+	cmd.Flags().StringS("m", "m", "", "set compression method")
+	cmd.Flags().StringS("o", "o", "", "set output directory")
+	cmd.Flags().StringS("p", "p", "", "set password")
+	cmd.Flags().BoolS("r", "r", false, "recurse subdirectories")
+	cmd.Flags().StringS("sa", "sa", "", "set archive name mode")
+	cmd.Flags().StringS("scc", "scc", "", "set charset for console input/output")
+	cmd.Flags().StringS("scrc", "scrc", "", "set hash function")
+	cmd.Flags().StringS("scs", "scs", "", "set charset for list files")
+	cmd.Flags().BoolS("sdel", "sdel", false, "delete files after compression")
+	cmd.Flags().BoolS("seml", "seml", false, "send archive by email")
+	cmd.Flags().StringS("sfx", "sfx", "", "create SFX archive")
+	cmd.Flags().StringS("si", "si", "", "read data from stdin")
+	cmd.Flags().BoolS("slp", "slp", false, "set large pages mode")
+	cmd.Flags().BoolS("slt", "slt", false, "show technical information for l command")
+	cmd.Flags().BoolS("snh", "snh", false, "store hard links as links")
+	cmd.Flags().BoolS("sni", "sni", false, "store NT security information")
+	cmd.Flags().BoolS("snl", "snl", false, "store symbolic links as links")
+	cmd.Flags().BoolS("sns", "sns", false, "store NTFS alternate streams")
+	cmd.Flags().BoolS("so", "so", false, "write data to stdout")
+	cmd.Flags().BoolS("spd", "spd", false, "disable wildcard matching for file names")
+	cmd.Flags().BoolS("spe", "spe", false, "eliminate duplication of root folder for extract command")
+	cmd.Flags().BoolS("spf", "spf", false, "use fully qualified file paths")
+	cmd.Flags().BoolS("ssc", "ssc", false, "set sensitive case mode")
+	cmd.Flags().BoolS("ssw", "ssw", false, "compress shared files")
+	cmd.Flags().BoolS("stl", "stl", false, "set archive timestamp from the most recently modified file")
+	cmd.Flags().StringS("stm", "stm", "", "set CPU thread affinity mask")
+	cmd.Flags().StringS("stx", "stx", "", "exclude archive type")
+	cmd.Flags().StringS("t", "t", "", "set type of archive")
+	cmd.Flags().StringS("v", "v", "", "create volumes")
+	cmd.Flags().StringS("w", "w", "", "set working directory")
+	cmd.Flags().BoolS("y", "y", false, "assume Yes on all queries")
+
+	cmd.Flag("ao").NoOptDefVal = " "
+	cmd.Flag("bb").NoOptDefVal = " "
+	cmd.Flag("bs").NoOptDefVal = " "
+	cmd.Flag("m").NoOptDefVal = " "
+	cmd.Flag("o").NoOptDefVal = " "
+	cmd.Flag("p").NoOptDefVal = " "
+	cmd.Flag("sa").NoOptDefVal = " "
+	cmd.Flag("scc").NoOptDefVal = " "
+	cmd.Flag("scrc").NoOptDefVal = " "
+	cmd.Flag("scs").NoOptDefVal = " "
+	cmd.Flag("sfx").NoOptDefVal = " "
+	cmd.Flag("si").NoOptDefVal = " "
+	cmd.Flag("stm").NoOptDefVal = " "
+	cmd.Flag("stx").NoOptDefVal = " "
+	cmd.Flag("t").NoOptDefVal = " "
+	cmd.Flag("v").NoOptDefVal = " "
+	cmd.Flag("w").NoOptDefVal = " "
+}
+
+// addCommonFlagCompletions registers flag completions for common switches.
+func addCommonFlagCompletions(cmd *cobra.Command) {
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"ao":   carapace.ActionValues("a", "s", "t", "u"),
+		"bb":   carapace.ActionValues("0", "1", "2", "3"),
+		"o":    carapace.ActionDirectories(),
+		"sa":   carapace.ActionValues("a", "e", "s"),
+		"scc":  carapace.ActionValues("UTF-8", "WIN", "DOS"),
+		"scrc": carapace.ActionValues("CRC32", "CRC64", "SHA1", "SHA256", "*"),
+		"scs":  carapace.ActionValues("UTF-8", "UTF-16LE", "UTF-16BE", "WIN", "DOS"),
+		"sfx":  carapace.ActionFiles(),
+		"t": carapace.ActionValues(
+			"7z", "bzip2", "cab", "gzip",
+			"iso", "lzma", "lzma86",
+			"tar", "wim", "xz", "zip",
+		),
+		"w": carapace.ActionDirectories(),
+	})
+}

--- a/completers/common/7z_completer/cmd/root.go
+++ b/completers/common/7z_completer/cmd/root.go
@@ -71,33 +71,61 @@ func addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolS("y", "y", false, "assume Yes on all queries")
 
 	cmd.Flag("ai").NoOptDefVal = " "
+	cmd.Flag("ai").OptargDelimiter = -1
 	cmd.Flag("ao").NoOptDefVal = " "
+	cmd.Flag("ao").OptargDelimiter = -1
 	cmd.Flag("ax").NoOptDefVal = " "
+	cmd.Flag("ax").OptargDelimiter = -1
 	cmd.Flag("bb").NoOptDefVal = " "
+	cmd.Flag("bb").OptargDelimiter = -1
 	cmd.Flag("bs").NoOptDefVal = " "
+	cmd.Flag("bs").OptargDelimiter = -1
 	cmd.Flag("i").NoOptDefVal = " "
+	cmd.Flag("i").OptargDelimiter = -1
 	cmd.Flag("m").NoOptDefVal = " "
+	cmd.Flag("m").OptargDelimiter = -1
 	cmd.Flag("o").NoOptDefVal = " "
+	cmd.Flag("o").OptargDelimiter = -1
 	cmd.Flag("p").NoOptDefVal = " "
+	cmd.Flag("p").OptargDelimiter = -1
 	cmd.Flag("r").NoOptDefVal = " "
+	cmd.Flag("r").OptargDelimiter = -1
 	cmd.Flag("sa").NoOptDefVal = " "
+	cmd.Flag("sa").OptargDelimiter = -1
 	cmd.Flag("scc").NoOptDefVal = " "
+	cmd.Flag("scc").OptargDelimiter = -1
 	cmd.Flag("scrc").NoOptDefVal = " "
+	cmd.Flag("scrc").OptargDelimiter = -1
 	cmd.Flag("scs").NoOptDefVal = " "
+	cmd.Flag("scs").OptargDelimiter = -1
 	cmd.Flag("seml").NoOptDefVal = " "
+	cmd.Flag("seml").OptargDelimiter = -1
 	cmd.Flag("sfx").NoOptDefVal = " "
+	cmd.Flag("sfx").OptargDelimiter = -1
 	cmd.Flag("si").NoOptDefVal = " "
+	cmd.Flag("si").OptargDelimiter = -1
 	cmd.Flag("slp").NoOptDefVal = " "
+	cmd.Flag("slp").OptargDelimiter = -1
 	cmd.Flag("sns").NoOptDefVal = " "
+	cmd.Flag("sns").OptargDelimiter = -1
 	cmd.Flag("spf").NoOptDefVal = " "
+	cmd.Flag("spf").OptargDelimiter = -1
 	cmd.Flag("ssc").NoOptDefVal = " "
+	cmd.Flag("ssc").OptargDelimiter = -1
 	cmd.Flag("stm").NoOptDefVal = " "
+	cmd.Flag("stm").OptargDelimiter = -1
 	cmd.Flag("stx").NoOptDefVal = " "
+	cmd.Flag("stx").OptargDelimiter = -1
 	cmd.Flag("t").NoOptDefVal = " "
+	cmd.Flag("t").OptargDelimiter = -1
 	cmd.Flag("u").NoOptDefVal = " "
+	cmd.Flag("u").OptargDelimiter = -1
 	cmd.Flag("v").NoOptDefVal = " "
+	cmd.Flag("v").OptargDelimiter = -1
 	cmd.Flag("w").NoOptDefVal = " "
+	cmd.Flag("w").OptargDelimiter = -1
 	cmd.Flag("x").NoOptDefVal = " "
+	cmd.Flag("x").OptargDelimiter = -1
 }
 
 // addCommonFlagCompletions registers flag completions for common switches.

--- a/completers/common/7z_completer/cmd/root.go
+++ b/completers/common/7z_completer/cmd/root.go
@@ -25,61 +25,79 @@ func init() {
 
 // addCommonFlags registers switches shared across all 7z subcommands.
 func addCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().StringS("ai", "ai", "", "include archive filenames")
 	cmd.Flags().BoolS("an", "an", false, "disable archive_name field")
 	cmd.Flags().StringS("ao", "ao", "", "set overwrite mode")
+	cmd.Flags().StringS("ax", "ax", "", "exclude archive filenames")
 	cmd.Flags().StringS("bb", "bb", "", "set output log level")
 	cmd.Flags().BoolS("bd", "bd", false, "disable progress indicator")
 	cmd.Flags().StringS("bs", "bs", "", "set output stream for output/error/progress")
 	cmd.Flags().BoolS("bt", "bt", false, "show execution time statistics")
+	cmd.Flags().StringS("i", "i", "", "include filenames")
 	cmd.Flags().StringS("m", "m", "", "set compression method")
 	cmd.Flags().StringS("o", "o", "", "set output directory")
 	cmd.Flags().StringS("p", "p", "", "set password")
-	cmd.Flags().BoolS("r", "r", false, "recurse subdirectories")
+	cmd.Flags().StringS("r", "r", "", "recurse subdirectories")
 	cmd.Flags().StringS("sa", "sa", "", "set archive name mode")
 	cmd.Flags().StringS("scc", "scc", "", "set charset for console input/output")
 	cmd.Flags().StringS("scrc", "scrc", "", "set hash function")
 	cmd.Flags().StringS("scs", "scs", "", "set charset for list files")
 	cmd.Flags().BoolS("sdel", "sdel", false, "delete files after compression")
-	cmd.Flags().BoolS("seml", "seml", false, "send archive by email")
+	cmd.Flags().StringS("seml", "seml", "", "send archive by email")
 	cmd.Flags().StringS("sfx", "sfx", "", "create SFX archive")
 	cmd.Flags().StringS("si", "si", "", "read data from stdin")
-	cmd.Flags().BoolS("slp", "slp", false, "set large pages mode")
+	cmd.Flags().StringS("slp", "slp", "", "set large pages mode")
 	cmd.Flags().BoolS("slt", "slt", false, "show technical information for l command")
 	cmd.Flags().BoolS("snh", "snh", false, "store hard links as links")
 	cmd.Flags().BoolS("sni", "sni", false, "store NT security information")
 	cmd.Flags().BoolS("snl", "snl", false, "store symbolic links as links")
-	cmd.Flags().BoolS("sns", "sns", false, "store NTFS alternate streams")
+	cmd.Flags().StringS("sns", "sns", "", "store NTFS alternate streams")
 	cmd.Flags().BoolS("so", "so", false, "write data to stdout")
 	cmd.Flags().BoolS("spd", "spd", false, "disable wildcard matching for file names")
 	cmd.Flags().BoolS("spe", "spe", false, "eliminate duplication of root folder for extract command")
-	cmd.Flags().BoolS("spf", "spf", false, "use fully qualified file paths")
-	cmd.Flags().BoolS("ssc", "ssc", false, "set sensitive case mode")
+	cmd.Flags().StringS("spf", "spf", "", "use fully qualified file paths")
+	cmd.Flags().StringS("ssc", "ssc", "", "set sensitive case mode")
+	cmd.Flags().BoolS("sse", "sse", false, "stop archive creating if input file cannot be opened")
+	cmd.Flags().BoolS("ssp", "ssp", false, "do not change Last Access Time of source files")
 	cmd.Flags().BoolS("ssw", "ssw", false, "compress shared files")
 	cmd.Flags().BoolS("stl", "stl", false, "set archive timestamp from the most recently modified file")
 	cmd.Flags().StringS("stm", "stm", "", "set CPU thread affinity mask")
 	cmd.Flags().StringS("stx", "stx", "", "exclude archive type")
 	cmd.Flags().StringS("t", "t", "", "set type of archive")
+	cmd.Flags().StringS("u", "u", "", "update options")
 	cmd.Flags().StringS("v", "v", "", "create volumes")
 	cmd.Flags().StringS("w", "w", "", "set working directory")
+	cmd.Flags().StringS("x", "x", "", "exclude filenames")
 	cmd.Flags().BoolS("y", "y", false, "assume Yes on all queries")
 
+	cmd.Flag("ai").NoOptDefVal = " "
 	cmd.Flag("ao").NoOptDefVal = " "
+	cmd.Flag("ax").NoOptDefVal = " "
 	cmd.Flag("bb").NoOptDefVal = " "
 	cmd.Flag("bs").NoOptDefVal = " "
+	cmd.Flag("i").NoOptDefVal = " "
 	cmd.Flag("m").NoOptDefVal = " "
 	cmd.Flag("o").NoOptDefVal = " "
 	cmd.Flag("p").NoOptDefVal = " "
+	cmd.Flag("r").NoOptDefVal = " "
 	cmd.Flag("sa").NoOptDefVal = " "
 	cmd.Flag("scc").NoOptDefVal = " "
 	cmd.Flag("scrc").NoOptDefVal = " "
 	cmd.Flag("scs").NoOptDefVal = " "
+	cmd.Flag("seml").NoOptDefVal = " "
 	cmd.Flag("sfx").NoOptDefVal = " "
 	cmd.Flag("si").NoOptDefVal = " "
+	cmd.Flag("slp").NoOptDefVal = " "
+	cmd.Flag("sns").NoOptDefVal = " "
+	cmd.Flag("spf").NoOptDefVal = " "
+	cmd.Flag("ssc").NoOptDefVal = " "
 	cmd.Flag("stm").NoOptDefVal = " "
 	cmd.Flag("stx").NoOptDefVal = " "
 	cmd.Flag("t").NoOptDefVal = " "
+	cmd.Flag("u").NoOptDefVal = " "
 	cmd.Flag("v").NoOptDefVal = " "
 	cmd.Flag("w").NoOptDefVal = " "
+	cmd.Flag("x").NoOptDefVal = " "
 }
 
 // addCommonFlagCompletions registers flag completions for common switches.
@@ -88,15 +106,22 @@ func addCommonFlagCompletions(cmd *cobra.Command) {
 		"ao":   carapace.ActionValues("a", "s", "t", "u"),
 		"bb":   carapace.ActionValues("0", "1", "2", "3"),
 		"o":    carapace.ActionDirectories(),
+		"r":    carapace.ActionValues("-", "0"),
 		"sa":   carapace.ActionValues("a", "e", "s"),
 		"scc":  carapace.ActionValues("UTF-8", "WIN", "DOS"),
-		"scrc": carapace.ActionValues("CRC32", "CRC64", "SHA1", "SHA256", "*"),
+		"scrc": carapace.ActionValues("CRC32", "CRC64", "SHA1", "SHA256", "XXH64", "*"),
 		"scs":  carapace.ActionValues("UTF-8", "UTF-16LE", "UTF-16BE", "WIN", "DOS"),
+		"seml": carapace.ActionValues("."),
 		"sfx":  carapace.ActionFiles(),
+		"slp":  carapace.ActionValues("-"),
+		"sns":  carapace.ActionValues("-"),
+		"spf":  carapace.ActionValues("2"),
+		"ssc":  carapace.ActionValues("-"),
 		"t": carapace.ActionValues(
 			"7z", "bzip2", "cab", "gzip",
 			"iso", "lzma", "lzma86",
-			"tar", "wim", "xz", "zip",
+			"tar", "udf", "wim", "xz", "zip",
+			"zstd", "split",
 		),
 		"w": carapace.ActionDirectories(),
 	})

--- a/completers/common/7z_completer/cmd/root.go
+++ b/completers/common/7z_completer/cmd/root.go
@@ -20,118 +20,109 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	addCommonFlags(rootCmd)
-	addCommonFlagCompletions(rootCmd)
-}
+	rootCmd.PersistentFlags().StringS("ai", "ai", "", "include archive filenames")
+	rootCmd.PersistentFlags().BoolS("an", "an", false, "disable archive_name field")
+	rootCmd.PersistentFlags().StringS("ao", "ao", "", "set overwrite mode")
+	rootCmd.PersistentFlags().StringS("ax", "ax", "", "exclude archive filenames")
+	rootCmd.PersistentFlags().StringS("bb", "bb", "", "set output log level")
+	rootCmd.PersistentFlags().BoolS("bd", "bd", false, "disable progress indicator")
+	rootCmd.PersistentFlags().StringS("bs", "bs", "", "set output stream for output/error/progress")
+	rootCmd.PersistentFlags().BoolS("bt", "bt", false, "show execution time statistics")
+	rootCmd.PersistentFlags().StringS("i", "i", "", "include filenames")
+	rootCmd.PersistentFlags().StringS("m", "m", "", "set compression method")
+	rootCmd.PersistentFlags().StringS("o", "o", "", "set output directory")
+	rootCmd.PersistentFlags().StringS("p", "p", "", "set password")
+	rootCmd.PersistentFlags().StringS("r", "r", "", "recurse subdirectories")
+	rootCmd.PersistentFlags().StringS("sa", "sa", "", "set archive name mode")
+	rootCmd.PersistentFlags().StringS("scc", "scc", "", "set charset for console input/output")
+	rootCmd.PersistentFlags().StringS("scrc", "scrc", "", "set hash function")
+	rootCmd.PersistentFlags().StringS("scs", "scs", "", "set charset for list files")
+	rootCmd.PersistentFlags().BoolS("sdel", "sdel", false, "delete files after compression")
+	rootCmd.PersistentFlags().StringS("seml", "seml", "", "send archive by email")
+	rootCmd.PersistentFlags().StringS("sfx", "sfx", "", "create SFX archive")
+	rootCmd.PersistentFlags().StringS("si", "si", "", "read data from stdin")
+	rootCmd.PersistentFlags().StringS("slp", "slp", "", "set large pages mode")
+	rootCmd.PersistentFlags().BoolS("slt", "slt", false, "show technical information for l command")
+	rootCmd.PersistentFlags().BoolS("snh", "snh", false, "store hard links as links")
+	rootCmd.PersistentFlags().BoolS("sni", "sni", false, "store NT security information")
+	rootCmd.PersistentFlags().BoolS("snl", "snl", false, "store symbolic links as links")
+	rootCmd.PersistentFlags().StringS("sns", "sns", "", "store NTFS alternate streams")
+	rootCmd.PersistentFlags().BoolS("so", "so", false, "write data to stdout")
+	rootCmd.PersistentFlags().BoolS("spd", "spd", false, "disable wildcard matching for file names")
+	rootCmd.PersistentFlags().BoolS("spe", "spe", false, "eliminate duplication of root folder for extract command")
+	rootCmd.PersistentFlags().StringS("spf", "spf", "", "use fully qualified file paths")
+	rootCmd.PersistentFlags().StringS("ssc", "ssc", "", "set sensitive case mode")
+	rootCmd.PersistentFlags().BoolS("sse", "sse", false, "stop archive creating if input file cannot be opened")
+	rootCmd.PersistentFlags().BoolS("ssp", "ssp", false, "do not change Last Access Time of source files")
+	rootCmd.PersistentFlags().BoolS("ssw", "ssw", false, "compress shared files")
+	rootCmd.PersistentFlags().BoolS("stl", "stl", false, "set archive timestamp from the most recently modified file")
+	rootCmd.PersistentFlags().StringS("stm", "stm", "", "set CPU thread affinity mask")
+	rootCmd.PersistentFlags().StringS("stx", "stx", "", "exclude archive type")
+	rootCmd.PersistentFlags().StringS("t", "t", "", "set type of archive")
+	rootCmd.PersistentFlags().StringS("u", "u", "", "update options")
+	rootCmd.PersistentFlags().StringS("v", "v", "", "create volumes")
+	rootCmd.PersistentFlags().StringS("w", "w", "", "set working directory")
+	rootCmd.PersistentFlags().StringS("x", "x", "", "exclude filenames")
+	rootCmd.PersistentFlags().BoolS("y", "y", false, "assume Yes on all queries")
 
-// addCommonFlags registers switches shared across all 7z subcommands.
-func addCommonFlags(cmd *cobra.Command) {
-	cmd.Flags().StringS("ai", "ai", "", "include archive filenames")
-	cmd.Flags().BoolS("an", "an", false, "disable archive_name field")
-	cmd.Flags().StringS("ao", "ao", "", "set overwrite mode")
-	cmd.Flags().StringS("ax", "ax", "", "exclude archive filenames")
-	cmd.Flags().StringS("bb", "bb", "", "set output log level")
-	cmd.Flags().BoolS("bd", "bd", false, "disable progress indicator")
-	cmd.Flags().StringS("bs", "bs", "", "set output stream for output/error/progress")
-	cmd.Flags().BoolS("bt", "bt", false, "show execution time statistics")
-	cmd.Flags().StringS("i", "i", "", "include filenames")
-	cmd.Flags().StringS("m", "m", "", "set compression method")
-	cmd.Flags().StringS("o", "o", "", "set output directory")
-	cmd.Flags().StringS("p", "p", "", "set password")
-	cmd.Flags().StringS("r", "r", "", "recurse subdirectories")
-	cmd.Flags().StringS("sa", "sa", "", "set archive name mode")
-	cmd.Flags().StringS("scc", "scc", "", "set charset for console input/output")
-	cmd.Flags().StringS("scrc", "scrc", "", "set hash function")
-	cmd.Flags().StringS("scs", "scs", "", "set charset for list files")
-	cmd.Flags().BoolS("sdel", "sdel", false, "delete files after compression")
-	cmd.Flags().StringS("seml", "seml", "", "send archive by email")
-	cmd.Flags().StringS("sfx", "sfx", "", "create SFX archive")
-	cmd.Flags().StringS("si", "si", "", "read data from stdin")
-	cmd.Flags().StringS("slp", "slp", "", "set large pages mode")
-	cmd.Flags().BoolS("slt", "slt", false, "show technical information for l command")
-	cmd.Flags().BoolS("snh", "snh", false, "store hard links as links")
-	cmd.Flags().BoolS("sni", "sni", false, "store NT security information")
-	cmd.Flags().BoolS("snl", "snl", false, "store symbolic links as links")
-	cmd.Flags().StringS("sns", "sns", "", "store NTFS alternate streams")
-	cmd.Flags().BoolS("so", "so", false, "write data to stdout")
-	cmd.Flags().BoolS("spd", "spd", false, "disable wildcard matching for file names")
-	cmd.Flags().BoolS("spe", "spe", false, "eliminate duplication of root folder for extract command")
-	cmd.Flags().StringS("spf", "spf", "", "use fully qualified file paths")
-	cmd.Flags().StringS("ssc", "ssc", "", "set sensitive case mode")
-	cmd.Flags().BoolS("sse", "sse", false, "stop archive creating if input file cannot be opened")
-	cmd.Flags().BoolS("ssp", "ssp", false, "do not change Last Access Time of source files")
-	cmd.Flags().BoolS("ssw", "ssw", false, "compress shared files")
-	cmd.Flags().BoolS("stl", "stl", false, "set archive timestamp from the most recently modified file")
-	cmd.Flags().StringS("stm", "stm", "", "set CPU thread affinity mask")
-	cmd.Flags().StringS("stx", "stx", "", "exclude archive type")
-	cmd.Flags().StringS("t", "t", "", "set type of archive")
-	cmd.Flags().StringS("u", "u", "", "update options")
-	cmd.Flags().StringS("v", "v", "", "create volumes")
-	cmd.Flags().StringS("w", "w", "", "set working directory")
-	cmd.Flags().StringS("x", "x", "", "exclude filenames")
-	cmd.Flags().BoolS("y", "y", false, "assume Yes on all queries")
+	rootCmd.Flag("ai").NoOptDefVal = " "
+	rootCmd.Flag("ai").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("ao").NoOptDefVal = " "
+	rootCmd.Flag("ao").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("ax").NoOptDefVal = " "
+	rootCmd.Flag("ax").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("bb").NoOptDefVal = " "
+	rootCmd.Flag("bb").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("bs").NoOptDefVal = " "
+	rootCmd.Flag("bs").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("i").NoOptDefVal = " "
+	rootCmd.Flag("i").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("m").NoOptDefVal = " "
+	rootCmd.Flag("m").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("o").NoOptDefVal = " "
+	rootCmd.Flag("o").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("p").NoOptDefVal = " "
+	rootCmd.Flag("p").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("r").NoOptDefVal = " "
+	rootCmd.Flag("r").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("sa").NoOptDefVal = " "
+	rootCmd.Flag("sa").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("scc").NoOptDefVal = " "
+	rootCmd.Flag("scc").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("scrc").NoOptDefVal = " "
+	rootCmd.Flag("scrc").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("scs").NoOptDefVal = " "
+	rootCmd.Flag("scs").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("seml").NoOptDefVal = " "
+	rootCmd.Flag("seml").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("sfx").NoOptDefVal = " "
+	rootCmd.Flag("sfx").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("si").NoOptDefVal = " "
+	rootCmd.Flag("si").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("slp").NoOptDefVal = " "
+	rootCmd.Flag("slp").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("sns").NoOptDefVal = " "
+	rootCmd.Flag("sns").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("spf").NoOptDefVal = " "
+	rootCmd.Flag("spf").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("ssc").NoOptDefVal = " "
+	rootCmd.Flag("ssc").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("stm").NoOptDefVal = " "
+	rootCmd.Flag("stm").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("stx").NoOptDefVal = " "
+	rootCmd.Flag("stx").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("t").NoOptDefVal = " "
+	rootCmd.Flag("t").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("u").NoOptDefVal = " "
+	rootCmd.Flag("u").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("v").NoOptDefVal = " "
+	rootCmd.Flag("v").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("w").NoOptDefVal = " "
+	rootCmd.Flag("w").OptargDelimiter = pflag.DelimiterDisabled
+	rootCmd.Flag("x").NoOptDefVal = " "
+	rootCmd.Flag("x").OptargDelimiter = pflag.DelimiterDisabled
 
-	cmd.Flag("ai").NoOptDefVal = " "
-	cmd.Flag("ai").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("ao").NoOptDefVal = " "
-	cmd.Flag("ao").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("ax").NoOptDefVal = " "
-	cmd.Flag("ax").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("bb").NoOptDefVal = " "
-	cmd.Flag("bb").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("bs").NoOptDefVal = " "
-	cmd.Flag("bs").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("i").NoOptDefVal = " "
-	cmd.Flag("i").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("m").NoOptDefVal = " "
-	cmd.Flag("m").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("o").NoOptDefVal = " "
-	cmd.Flag("o").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("p").NoOptDefVal = " "
-	cmd.Flag("p").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("r").NoOptDefVal = " "
-	cmd.Flag("r").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("sa").NoOptDefVal = " "
-	cmd.Flag("sa").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("scc").NoOptDefVal = " "
-	cmd.Flag("scc").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("scrc").NoOptDefVal = " "
-	cmd.Flag("scrc").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("scs").NoOptDefVal = " "
-	cmd.Flag("scs").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("seml").NoOptDefVal = " "
-	cmd.Flag("seml").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("sfx").NoOptDefVal = " "
-	cmd.Flag("sfx").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("si").NoOptDefVal = " "
-	cmd.Flag("si").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("slp").NoOptDefVal = " "
-	cmd.Flag("slp").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("sns").NoOptDefVal = " "
-	cmd.Flag("sns").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("spf").NoOptDefVal = " "
-	cmd.Flag("spf").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("ssc").NoOptDefVal = " "
-	cmd.Flag("ssc").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("stm").NoOptDefVal = " "
-	cmd.Flag("stm").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("stx").NoOptDefVal = " "
-	cmd.Flag("stx").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("t").NoOptDefVal = " "
-	cmd.Flag("t").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("u").NoOptDefVal = " "
-	cmd.Flag("u").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("v").NoOptDefVal = " "
-	cmd.Flag("v").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("w").NoOptDefVal = " "
-	cmd.Flag("w").OptargDelimiter = pflag.DelimiterDisabled
-	cmd.Flag("x").NoOptDefVal = " "
-	cmd.Flag("x").OptargDelimiter = pflag.DelimiterDisabled
-}
-
-// addCommonFlagCompletions registers flag completions for common switches.
-func addCommonFlagCompletions(cmd *cobra.Command) {
-	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"ao":   carapace.ActionValues("a", "s", "t", "u"),
 		"bb":   carapace.ActionValues("0", "1", "2", "3"),
 		"o":    carapace.ActionDirectories(),

--- a/completers/common/7z_completer/cmd/root.go
+++ b/completers/common/7z_completer/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/carapace-sh/carapace"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var rootCmd = &cobra.Command{
@@ -71,61 +72,61 @@ func addCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolS("y", "y", false, "assume Yes on all queries")
 
 	cmd.Flag("ai").NoOptDefVal = " "
-	cmd.Flag("ai").OptargDelimiter = -1
+	cmd.Flag("ai").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("ao").NoOptDefVal = " "
-	cmd.Flag("ao").OptargDelimiter = -1
+	cmd.Flag("ao").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("ax").NoOptDefVal = " "
-	cmd.Flag("ax").OptargDelimiter = -1
+	cmd.Flag("ax").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("bb").NoOptDefVal = " "
-	cmd.Flag("bb").OptargDelimiter = -1
+	cmd.Flag("bb").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("bs").NoOptDefVal = " "
-	cmd.Flag("bs").OptargDelimiter = -1
+	cmd.Flag("bs").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("i").NoOptDefVal = " "
-	cmd.Flag("i").OptargDelimiter = -1
+	cmd.Flag("i").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("m").NoOptDefVal = " "
-	cmd.Flag("m").OptargDelimiter = -1
+	cmd.Flag("m").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("o").NoOptDefVal = " "
-	cmd.Flag("o").OptargDelimiter = -1
+	cmd.Flag("o").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("p").NoOptDefVal = " "
-	cmd.Flag("p").OptargDelimiter = -1
+	cmd.Flag("p").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("r").NoOptDefVal = " "
-	cmd.Flag("r").OptargDelimiter = -1
+	cmd.Flag("r").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("sa").NoOptDefVal = " "
-	cmd.Flag("sa").OptargDelimiter = -1
+	cmd.Flag("sa").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("scc").NoOptDefVal = " "
-	cmd.Flag("scc").OptargDelimiter = -1
+	cmd.Flag("scc").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("scrc").NoOptDefVal = " "
-	cmd.Flag("scrc").OptargDelimiter = -1
+	cmd.Flag("scrc").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("scs").NoOptDefVal = " "
-	cmd.Flag("scs").OptargDelimiter = -1
+	cmd.Flag("scs").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("seml").NoOptDefVal = " "
-	cmd.Flag("seml").OptargDelimiter = -1
+	cmd.Flag("seml").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("sfx").NoOptDefVal = " "
-	cmd.Flag("sfx").OptargDelimiter = -1
+	cmd.Flag("sfx").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("si").NoOptDefVal = " "
-	cmd.Flag("si").OptargDelimiter = -1
+	cmd.Flag("si").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("slp").NoOptDefVal = " "
-	cmd.Flag("slp").OptargDelimiter = -1
+	cmd.Flag("slp").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("sns").NoOptDefVal = " "
-	cmd.Flag("sns").OptargDelimiter = -1
+	cmd.Flag("sns").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("spf").NoOptDefVal = " "
-	cmd.Flag("spf").OptargDelimiter = -1
+	cmd.Flag("spf").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("ssc").NoOptDefVal = " "
-	cmd.Flag("ssc").OptargDelimiter = -1
+	cmd.Flag("ssc").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("stm").NoOptDefVal = " "
-	cmd.Flag("stm").OptargDelimiter = -1
+	cmd.Flag("stm").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("stx").NoOptDefVal = " "
-	cmd.Flag("stx").OptargDelimiter = -1
+	cmd.Flag("stx").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("t").NoOptDefVal = " "
-	cmd.Flag("t").OptargDelimiter = -1
+	cmd.Flag("t").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("u").NoOptDefVal = " "
-	cmd.Flag("u").OptargDelimiter = -1
+	cmd.Flag("u").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("v").NoOptDefVal = " "
-	cmd.Flag("v").OptargDelimiter = -1
+	cmd.Flag("v").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("w").NoOptDefVal = " "
-	cmd.Flag("w").OptargDelimiter = -1
+	cmd.Flag("w").OptargDelimiter = pflag.DelimiterDisabled
 	cmd.Flag("x").NoOptDefVal = " "
-	cmd.Flag("x").OptargDelimiter = -1
+	cmd.Flag("x").OptargDelimiter = pflag.DelimiterDisabled
 }
 
 // addCommonFlagCompletions registers flag completions for common switches.

--- a/completers/common/7z_completer/cmd/t.go
+++ b/completers/common/7z_completer/cmd/t.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var tCmd = &cobra.Command{
+	Use:   "t",
+	Short: "Test integrity of archive",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(tCmd).Standalone()
+
+	addCommonFlags(tCmd)
+	addCommonFlagCompletions(tCmd)
+	rootCmd.AddCommand(tCmd)
+
+	carapace.Gen(tCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/t.go
+++ b/completers/common/7z_completer/cmd/t.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(tCmd)
 	rootCmd.AddCommand(tCmd)
 
-	carapace.Gen(tCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(tCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/t.go
+++ b/completers/common/7z_completer/cmd/t.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(tCmd)
 
 	carapace.Gen(tCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/t.go
+++ b/completers/common/7z_completer/cmd/t.go
@@ -21,4 +21,8 @@ func init() {
 	carapace.Gen(tCmd).PositionalCompletion(
 		carapace.ActionFiles(),
 	)
+
+	carapace.Gen(tCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
 }

--- a/completers/common/7z_completer/cmd/t.go
+++ b/completers/common/7z_completer/cmd/t.go
@@ -14,8 +14,6 @@ var tCmd = &cobra.Command{
 func init() {
 	carapace.Gen(tCmd).Standalone()
 
-	addCommonFlags(tCmd)
-	addCommonFlagCompletions(tCmd)
 	rootCmd.AddCommand(tCmd)
 
 	carapace.Gen(tCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/u.go
+++ b/completers/common/7z_completer/cmd/u.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var uCmd = &cobra.Command{
+	Use:   "u",
+	Short: "Update files to archive",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(uCmd).Standalone()
+
+	addCommonFlags(uCmd)
+	addCommonFlagCompletions(uCmd)
+	rootCmd.AddCommand(uCmd)
+
+	carapace.Gen(uCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+
+	carapace.Gen(uCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/u.go
+++ b/completers/common/7z_completer/cmd/u.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(uCmd)
 
 	carapace.Gen(uCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/cmd/u.go
+++ b/completers/common/7z_completer/cmd/u.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(uCmd)
 	rootCmd.AddCommand(uCmd)
 
-	carapace.Gen(uCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(uCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/u.go
+++ b/completers/common/7z_completer/cmd/u.go
@@ -14,8 +14,6 @@ var uCmd = &cobra.Command{
 func init() {
 	carapace.Gen(uCmd).Standalone()
 
-	addCommonFlags(uCmd)
-	addCommonFlagCompletions(uCmd)
 	rootCmd.AddCommand(uCmd)
 
 	carapace.Gen(uCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/x.go
+++ b/completers/common/7z_completer/cmd/x.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var xCmd = &cobra.Command{
+	Use:   "x",
+	Short: "Extract files with full paths",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(xCmd).Standalone()
+
+	addCommonFlags(xCmd)
+	addCommonFlagCompletions(xCmd)
+	rootCmd.AddCommand(xCmd)
+
+	carapace.Gen(xCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+
+	carapace.Gen(xCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/7z_completer/cmd/x.go
+++ b/completers/common/7z_completer/cmd/x.go
@@ -14,8 +14,6 @@ var xCmd = &cobra.Command{
 func init() {
 	carapace.Gen(xCmd).Standalone()
 
-	addCommonFlags(xCmd)
-	addCommonFlagCompletions(xCmd)
 	rootCmd.AddCommand(xCmd)
 
 	carapace.Gen(xCmd).PositionalAnyCompletion(

--- a/completers/common/7z_completer/cmd/x.go
+++ b/completers/common/7z_completer/cmd/x.go
@@ -18,10 +18,6 @@ func init() {
 	addCommonFlagCompletions(xCmd)
 	rootCmd.AddCommand(xCmd)
 
-	carapace.Gen(xCmd).PositionalCompletion(
-		carapace.ActionFiles(),
-	)
-
 	carapace.Gen(xCmd).PositionalAnyCompletion(
 		carapace.ActionFiles(),
 	)

--- a/completers/common/7z_completer/cmd/x.go
+++ b/completers/common/7z_completer/cmd/x.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(xCmd)
 
 	carapace.Gen(xCmd).PositionalAnyCompletion(
-		carapace.ActionFiles(),
+		carapace.ActionFiles().FilterArgs(),
 	)
 }

--- a/completers/common/7z_completer/main.go
+++ b/completers/common/7z_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/7z_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/carapace-sh/carapace-bin
 go 1.26.2
 
 require (
-	github.com/carapace-sh/carapace v1.14.0
+	github.com/carapace-sh/carapace v1.15.0
 	github.com/carapace-sh/carapace-bridge v1.6.2
 	github.com/carapace-sh/carapace-jjlex v0.1.8
 	github.com/carapace-sh/carapace-jq v0.0.3
@@ -27,6 +27,6 @@ require (
 	github.com/kevinburke/ssh_config v1.4.0
 )
 
-replace github.com/spf13/pflag => github.com/carapace-sh/carapace-pflag v1.2.0
+replace github.com/spf13/pflag => github.com/carapace-sh/carapace-pflag v1.3.0
 
 replace github.com/kevinburke/ssh_config => github.com/carapace-sh/ssh_config v1.4.1-0.20260319075335-4f04016b8b4b

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
-github.com/carapace-sh/carapace v1.14.0 h1:51JZwCUcG/BgwXWW7rp1r3NQbV/lwVViY6Ei8hWLgA8=
-github.com/carapace-sh/carapace v1.14.0/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
+github.com/carapace-sh/carapace v1.15.0 h1:95WnDd2qXmt8ND+odPnsnfq2LA6394P28QSLteA4e5c=
+github.com/carapace-sh/carapace v1.15.0/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
 github.com/carapace-sh/carapace-bridge v1.6.2 h1:vHhmr6/6GSZziQlEMBSg3nle8vaPFXK0aOZYsjPQ4PY=
 github.com/carapace-sh/carapace-bridge v1.6.2/go.mod h1:NWgiBA+G0lc82KgSzQaXTkUgb6CTRERsNkVNnY+fSwk=
 github.com/carapace-sh/carapace-jjlex v0.1.8 h1:+Pip1sOri76w4cBGVcMv+tLWzK24696rATlW9i5M7Z4=
 github.com/carapace-sh/carapace-jjlex v0.1.8/go.mod h1:rT0jaDX51zqHg7XHIMv+OQuBuYHvePQt8GCRPr2V9iU=
 github.com/carapace-sh/carapace-jq v0.0.3 h1:DbVKss+jpg54McQNBg0WBFO60Vz+WwbRgjoJWyGgETY=
 github.com/carapace-sh/carapace-jq v0.0.3/go.mod h1:wF5p2OM8wgLQwULZp2PQXIo7AYiSWAHAn1bNBmkHKQE=
-github.com/carapace-sh/carapace-pflag v1.2.0 h1:loeG/m87umRsN8DgjZkDs4gN70M+P9a7/K5pOJS6zZM=
-github.com/carapace-sh/carapace-pflag v1.2.0/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/carapace-sh/carapace-pflag v1.3.0 h1:RT1xJ+2p4c2WqYXPZZA7zu2jIi6Vt+pmalZf75yFzBM=
+github.com/carapace-sh/carapace-pflag v1.3.0/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/carapace-sh/carapace-pnpm v0.0.2 h1:+hOrliH7O1bq1jonNbZPMbvijBafHxEP0b/N+74V75I=
 github.com/carapace-sh/carapace-pnpm v0.0.2/go.mod h1:f9I//SNUgRPSdU/qrZQf49lgOQMxUlX+0CJonGSCeCk=
 github.com/carapace-sh/carapace-selfupdate v0.0.10 h1:ZvutqGwVvSj6TmI/tLcort63JD6PaOG0ia6squwbTuo=


### PR DESCRIPTION
closes #3356

### Command
`7z` — [p7zip](https://github.com/p7zip-project/p7zip)

### Description
Adds shell completion for the `7z` command (command-line port of 7-Zip).

### Commands
All 11 commands from the [man page](https://linux.die.net/man/1/7z):

| Command | Description |
|---------|-------------|
| `a` | Add files to archive |
| `b` | Benchmark |
| `d` | Delete files from archive |
| `e` | Extract files from archive (without directory names) |
| `h` | Calculate hash values for files |
| `i` | Show information about supported formats |
| `l` | List contents of archive |
| `rn` | Rename files in archive |
| `t` | Test integrity of archive |
| `u` | Update files to archive |
| `x` | Extract files with full paths |

### Switches
37 switches including `-t`, `-o`, `-p`, `-m`, `-r`, `-y`, `-ao`, `-bb`, `-scc`, `-scs`, `-scrc`, `-sfx`, and more.

### Flag completions
- `-t` → archive types (`7z`, `zip`, `tar`, `gzip`, `bzip2`, `cab`, `iso`, `lzma`, `lzma86`, `wim`, `xz`)
- `-o`, `-w` → directory completion
- `-ao` → overwrite modes (`a`, `s`, `t`, `u`)
- `-sa` → archive name modes (`a`, `e`, `s`)
- `-scc` → console charsets (`UTF-8`, `WIN`, `DOS`)
- `-scs` → list file charsets (`UTF-8`, `UTF-16LE`, `UTF-16BE`, `WIN`, `DOS`)
- `-scrc` → hash functions (`CRC32`, `CRC64`, `SHA1`, `SHA256`, `*`)
- `-bb` → log levels (`0`–`3`)
- `-sfx` → SFX module file completion

### Verification
- `go build` ✅
- `go vet` ✅
- `carapace-lint` ✅
