### PR TITLE
Add balooctl6 completer

### DIFF
--- a/completers/common/balooctl6_completer/cmd/config.go
+++ b/completers/common/balooctl6_completer/cmd/config.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCommand() *cobra.Command {
+	configCmd := &cobra.Command{
+		Use:   "config",
+		Short: "Modify the Baloo configuration",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	configCmd.AddCommand(
+		newConfigAddCommand(),
+		newConfigHelpCommand(),
+		newConfigListCommand("list", "Show the value of a config parameter"),
+		newConfigRemoveCommand("remove", "Remove a value from a config parameter"),
+		newConfigRemoveCommand("rm", "Remove a value from a config parameter"),
+		newConfigSetCommand(),
+		newConfigListCommand("show", "Show the value of a config parameter"),
+		newConfigListCommand("ls", "Show the value of a config parameter"),
+	)
+
+	carapace.Gen(configCmd).PositionalCompletion(
+		actionConfigCommands(),
+	)
+
+	return configCmd
+}
+
+func newConfigAddCommand() *cobra.Command {
+	addCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a value to config parameter",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	carapace.Gen(addCmd).PositionalCompletion(
+		actionModifiableConfigParameters(),
+		actionConfigValue(),
+	)
+
+	return addCmd
+}
+
+func newConfigHelpCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "help",
+		Short: "Display the config help menu",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+}
+
+func newConfigListCommand(use string, short string) *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	carapace.Gen(listCmd).PositionalCompletion(
+		actionListableConfigParameters(),
+	)
+
+	return listCmd
+}
+
+func newConfigRemoveCommand(use string, short string) *cobra.Command {
+	removeCmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	carapace.Gen(removeCmd).PositionalCompletion(
+		actionModifiableConfigParameters(),
+		actionConfigValue(),
+	)
+
+	return removeCmd
+}
+
+func newConfigSetCommand() *cobra.Command {
+	setCmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set the value of a config parameter",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	carapace.Gen(setCmd).PositionalCompletion(
+		actionSettableConfigParameters(),
+		actionBooleanValues(),
+	)
+
+	return setCmd
+}
+
+func actionBooleanValues() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"true", "enable the option",
+		"yes", "enable the option",
+		"y", "enable the option",
+		"1", "enable the option",
+		"false", "disable the option",
+		"no", "disable the option",
+		"n", "disable the option",
+		"0", "disable the option",
+	)
+}
+
+func actionConfigCommands() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"add", "Add a value to config parameter",
+		"rm", "Remove a value from a config parameter",
+		"remove", "Remove a value from a config parameter",
+		"list", "Show the value of a config parameter",
+		"ls", "Show the value of a config parameter",
+		"show", "Show the value of a config parameter",
+		"set", "Set the value of a config parameter",
+		"help", "Display the config help menu",
+	)
+}
+
+func actionConfigValue() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) < 1 {
+			return carapace.ActionValues()
+		}
+
+		switch c.Args[0] {
+		case "includeFolders", "excludeFolders":
+			return carapace.ActionDirectories()
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+func actionListableConfigParameters() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"hidden", "Controls if Baloo indexes hidden files and folders",
+		"contentIndexing", "Controls if Baloo indexes file content",
+		"includeFolders", "The list of folders which Baloo indexes",
+		"excludeFolders", "The list of folders which Baloo will never index",
+		"excludeFilters", "The list of filters which are used to exclude files",
+		"excludeMimetypes", "The list of mimetypes which are used to exclude files",
+	)
+}
+
+func actionModifiableConfigParameters() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"includeFolders", "The list of folders which Baloo indexes",
+		"excludeFolders", "The list of folders which Baloo will never index",
+		"excludeFilters", "The list of filters which are used to exclude files",
+		"excludeMimetypes", "The list of mimetypes which are used to exclude files",
+	)
+}
+
+func actionSettableConfigParameters() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"hidden", "Controls if Baloo indexes hidden files and folders",
+		"contentIndexing", "Controls if Baloo indexes file content",
+	)
+}

--- a/completers/common/balooctl6_completer/cmd/root.go
+++ b/completers/common/balooctl6_completer/cmd/root.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "balooctl6",
+	Short: "control the Baloo file indexer",
+	Long:  "https://community.kde.org/Baloo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().StringP("format", "f", "multiline", "Output format")
+	rootCmd.PersistentFlags().Bool("help-all", false, "Displays help, including generic Qt options")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Displays help on commandline options")
+	rootCmd.PersistentFlags().String("qmljsdebugger", "", "Activates the QML/JS debugger with a specified port")
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "Displays version information")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"format": carapace.ActionValuesDescribed(
+			"multiline", "multi-line file status output",
+			"json", "JSON file status output",
+			"simple", "single-line file status output",
+		),
+	})
+
+	rootCmd.AddCommand(
+		newConfigCommand(),
+		newFileCommand("clear", "Forget the specified files"),
+		newCommand("check", "Check for any unindexed files and index them"),
+		newCommand("disable", "Disable the file indexer"),
+		newCommand("enable", "Enable the file indexer"),
+		newCommand("failed", "Display files which could not be indexed"),
+		newFileCommand("index", "Index the specified files"),
+		newCommand("indexSize", "Display the disk space used by index"),
+		newCommand("monitor", "Monitor the file indexer"),
+		newCommand("purge", "Remove the index database"),
+		newCommand("resume", "Resume the file indexer"),
+		newFileCommand("status", "Print the status of the indexer"),
+		newCommand("suspend", "Suspend the file indexer"),
+	)
+}
+
+func newCommand(use string, short string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+}
+
+func newFileCommand(use string, short string) *cobra.Command {
+	command := newCommand(use, short)
+
+	carapace.Gen(command).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+
+	return command
+}

--- a/completers/common/balooctl6_completer/main.go
+++ b/completers/common/balooctl6_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/balooctl6_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Closes #3341.

## Summary
- add a native `balooctl6` completer with the Baloo top-level commands
- complete `--format` values and Qt/help/version flags from `balooctl6 --help-all`
- complete file arguments for `status`, `index`, and `clear`
- complete `config` subcommands, config parameters, folder values, and boolean values

## Validation
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/balooctl6_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./completers/common/balooctl6_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/carapace ./cmd/carapace/cmd/completers`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./completers/common/balooctl6_completer --help`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./completers/common/balooctl6_completer config --help`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./completers/common/balooctl6_completer config set --help`
- `git diff --check`