### PR TITLE
Add OpenRC completers

### DIFF
--- a/completers/common/openrc_completer/cmd/root.go
+++ b/completers/common/openrc_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "openrc [flags] [runlevel]",
+	Short: "stops and starts services for the specified runlevel",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.Flags().BoolP("no-stop", "n", false, "Do not stop any services")
+	rootCmd.Flags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.Flags().BoolP("override", "o", false, "Override the next runlevel")
+	rootCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.Flags().BoolP("service", "s", false, "Run the service specified with the rest of the arguments")
+	rootCmd.Flags().BoolP("sys", "S", false, "Output the RC system type")
+	rootCmd.Flags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.Flags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.Flags().BoolP("version", "V", false, "Display software version")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		openrc.ActionRunlevels(),
+	)
+}

--- a/completers/common/openrc_completer/main.go
+++ b/completers/common/openrc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/openrc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-service_completer/cmd/root.go
+++ b/completers/common/rc-service_completer/cmd/root.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-service [flags] service command [args...]",
+	Short: "locate and run an OpenRC service with the given arguments",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("debug", "d", false, "Run service scripts with shell tracing")
+	rootCmd.Flags().BoolP("dry-run", "Z", false, "Display commands rather than executing them")
+	rootCmd.Flags().BoolP("exists", "e", false, "Return success if the service exists")
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.Flags().BoolP("ifcrashed", "c", false, "Run only if the service has crashed")
+	rootCmd.Flags().BoolP("ifexists", "i", false, "Return success if the service does not exist")
+	rootCmd.Flags().BoolP("ifinactive", "I", false, "Run only if the service is inactive")
+	rootCmd.Flags().BoolP("ifnotstarted", "N", false, "Run only if the service is not started")
+	rootCmd.Flags().BoolP("ifstarted", "s", false, "Run only if the service is started")
+	rootCmd.Flags().BoolP("ifstopped", "S", false, "Run only if the service is stopped")
+	rootCmd.Flags().BoolP("list", "l", false, "List all available services")
+	rootCmd.Flags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.Flags().BoolP("nodeps", "D", false, "Ignore dependencies when running the service")
+	rootCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.Flags().BoolP("resolve", "r", false, "Resolve the full path of the service")
+	rootCmd.Flags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.Flags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.Flags().BoolP("version", "V", false, "Display software version")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		openrc.ActionServices(),
+		openrc.ActionServiceCommands(),
+	)
+}

--- a/completers/common/rc-service_completer/main.go
+++ b/completers/common/rc-service_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-service_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-status_completer/cmd/root.go
+++ b/completers/common/rc-status_completer/cmd/root.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-status [flags] [runlevel]",
+	Short: "show status info about OpenRC runlevels",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("all", "a", false, "Show all runlevels and their services")
+	rootCmd.Flags().BoolP("crashed", "c", false, "List all crashed services")
+	rootCmd.Flags().StringP("format", "f", "", "Select an output format")
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.Flags().StringArrayP("in-state", "i", nil, "Show services in the given state")
+	rootCmd.Flags().BoolP("list", "l", false, "List all defined runlevels")
+	rootCmd.Flags().BoolP("manual", "m", false, "Show all manually started services")
+	rootCmd.Flags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.Flags().BoolP("runlevel", "r", false, "Print the current runlevel name")
+	rootCmd.Flags().BoolP("servicelist", "s", false, "Show all services")
+	rootCmd.Flags().BoolP("supervised", "S", false, "Show all supervised services")
+	rootCmd.Flags().BoolP("unused", "u", false, "Show services not assigned to any runlevel")
+	rootCmd.Flags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.Flags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.Flags().BoolP("version", "V", false, "Display software version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"format":   carapace.ActionValues("ini"),
+		"in-state": openrc.ActionServiceStates(),
+	})
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		openrc.ActionRunlevels(),
+	)
+}

--- a/completers/common/rc-status_completer/main.go
+++ b/completers/common/rc-status_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-status_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-update_completer/cmd/root.go
+++ b/completers/common/rc-update_completer/cmd/root.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-update",
+	Short: "add and remove OpenRC services to and from a runlevel",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.PersistentFlags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.PersistentFlags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.PersistentFlags().BoolP("version", "V", false, "Display software version")
+
+	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(deleteCmd)
+	rootCmd.AddCommand(showCmd)
+}
+
+var addCmd = &cobra.Command{
+	Use:   "add service [runlevel...]",
+	Short: "add a service to a runlevel",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete service [runlevel...]",
+	Aliases: []string{"del", "remove", "rm"},
+	Short:   "delete a service from a runlevel",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+var showCmd = &cobra.Command{
+	Use:   "show [runlevel...]",
+	Short: "show enabled services and their runlevels",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(addCmd).Standalone()
+	addCmd.Flags().BoolP("stack", "s", false, "Add the runlevel to the current runlevel stack")
+	carapace.Gen(addCmd).PositionalCompletion(
+		openrc.ActionServices(),
+	)
+	carapace.Gen(addCmd).PositionalAnyCompletion(
+		openrc.ActionRunlevels(),
+	)
+
+	carapace.Gen(deleteCmd).Standalone()
+	deleteCmd.Flags().BoolP("all", "a", false, "Remove the service from all runlevels")
+	deleteCmd.Flags().BoolP("stack", "s", false, "Remove the runlevel from the current runlevel stack")
+	carapace.Gen(deleteCmd).PositionalCompletion(
+		openrc.ActionServices(),
+	)
+	carapace.Gen(deleteCmd).PositionalAnyCompletion(
+		openrc.ActionRunlevels(),
+	)
+
+	carapace.Gen(showCmd).Standalone()
+	showCmd.Flags().BoolP("update", "u", false, "Force an update of the dependency tree cache")
+	showCmd.Flags().BoolP("verbose", "v", false, "Show all services")
+	carapace.Gen(showCmd).PositionalAnyCompletion(
+		openrc.ActionRunlevels(),
+	)
+}

--- a/completers/common/rc-update_completer/main.go
+++ b/completers/common/rc-update_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-update_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/openrc/openrc.go
+++ b/pkg/actions/tools/openrc/openrc.go
@@ -1,0 +1,139 @@
+package openrc
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionServices completes OpenRC service scripts from system and user init directories.
+func ActionServices() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionValues(readNames(serviceDirs(), false)...)
+	})
+}
+
+// ActionRunlevels completes OpenRC runlevels from system and user runlevel directories.
+func ActionRunlevels() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		static := map[string]string{
+			"boot":     "early boot services",
+			"default":  "default runlevel",
+			"reboot":   "shutdown and reboot the host",
+			"shutdown": "shutdown and halt the host",
+			"single":   "single-user runlevel",
+			"sysinit":  "system initialization services",
+		}
+
+		described := make([]string, 0, len(static)*2)
+		for _, name := range sortedKeys(static) {
+			described = append(described, name, static[name])
+		}
+
+		var dynamic []string
+		for _, name := range readNames(runlevelDirs(), true) {
+			if _, ok := static[name]; !ok {
+				dynamic = append(dynamic, name)
+			}
+		}
+
+		return carapace.Batch(
+			carapace.ActionValuesDescribed(described...),
+			carapace.ActionValues(dynamic...),
+		).ToA()
+	})
+}
+
+// ActionServiceCommands completes common commands supported by OpenRC service scripts.
+func ActionServiceCommands() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"start", "start the service",
+		"stop", "stop the service",
+		"restart", "restart the service",
+		"status", "show service status",
+		"zap", "forget the service's started state",
+		"describe", "show service description",
+		"needsme", "show services that need this service",
+		"ineed", "show services this service needs",
+		"iuse", "show services this service uses",
+		"broken", "show broken dependencies",
+		"provide", "show virtual services provided",
+		"cgroup_cleanup", "clean cgroups for a stopped service",
+	)
+}
+
+// ActionServiceStates completes service states accepted by rc-status --in-state.
+func ActionServiceStates() carapace.Action {
+	return carapace.ActionValues(
+		"stopped",
+		"started",
+		"stopping",
+		"starting",
+		"inactive",
+		"hotplugged",
+		"failed",
+		"scheduled",
+		"crashed",
+	)
+}
+
+func serviceDirs() []string {
+	dirs := []string{
+		"/etc/init.d",
+		"/usr/local/etc/init.d",
+		"/etc/user/init.d",
+	}
+	if configHome := xdgConfigHome(); configHome != "" {
+		dirs = append(dirs, filepath.Join(configHome, "rc", "init.d"))
+	}
+	return dirs
+}
+
+func runlevelDirs() []string {
+	dirs := []string{"/etc/runlevels"}
+	if configHome := xdgConfigHome(); configHome != "" {
+		dirs = append(dirs, filepath.Join(configHome, "rc", "runlevels"))
+	}
+	return dirs
+}
+
+func xdgConfigHome() string {
+	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
+		return configHome
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config")
+	}
+	return ""
+}
+
+func readNames(dirs []string, dirsOnly bool) []string {
+	seen := make(map[string]bool)
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.Name() == "" || entry.Name()[0] == '.' {
+				continue
+			}
+			if dirsOnly && !entry.IsDir() {
+				continue
+			}
+			seen[entry.Name()] = true
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Closes #3362.

## Summary
- add shared OpenRC actions for services, runlevels, service commands, and service states
- add completers for `openrc`, `rc-service`, `rc-status`, and `rc-update`
- wire positional and flag value completions for common OpenRC workflows

## Validation
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./pkg/actions/tools/openrc ./completers/common/openrc_completer/... ./completers/common/rc-service_completer/... ./completers/common/rc-status_completer/... ./completers/common/rc-update_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/openrc_completer/cmd/*.go completers/common/rc-service_completer/cmd/*.go completers/common/rc-status_completer/cmd/*.go completers/common/rc-update_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/carapace ./cmd/carapace/cmd/completers`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- `/tmp/codex-go-toolchain/bin/carapace --list | rg 'openrc|rc-service|rc-status|rc-update'`
- `git diff --check`