### PR TITLE
Add iwctl completer

### DIFF
--- a/completers/common/iwctl_completer/cmd/root.go
+++ b/completers/common/iwctl_completer/cmd/root.go
@@ -1,0 +1,343 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/iwctl"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "iwctl [flags] [commands]",
+	Short: "Internet wireless control utility",
+	Long:  "https://archive.kernel.org/oldwiki/iwd.wiki.kernel.org/",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("dont-ask", "v", false, "Don't ask for missing credentials")
+	rootCmd.Flags().BoolP("help", "h", false, "Show help message and exit")
+	rootCmd.Flags().StringP("passphrase", "P", "", "Provide passphrase")
+	rootCmd.Flags().StringP("password", "p", "", "Provide password")
+	rootCmd.Flags().StringP("username", "u", "", "Provide username")
+
+	rootCmd.AddCommand(adapterCmd)
+	rootCmd.AddCommand(adHocCmd)
+	rootCmd.AddCommand(apCmd)
+	rootCmd.AddCommand(debugCmd)
+	rootCmd.AddCommand(deviceCmd)
+	rootCmd.AddCommand(dppCmd)
+	rootCmd.AddCommand(exitCmd)
+	rootCmd.AddCommand(helpCmd)
+	rootCmd.AddCommand(knownNetworksCmd)
+	rootCmd.AddCommand(pkexCmd)
+	rootCmd.AddCommand(quitCmd)
+	rootCmd.AddCommand(stationCmd)
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(wscCmd)
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"passphrase": carapace.ActionValues(),
+		"password":   carapace.ActionValues(),
+		"username":   carapace.ActionValues(),
+	})
+}
+
+var adapterCmd = &cobra.Command{
+	Use:   "adapter",
+	Short: "manage adapters",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var adHocCmd = &cobra.Command{
+	Use:   "ad-hoc",
+	Short: "manage ad-hoc networks",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var apCmd = &cobra.Command{
+	Use:   "ap",
+	Short: "manage access points",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var debugCmd = &cobra.Command{
+	Use:   "debug",
+	Short: "manage station debug functions",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "manage devices",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var dppCmd = &cobra.Command{
+	Use:   "dpp",
+	Short: "manage device provisioning",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var exitCmd = &cobra.Command{
+	Use:   "exit",
+	Short: "exit interactive mode",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "display help",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var knownNetworksCmd = &cobra.Command{
+	Use:   "known-networks",
+	Short: "manage known networks",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pkexCmd = &cobra.Command{
+	Use:   "pkex",
+	Short: "manage shared code device provisioning",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var quitCmd = &cobra.Command{
+	Use:   "quit",
+	Short: "quit interactive mode",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var stationCmd = &cobra.Command{
+	Use:   "station",
+	Short: "manage stations",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "display version",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var wscCmd = &cobra.Command{
+	Use:   "wsc",
+	Short: "manage Wi-Fi Simple Configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(adapterCmd).Standalone()
+	carapace.Gen(adapterCmd).PositionalCompletion(
+		withList(iwctl.ActionAdapters(), "list adapters"),
+		afterEntity(commands(
+			"show", "show adapter info",
+			"set-property", "set property",
+		)),
+		propertyAfter("set-property", iwctl.ActionAdapterProperties()),
+		propertyValueAfter("set-property", 2),
+	)
+
+	carapace.Gen(deviceCmd).Standalone()
+	carapace.Gen(deviceCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list devices"),
+		afterEntity(commands(
+			"show", "show device info",
+			"set-property", "set property",
+		)),
+		propertyAfter("set-property", iwctl.ActionDeviceProperties()),
+		propertyValueAfter("set-property", 2),
+	)
+
+	carapace.Gen(knownNetworksCmd).Standalone()
+	carapace.Gen(knownNetworksCmd).PositionalCompletion(
+		withList(iwctl.ActionKnownNetworks(), "list known networks"),
+		afterEntity(commands(
+			"forget", "forget known network",
+			"show", "show known network",
+			"set-property", "set property",
+		)),
+		propertyAfter("set-property", iwctl.ActionKnownNetworkProperties()),
+		propertyValueAfter("set-property", 2),
+	)
+
+	carapace.Gen(stationCmd).Standalone()
+	carapace.Gen(stationCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list devices in station mode"),
+		afterEntity(commands(
+			"connect", "connect to network",
+			"connect-hidden", "connect to hidden network",
+			"disconnect", "disconnect",
+			"get-bsses", "get BSSes for a network",
+			"get-hidden-access-points", "get hidden access points",
+			"get-networks", "get networks",
+			"scan", "scan for networks",
+			"show", "show station info",
+		)),
+		stationArgument(),
+		stationSecurityArgument(),
+	)
+
+	carapace.Gen(apCmd).Standalone()
+	carapace.Gen(apCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list devices in AP mode"),
+		afterEntity(commands(
+			"get-networks", "get network list after scanning",
+			"scan", "start an AP scan",
+			"show", "show AP info",
+			"start", "start an access point",
+			"start-profile", "start an access point from a profile",
+			"stop", "stop a started access point",
+		)),
+	)
+
+	carapace.Gen(adHocCmd).Standalone()
+	carapace.Gen(adHocCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list devices in ad-hoc mode"),
+		afterEntity(commands(
+			"start", "start or join an ad-hoc network",
+			"start_open", "start or join an open ad-hoc network",
+			"stop", "leave an ad-hoc network",
+		)),
+	)
+
+	carapace.Gen(dppCmd).Standalone()
+	carapace.Gen(dppCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list DPP-capable devices"),
+		afterEntity(commands(
+			"show", "show DPP state",
+			"start-configurator", "start a DPP configurator",
+			"start-enrollee", "start a DPP enrollee",
+			"stop", "abort DPP operations",
+		)),
+	)
+
+	carapace.Gen(pkexCmd).Standalone()
+	carapace.Gen(pkexCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list shared code capable devices"),
+		afterEntity(commands(
+			"configure", "start a shared code configurator",
+			"enroll", "start a shared code enrollee",
+			"show", "show shared code state",
+			"stop", "abort shared code operations",
+		)),
+	)
+
+	carapace.Gen(wscCmd).Standalone()
+	carapace.Gen(wscCmd).PositionalCompletion(
+		withList(iwctl.ActionDevices(), "list WSC-capable devices"),
+		afterEntity(commands(
+			"cancel", "abort WSC operations",
+			"push-button", "push button mode",
+			"start-pin", "PIN mode with generated PIN",
+			"start-user-pin", "PIN mode",
+		)),
+	)
+
+	carapace.Gen(debugCmd).Standalone()
+	carapace.Gen(debugCmd).PositionalCompletion(
+		iwctl.ActionDevices(),
+		commands(
+			"autoconnect", "set AutoConnect property",
+			"connect", "connect to a specific BSS",
+			"get-networks", "get networks",
+			"roam", "roam to a BSS",
+		),
+		debugArgument(),
+	)
+}
+
+func commands(values ...string) carapace.Action {
+	return carapace.ActionValuesDescribed(values...)
+}
+
+func withList(action carapace.Action, description string) carapace.Action {
+	return carapace.Batch(
+		carapace.ActionValuesDescribed("list", description),
+		action,
+	).ToA()
+}
+
+func afterEntity(action carapace.Action) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) > 0 && c.Args[0] == "list" {
+			return carapace.ActionValues()
+		}
+		return action
+	})
+}
+
+func propertyAfter(command string, action carapace.Action) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) > 1 && c.Args[1] == command {
+			return action
+		}
+		return carapace.ActionValues()
+	})
+}
+
+func propertyValueAfter(command string, propertyIndex int) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) > propertyIndex && c.Args[1] == command {
+			return iwctl.ActionPropertyValues(c.Args[propertyIndex])
+		}
+		return carapace.ActionValues()
+	})
+}
+
+func stationArgument() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) < 2 {
+			return carapace.ActionValues()
+		}
+
+		switch c.Args[1] {
+		case "connect", "get-bsses":
+			return iwctl.ActionNetworks(c.Args[0])
+		case "get-hidden-access-points":
+			return carapace.ActionValues("rssi-dbms")
+		case "get-networks":
+			return carapace.ActionValues("rssi-dbms", "rssi-bars")
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+func stationSecurityArgument() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) < 2 {
+			return carapace.ActionValues()
+		}
+
+		switch c.Args[1] {
+		case "connect", "get-bsses":
+			return iwctl.ActionSecurityTypes()
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+func debugArgument() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) < 2 {
+			return carapace.ActionValues()
+		}
+
+		switch c.Args[1] {
+		case "autoconnect":
+			return carapace.ActionValues("on", "off")
+		case "connect", "roam":
+			return iwctl.ActionBSSes(c.Args[0])
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}

--- a/completers/common/iwctl_completer/main.go
+++ b/completers/common/iwctl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/iwctl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/iwctl/iwctl.go
+++ b/pkg/actions/tools/iwctl/iwctl.go
@@ -1,0 +1,119 @@
+package iwctl
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionAdapters completes IWD adapter names.
+func ActionAdapters() carapace.Action {
+	return actionTableNames("adapter", "list")
+}
+
+// ActionDevices completes IWD wireless device names.
+func ActionDevices() carapace.Action {
+	return actionTableNames("device", "list")
+}
+
+// ActionKnownNetworks completes saved network names.
+func ActionKnownNetworks() carapace.Action {
+	return actionTableNames("known-networks", "list")
+}
+
+// ActionNetworks completes networks visible to a station.
+func ActionNetworks(device string) carapace.Action {
+	if device == "" {
+		return carapace.ActionValues()
+	}
+	return actionTableNames("station", device, "get-networks")
+}
+
+// ActionBSSes completes BSS addresses visible to a station.
+func ActionBSSes(device string) carapace.Action {
+	if device == "" {
+		return carapace.ActionValues()
+	}
+	return actionTableNames("station", device, "get-bsses")
+}
+
+// ActionSecurityTypes completes network security type arguments.
+func ActionSecurityTypes() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"open", "open network",
+		"psk", "pre-shared key network",
+		"8021x", "802.1X network",
+	)
+}
+
+// ActionDeviceProperties completes writable device properties.
+func ActionDeviceProperties() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"Mode", "operation mode",
+		"Powered", "powered state",
+	)
+}
+
+// ActionAdapterProperties completes writable adapter properties.
+func ActionAdapterProperties() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"Powered", "powered state",
+	)
+}
+
+// ActionKnownNetworkProperties completes writable known-network properties.
+func ActionKnownNetworkProperties() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"AutoConnect", "automatic connection state",
+	)
+}
+
+// ActionPropertyValues completes values for writable properties.
+func ActionPropertyValues(property string) carapace.Action {
+	switch property {
+	case "AutoConnect":
+		return carapace.ActionValues("yes", "no")
+	case "Mode":
+		return carapace.ActionValues("ad-hoc", "ap", "station")
+	case "Powered":
+		return carapace.ActionValues("on", "off")
+	default:
+		return carapace.ActionValues()
+	}
+}
+
+func actionTableNames(args ...string) carapace.Action {
+	return carapace.ActionExecCommand("iwctl", args...)(func(output []byte) carapace.Action {
+		return carapace.ActionValues(parseTableNames(output)...)
+	})
+}
+
+func parseTableNames(output []byte) []string {
+	lines := strings.Split(string(output), "\n")
+	names := make([]string, 0)
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.Contains(line, "---") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) == 0 || skipFirstField(fields[0]) {
+			continue
+		}
+
+		names = append(names, fields[0])
+	}
+
+	return names
+}
+
+func skipFirstField(field string) bool {
+	switch field {
+	case "Name", "Address", "Adapter", "Adapters", "Available", "Devices", "Known", "Networks":
+		return true
+	default:
+		return strings.HasPrefix(field, "[iwd]")
+	}
+}


### PR DESCRIPTION
Closes #3355.

## Summary
- add shared `iwctl` actions for adapters, devices, known networks, station networks, BSSes, security types, and writable properties
- add a native `iwctl` completer covering IWD command families from the upstream client sources
- wire global flags, top-level commands, family commands, positional completions, and writable property values

## Validation
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH gofmt -w pkg/actions/tools/iwctl/iwctl.go completers/common/iwctl_completer/main.go completers/common/iwctl_completer/cmd/root.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./pkg/actions/tools/iwctl ./completers/common/iwctl_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/iwctl_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/carapace ./cmd/carapace/cmd/completers`
- `/tmp/codex-go-toolchain/bin/carapace --list | rg 'iwctl'`
- `git diff --check`