### PR TITLE
Add balooctl6 completer

### DIFF
--- a/cmd/carapace-generate/pkg/completer/completers_test.go
+++ b/cmd/carapace-generate/pkg/completer/completers_test.go
@@ -1,0 +1,14 @@
+package completer
+
+import "testing"
+
+func TestReadCompletersBalooctl6(t *testing.T) {
+	completers, err := ReadCompleters("../../../../completers", "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := completers.Lookup("balooctl6@linux"); !ok {
+		t.Fatal("expected balooctl6 linux completer")
+	}
+}

--- a/completers/linux/balooctl6_completer/cmd/check.go
+++ b/completers/linux/balooctl6_completer/cmd/check.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check for any unindexed files and index them",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(checkCmd).Standalone()
+
+	rootCmd.AddCommand(checkCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/clear.go
+++ b/completers/linux/balooctl6_completer/cmd/clear.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var clearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Forget the specified files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(clearCmd).Standalone()
+
+	rootCmd.AddCommand(clearCmd)
+
+	carapace.Gen(clearCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/config.go
+++ b/completers/linux/balooctl6_completer/cmd/config.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Modify the Baloo configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configCmd).Standalone()
+
+	rootCmd.AddCommand(configCmd)
+
+	carapace.Gen(configCmd).PositionalCompletion(
+		carapace.ActionValues("add", "help", "list", "ls", "remove", "rm", "set", "show").StyleF(style.ForKeyword),
+	)
+}
+
+func actionConfigListParameters() carapace.Action {
+	return carapace.ActionValues(
+		"contentIndexing",
+		"excludeFilters",
+		"excludeFolders",
+		"excludeMimetypes",
+		"hidden",
+		"includeFolders",
+	).StyleF(style.ForKeyword)
+}
+
+func actionConfigModifyParameters() carapace.Action {
+	return carapace.ActionValues(
+		"excludeFilters",
+		"excludeFolders",
+		"excludeMimetypes",
+		"includeFolders",
+	).StyleF(style.ForKeyword)
+}
+
+func actionConfigSetParameters() carapace.Action {
+	return carapace.ActionValues("contentIndexing", "hidden").StyleF(style.ForKeyword)
+}
+
+func actionBooleanValues() carapace.Action {
+	return carapace.ActionValues("true", "false", "yes", "no", "y", "n", "1", "0").StyleF(style.ForKeyword)
+}

--- a/completers/linux/balooctl6_completer/cmd/configAdd.go
+++ b/completers/linux/balooctl6_completer/cmd/configAdd.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a value to config parameter",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configAddCmd).Standalone()
+
+	configCmd.AddCommand(configAddCmd)
+
+	carapace.Gen(configAddCmd).PositionalCompletion(
+		actionConfigModifyParameters(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if len(c.Args) == 0 {
+				return carapace.ActionValues()
+			}
+			switch c.Args[0] {
+			case "includeFolders", "excludeFolders":
+				return carapace.ActionDirectories()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/configHelp.go
+++ b/completers/linux/balooctl6_completer/cmd/configHelp.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configHelpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Display the config help menu",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configHelpCmd).Standalone()
+
+	configCmd.AddCommand(configHelpCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/configList.go
+++ b/completers/linux/balooctl6_completer/cmd/configList.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls", "show"},
+	Short:   "Show the value of a config parameter",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configListCmd).Standalone()
+
+	configCmd.AddCommand(configListCmd)
+
+	carapace.Gen(configListCmd).PositionalCompletion(
+		actionConfigListParameters(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/configRemove.go
+++ b/completers/linux/balooctl6_completer/cmd/configRemove.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configRemoveCmd = &cobra.Command{
+	Use:     "remove",
+	Aliases: []string{"rm"},
+	Short:   "Remove a value from a config parameter",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configRemoveCmd).Standalone()
+
+	configCmd.AddCommand(configRemoveCmd)
+
+	carapace.Gen(configRemoveCmd).PositionalCompletion(
+		actionConfigModifyParameters(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if len(c.Args) == 0 {
+				return carapace.ActionValues()
+			}
+			switch c.Args[0] {
+			case "includeFolders", "excludeFolders":
+				return carapace.ActionDirectories()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/configSet.go
+++ b/completers/linux/balooctl6_completer/cmd/configSet.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set the value of a config parameter",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configSetCmd).Standalone()
+
+	configCmd.AddCommand(configSetCmd)
+
+	carapace.Gen(configSetCmd).PositionalCompletion(
+		actionConfigSetParameters(),
+		actionBooleanValues(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/disable.go
+++ b/completers/linux/balooctl6_completer/cmd/disable.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(disableCmd).Standalone()
+
+	rootCmd.AddCommand(disableCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/enable.go
+++ b/completers/linux/balooctl6_completer/cmd/enable.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var enableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(enableCmd).Standalone()
+
+	rootCmd.AddCommand(enableCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/failed.go
+++ b/completers/linux/balooctl6_completer/cmd/failed.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var failedCmd = &cobra.Command{
+	Use:   "failed",
+	Short: "Display files which could not be indexed",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(failedCmd).Standalone()
+
+	rootCmd.AddCommand(failedCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/index.go
+++ b/completers/linux/balooctl6_completer/cmd/index.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Index the specified files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(indexCmd).Standalone()
+
+	rootCmd.AddCommand(indexCmd)
+
+	carapace.Gen(indexCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/indexSize.go
+++ b/completers/linux/balooctl6_completer/cmd/indexSize.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var indexSizeCmd = &cobra.Command{
+	Use:   "indexSize",
+	Short: "Display the disk space used by index",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(indexSizeCmd).Standalone()
+
+	rootCmd.AddCommand(indexSizeCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/monitor.go
+++ b/completers/linux/balooctl6_completer/cmd/monitor.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var monitorCmd = &cobra.Command{
+	Use:   "monitor",
+	Short: "Monitor the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(monitorCmd).Standalone()
+
+	rootCmd.AddCommand(monitorCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/purge.go
+++ b/completers/linux/balooctl6_completer/cmd/purge.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var purgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Remove the index database",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(purgeCmd).Standalone()
+
+	rootCmd.AddCommand(purgeCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/resume.go
+++ b/completers/linux/balooctl6_completer/cmd/resume.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(resumeCmd).Standalone()
+
+	rootCmd.AddCommand(resumeCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/root.go
+++ b/completers/linux/balooctl6_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "balooctl6",
+	Short: "Control the Baloo file indexer",
+	Long:  "https://community.kde.org/Baloo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().StringP("format", "f", "multiline", "Output format")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Displays help on commandline options")
+	rootCmd.PersistentFlags().Bool("help-all", false, "Displays help, including generic Qt options")
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "Displays version information")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"format": carapace.ActionValues("multiline", "json", "simple").StyleF(style.ForKeyword),
+	})
+}

--- a/completers/linux/balooctl6_completer/cmd/status.go
+++ b/completers/linux/balooctl6_completer/cmd/status.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print the status of the indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(statusCmd).Standalone()
+
+	rootCmd.AddCommand(statusCmd)
+
+	carapace.Gen(statusCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/suspend.go
+++ b/completers/linux/balooctl6_completer/cmd/suspend.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend",
+	Short: "Suspend the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(suspendCmd).Standalone()
+
+	rootCmd.AddCommand(suspendCmd)
+}

--- a/completers/linux/balooctl6_completer/main.go
+++ b/completers/linux/balooctl6_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/linux/balooctl6_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
- add a Linux completer for `balooctl6`
- include root flags, subcommands, file completions for file-oriented commands, and config subcommand completions
- add a generator test that verifies `balooctl6` is discovered for the Linux completer set

Closes #3341.

## Verification
- `go generate ./cmd/...`
- `go install -v -tags force_all ./cmd/carapace`
- `go test ./cmd/carapace-generate/pkg/completer ./completers/linux/balooctl6_completer/...`
- `go run ./cmd/carapace-lint completers/linux/balooctl6_completer/cmd/*.go`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./cmd/carapace-generate/pkg/completer ./completers/linux/balooctl6_completer/...`

Note: `go test -v ./cmd/...` still fails locally in the existing `cmd/carapace/cmd` invoke sandbox tests because the vendored `execabs` wrapper reports `carapace resolves to executable in current directory (./carapace)`. With `NO_COLOR` unset, the unrelated color macro expectation passes; the remaining failure is isolated to those existing invoke tests, not this completer package.