### PR TITLE
Add talosctl completer

### DIFF
--- a/completers/common/talosctl_completer/cmd/root.go
+++ b/completers/common/talosctl_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "talosctl",
+	Short:              "A CLI for out-of-band management of Kubernetes nodes created by Talos",
+	Long:               "https://docs.siderolabs.com/talos/latest/learn-more/talosctl",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCobra("talosctl"),
+	)
+}

--- a/completers/common/talosctl_completer/main.go
+++ b/completers/common/talosctl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/talosctl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Closes #3206.

## Summary
- add a native `talosctl` completer entry using the Cobra bridge
- disable local flag parsing so completion is delegated to `talosctl __complete`
- register the completer with the Talos documentation URL

## Validation
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH gofmt -w completers/common/talosctl_completer/main.go completers/common/talosctl_completer/cmd/root.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./completers/common/talosctl_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/talosctl_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/carapace ./cmd/carapace/cmd/completers`
- `/tmp/codex-go-toolchain/bin/carapace --list | rg 'talosctl'`
- `PATH=/tmp/codex-talos:/tmp/codex-go-toolchain/go/bin:$PATH go run ./completers/common/talosctl_completer _carapace bash talosctl ''` against downloaded `talosctl` v1.13.2
- `git diff --check`