### PR TITLE
complete systemctl unit files

### DIFF
--- a/completers/linux/systemctl_completer/cmd/action/action.go
+++ b/completers/linux/systemctl_completer/cmd/action/action.go
@@ -37,6 +37,21 @@ func ActionUnits(cmd *cobra.Command) carapace.Action {
 	})
 }
 
+func ActionUnitFiles(cmd *cobra.Command) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		opts := systemctl.UnitFileOpts{}.Default()
+		opts.User = userFlag(cmd)
+		return systemctl.ActionUnitFiles(opts)
+	})
+}
+
+func ActionUnitsAndFiles(cmd *cobra.Command) carapace.Action {
+	return carapace.Batch(
+		ActionUnits(cmd),
+		ActionUnitFiles(cmd),
+	).ToA()
+}
+
 func ActionEnvironmentVariables(cmd *cobra.Command) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 		return systemctl.ActionEnvironmentVariables(userFlag(cmd))

--- a/completers/linux/systemctl_completer/cmd/disable.go
+++ b/completers/linux/systemctl_completer/cmd/disable.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(disableCmd)
 
 	carapace.Gen(disableCmd).PositionalAnyCompletion(
-		action.ActionUnits(disableCmd).FilterArgs(),
+		action.ActionUnitFiles(disableCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/enable.go
+++ b/completers/linux/systemctl_completer/cmd/enable.go
@@ -20,7 +20,7 @@ func init() {
 
 	carapace.Gen(enableCmd).PositionalAnyCompletion(
 		carapace.Batch(
-			action.ActionUnits(enableCmd).FilterArgs(),
+			action.ActionUnitFiles(enableCmd).FilterArgs(),
 			carapace.ActionFiles(),
 		).ToA(),
 	)

--- a/completers/linux/systemctl_completer/cmd/isEnabled.go
+++ b/completers/linux/systemctl_completer/cmd/isEnabled.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(isEnabledCmd)
 
 	carapace.Gen(isEnabledCmd).PositionalAnyCompletion(
-		action.ActionUnits(isEnabledCmd).FilterArgs(),
+		action.ActionUnitFiles(isEnabledCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/mask.go
+++ b/completers/linux/systemctl_completer/cmd/mask.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(maskCmd)
 
 	carapace.Gen(maskCmd).PositionalAnyCompletion(
-		action.ActionUnits(maskCmd).FilterArgs(),
+		action.ActionUnitFiles(maskCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/preset.go
+++ b/completers/linux/systemctl_completer/cmd/preset.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(presetCmd)
 
 	carapace.Gen(presetCmd).PositionalAnyCompletion(
-		action.ActionUnits(presetCmd).FilterArgs(),
+		action.ActionUnitFiles(presetCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/reenable.go
+++ b/completers/linux/systemctl_completer/cmd/reenable.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(reenableCmd)
 
 	carapace.Gen(reenableCmd).PositionalAnyCompletion(
-		action.ActionUnits(reenableCmd).FilterArgs(),
+		action.ActionUnitFiles(reenableCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/restart.go
+++ b/completers/linux/systemctl_completer/cmd/restart.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(restartCmd)
 
 	carapace.Gen(restartCmd).PositionalAnyCompletion(
-		action.ActionUnits(restartCmd).FilterArgs(),
+		action.ActionUnitsAndFiles(restartCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/start.go
+++ b/completers/linux/systemctl_completer/cmd/start.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 
 	carapace.Gen(startCmd).PositionalAnyCompletion(
-		action.ActionUnits(startCmd).FilterArgs(),
+		action.ActionUnitsAndFiles(startCmd).FilterArgs(),
 	)
 }

--- a/completers/linux/systemctl_completer/cmd/unmask.go
+++ b/completers/linux/systemctl_completer/cmd/unmask.go
@@ -19,6 +19,6 @@ func init() {
 	rootCmd.AddCommand(unmaskCmd)
 
 	carapace.Gen(unmaskCmd).PositionalAnyCompletion(
-		action.ActionUnits(unmaskCmd).FilterArgs(),
+		action.ActionUnitFiles(unmaskCmd).FilterArgs(),
 	)
 }


### PR DESCRIPTION
## Summary
- add shared `systemctl` unit-file completion helper honoring `--user`
- include installed unit files for `start`/`restart` so unloaded services can complete
- use unit-file completions for unit-file commands like `enable`, `disable`, `is-enabled`, `mask`, `preset`, and `reenable`

Closes #2829

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH gofmt -w completers/linux/systemctl_completer/cmd/action/action.go completers/linux/systemctl_completer/cmd/start.go completers/linux/systemctl_completer/cmd/restart.go completers/linux/systemctl_completer/cmd/enable.go completers/linux/systemctl_completer/cmd/disable.go completers/linux/systemctl_completer/cmd/isEnabled.go completers/linux/systemctl_completer/cmd/reenable.go completers/linux/systemctl_completer/cmd/preset.go completers/linux/systemctl_completer/cmd/mask.go completers/linux/systemctl_completer/cmd/unmask.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./pkg/actions/tools/systemctl ./completers/linux/systemctl_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/linux/systemctl_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./completers/linux/systemctl_completer/... ./pkg/actions/tools/systemctl ./cmd/carapace ./cmd/carapace/cmd/completers`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- live local probes with `/tmp/codex-systemctl-completer _carapace bash systemctl start bolt`, `disable bolt`, and `status acp`
- `git diff --check`