### PR TITLE
Add kcl completer

### DIFF
--- a/cmd/carapace-generate/pkg/completer/completers_test.go
+++ b/cmd/carapace-generate/pkg/completer/completers_test.go
@@ -1,0 +1,14 @@
+package completer
+
+import "testing"
+
+func TestReadCompletersKcl(t *testing.T) {
+	completers, err := ReadCompleters("../../../../completers", "linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := completers.Lookup("kcl@common"); !ok {
+		t.Fatal("expected kcl common completer")
+	}
+}

--- a/completers/common/kcl_completer/cmd/root.go
+++ b/completers/common/kcl_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "kcl",
+	Short:              "A constraint-based record and functional language",
+	Long:               "https://kcl-lang.io",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCobra("kcl"),
+	)
+}

--- a/completers/common/kcl_completer/main.go
+++ b/completers/common/kcl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/kcl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
- add a common completer for `kcl` using the Cobra bridge
- add a generator test that verifies `kcl` is discovered in the common completer set

Closes #3242.

## Verification
- `go test ./cmd/carapace-generate/pkg/completer ./completers/common/kcl_completer/...`
- `go run ./cmd/carapace-lint completers/common/kcl_completer/cmd/*.go`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./cmd/carapace-generate/pkg/completer ./completers/common/kcl_completer/...`
- `go generate ./cmd/...`
- `go install -v -tags force_all ./cmd/carapace`