### PR TITLE
complete nix installables from flakes

### DIFF
--- a/pkg/actions/tools/nix/installables.go
+++ b/pkg/actions/tools/nix/installables.go
@@ -1,46 +1,12 @@
 package nix
 
 import (
-	"strings"
-
 	"github.com/carapace-sh/carapace"
 )
 
-// ActionInstallables completes nix packages and flakes
+// ActionInstallables completes Nix installables from flake refs.
 //
-// An installable nix derivation can either be a nix package (legacyPackages)
-// or a nixosModules output of a flake. There is no completion support implemented
-// for flake outputs due to the processing time required, so ActionInstallables
-// completes packages from the global/system/user channels available and flake names from the
-// global/system/user registry
+// Examples include flake references like `nixpkgs#hello`.
 func ActionInstallables() carapace.Action {
-	return carapace.ActionMultiParts("#", func(c carapace.Context) carapace.Action {
-		switch len(c.Parts) {
-		case 0:
-			return carapace.Batch(
-				ActionFlakes(),
-				carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
-					switch len(c.Parts) {
-					case 0:
-						return ActionLocalChannels().Suffix("#")
-					case 1:
-						return carapace.ActionMessage("TODO: support branch completion") // TODO support branch completion
-					default:
-						return carapace.ActionValues()
-					}
-				}),
-			).ToA()
-
-		case 1:
-			switch c.Parts[0] {
-			case ".":
-				return ActionFlakeAttributes(".")
-			default:
-				return ActionPackages(strings.SplitN(c.Parts[0], "/", 2)[0])
-			}
-
-		default:
-			return carapace.ActionValues()
-		}
-	})
+	return ActionFlakeRefs()
 }

--- a/pkg/actions/tools/nix/installables_test.go
+++ b/pkg/actions/tools/nix/installables_test.go
@@ -1,0 +1,46 @@
+package nix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/sandbox"
+)
+
+func TestActionInstallablesUsesFlakeAttributes(t *testing.T) {
+	binDir := t.TempDir()
+	nix := filepath.Join(binDir, "nix")
+	err := os.WriteFile(nix, []byte(`#!/bin/sh
+case "$*" in
+  "registry list")
+    printf 'global flake:nixpkgs github:NixOS/nixpkgs/nixpkgs-unstable\n'
+    ;;
+  "build nixpkgs")
+    printf 'attrs\nnixpkgs\n'
+    ;;
+  "build nixpkgs#he")
+    printf 'attrs\nnixpkgs#hello\nnixpkgs#helix\n'
+    ;;
+  *)
+    printf 'unexpected nix arguments: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`), 0o755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sandbox.Action(t, ActionInstallables)(func(s *sandbox.Sandbox) {
+		s.Run("").
+			Expect(carapace.ActionValuesDescribed(
+				"nixpkgs", "github:NixOS/nixpkgs/nixpkgs-unstable",
+			).Tag("flakes").Suffix("#").NoSpace('#'))
+
+		s.Run("nixpkgs#he").
+			Expect(carapace.ActionValues("helix", "hello").Prefix("nixpkgs#").NoSpace('#'))
+	})
+}


### PR DESCRIPTION
Closes #3343
Closes #2913

## Summary
- route `ActionInstallables` through the existing flake-ref completion path instead of local channel/package database completion
- avoid invoking `nix-channel` / `~/.nix-defexpr` when completing `nixpkgs#...` installables
- add a regression test with a fake `nix` command for registry and flake attribute completion

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./pkg/actions/tools/nix`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./completers/common/nix_completer/... ./pkg/actions/tools/nix ./cmd/carapace ./cmd/carapace/cmd/completers`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/nix_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build -o /tmp/codex-nix-completer ./completers/common/nix_completer`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- fake-`nix` live probe: `/tmp/codex-nix-completer _carapace bash nix shell nixpkgs#` returned `nixpkgs#hello` and `nixpkgs#zellij`
- `git diff --check`