### PR TITLE
complete paru root new flags

### DIFF
--- a/completers/linux/paru_completer/cmd/root.go
+++ b/completers/linux/paru_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/linux/paru_completer/cmd/common"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/paru"
 	"github.com/carapace-sh/carapace-bin/pkg/util/embed"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ func init() {
 	rootCmd.Flags().Bool("gendb", false, "Generates development package DB used for updating")
 	rootCmd.Flags().BoolP("help", "h", false, "show help")
 	rootCmd.Flags().BoolP("version", "V", false, "show version")
+	common.AddNewFlags(rootCmd)
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {

--- a/pkg/util/embed/flag.go
+++ b/pkg/util/embed/flag.go
@@ -32,16 +32,8 @@ func subcommandsAsFlags(cmd *cobra.Command, shorthandOnly bool, subcommands ...*
 			}
 		}
 
-		switch {
-		case strings.HasPrefix(args[0], "--"):
-			flags.Parse(args[:1])
-		case strings.HasPrefix(args[0], "-") && len(args[0]) > 1:
-			switch {
-			case nonposix:
-				flags.Parse([]string{args[0]})
-			default:
-				flags.Parse([]string{args[0][:2]})
-			}
+		if arg, ok := findSubcommandFlagArg(args, cmd.Flags(), flags, nonposix); ok {
+			flags.Parse([]string{arg})
 		}
 
 		var subcommand *cobra.Command
@@ -64,6 +56,45 @@ func subcommandsAsFlags(cmd *cobra.Command, shorthandOnly bool, subcommands ...*
 			cmd.Flags().AddFlagSet(flags)
 		}
 	})
+}
+
+func findSubcommandFlagArg(args []string, rootFlags, subcommandFlags *pflag.FlagSet, nonposix bool) (string, bool) {
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+
+		switch {
+		case strings.HasPrefix(arg, "--"):
+			name := strings.TrimPrefix(arg, "--")
+			if before, _, ok := strings.Cut(name, "="); ok {
+				name = before
+			}
+
+			if subcommandFlags.Lookup(name) != nil {
+				return "--" + name, true
+			}
+			if flag := rootFlags.Lookup(name); flag != nil && !strings.Contains(arg, "=") && flag.Value.Type() != "bool" {
+				index++
+			}
+
+		case strings.HasPrefix(arg, "-") && len(arg) > 1:
+			shorthand := arg[1:]
+			if !nonposix {
+				shorthand = arg[1:2]
+			}
+
+			if subcommandFlags.ShorthandLookup(shorthand) != nil {
+				return "-" + shorthand, true
+			}
+			if flag := rootFlags.ShorthandLookup(arg[1:2]); flag != nil && len(arg) == 2 && flag.Value.Type() != "bool" {
+				index++
+			}
+
+		default:
+			return "", false
+		}
+	}
+
+	return "", false
 }
 
 // SubcommandsAsFlags embeds subcommands as flags (e.g. `pacman -Syu` where `S` is actually a subcommand).

--- a/pkg/util/embed/flag_test.go
+++ b/pkg/util/embed/flag_test.go
@@ -1,0 +1,61 @@
+package embed
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestFindSubcommandFlagArgSkipsRootFlagValues(t *testing.T) {
+	rootFlags := pflag.NewFlagSet("root", pflag.ContinueOnError)
+	rootFlags.String("sudoflags", "", "Pass arguments to sudo")
+	rootFlags.BoolP("verbose", "v", false, "be verbose")
+
+	subcommandFlags := pflag.NewFlagSet("subcommands", pflag.ContinueOnError)
+	subcommandFlags.BoolP("query", "Q", false, "Query the package database")
+	subcommandFlags.BoolP("sync", "S", false, "Synchronize packages")
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "short subcommand after root string flag",
+			args: []string{"--sudoflags", "-S", "-Q", "--sudo"},
+			want: "-Q",
+		},
+		{
+			name: "long subcommand after root string flag with equals",
+			args: []string{"--sudoflags=-S", "--query", "--sudo"},
+			want: "--query",
+		},
+		{
+			name: "combined short subcommand",
+			args: []string{"-v", "-Syu", "--needed"},
+			want: "-S",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := findSubcommandFlagArg(tt.args, rootFlags, subcommandFlags, false)
+			if !ok {
+				t.Fatal("expected subcommand flag")
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFindSubcommandFlagArgStopsAtPositional(t *testing.T) {
+	rootFlags := pflag.NewFlagSet("root", pflag.ContinueOnError)
+	subcommandFlags := pflag.NewFlagSet("subcommands", pflag.ContinueOnError)
+	subcommandFlags.BoolP("query", "Q", false, "Query the package database")
+
+	if got, ok := findSubcommandFlagArg([]string{"package", "-Q"}, rootFlags, subcommandFlags, false); ok {
+		t.Fatalf("expected no subcommand flag, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2963

## Summary
- register paru's shared new/configuration flags on the root command so options like `--sudoflags` complete before a flag-style subcommand
- teach embedded flag-style subcommands to skip known root flag values and find the operation flag later in the argument list
- add helper coverage for root flag values, long operation flags, bundled short operations, and stopping at real positionals

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./pkg/util/embed ./completers/linux/paru_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./pkg/util/embed ./completers/linux/paru_completer/... ./completers/linux/pacman_completer/... ./completers/linux/yay_completer/... ./cmd/carapace ./cmd/carapace/cmd/completers`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/linux/paru_completer/cmd/*.go`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build -o /tmp/codex-paru-completer ./completers/linux/paru_completer`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH GOBIN=/tmp/codex-go-toolchain/bin go install -tags force_all ./cmd/carapace`
- live probes for `paru --sudo`, `paru --sudoflags -S -Q --su`, `paru -Q --su`, and `paru -Syu --needed`
- `git diff --check`