### PR TITLE
complete changed files for git checkout

### DIFF
--- a/completers/common/git_completer/cmd/checkout.go
+++ b/completers/common/git_completer/cmd/checkout.go
@@ -65,7 +65,10 @@ func init() {
 			if strings.HasPrefix(c.Value, ".") {
 				return git.ActionRefDiffs()
 			}
-			return git.ActionRefs(git.RefOption{}.Default())
+			return carapace.Batch(
+				git.ActionRefs(git.RefOption{}.Default()),
+				git.ActionRefDiffs(),
+			).ToA()
 		}),
 	)
 


### PR DESCRIPTION
## Summary
- include changed files in the first `git checkout` positional completion alongside refs
- preserve the existing `./` path-only behavior for explicit relative paths

Closes #3310

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH gofmt -w completers/common/git_completer/cmd/checkout.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./completers/common/git_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/git_completer/cmd/checkout.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./completers/common/git_completer/... ./cmd/carapace ./cmd/carapace/cmd/completers`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- live temp-repo probes with a modified `AGENTS.md`: `/tmp/codex-git-completer _carapace bash git checkout AG` and `/tmp/codex-git-completer _carapace bash git checkout ''`
- `git diff --check`