### PR TITLE
Add zfs and zpool completers

### DIFF
--- a/completers/common/zfs_completer/cmd/root.go
+++ b/completers/common/zfs_completer/cmd/root.go
@@ -1,0 +1,401 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/zfs"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "zfs",
+	Short: "configure ZFS datasets",
+	Long:  "https://openzfs.github.io/openzfs-docs/man/v2.4/8/zfs.8.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("?", "?", false, "display help")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	versionCmd := newCommand("version", "display ZFS version")
+	versionCmd.Flags().BoolS("j", "j", false, "display JSON")
+
+	listCmd := newCommand("list", "list properties of datasets")
+	boolFlag(listCmd, "H", "scripted mode")
+	boolFlag(listCmd, "p", "display exact numeric values")
+	boolFlag(listCmd, "r", "recurse into children")
+	boolFlag(listCmd, "j", "display JSON")
+	listCmd.Flags().Bool("json-int", false, "display JSON numbers as integers")
+	stringFlag(listCmd, "d", "limit recursion depth")
+	stringFlag(listCmd, "o", "properties to display")
+	stringFlag(listCmd, "s", "sort by property")
+	stringFlag(listCmd, "S", "sort by property in reverse")
+	stringFlag(listCmd, "t", "dataset types to display")
+	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{
+		"S": zfs.ActionDatasetProperties(),
+		"o": propertyListAction(zfs.ActionDatasetProperties()),
+		"s": zfs.ActionDatasetProperties(),
+		"t": zfs.ActionDatasetTypes().UniqueList(","),
+	})
+	carapace.Gen(listCmd).PositionalAnyCompletion(zfs.ActionDatasets("all"))
+
+	createCmd := newCommand("create", "create a new ZFS file system or volume")
+	boolFlag(createCmd, "p", "create parent datasets")
+	boolFlag(createCmd, "s", "create sparse volume")
+	boolFlag(createCmd, "u", "do not mount the created file system")
+	stringFlag(createCmd, "o", "set a dataset property")
+	stringFlag(createCmd, "V", "create a volume of the given size")
+	carapace.Gen(createCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(createCmd).PositionalCompletion(
+		zfs.ActionDatasets("filesystem", "volume").NoSpace(),
+	)
+
+	destroyCmd := newCommand("destroy", "destroy datasets, snapshots, or bookmarks")
+	boolFlag(destroyCmd, "d", "defer snapshot deletion")
+	boolFlag(destroyCmd, "f", "force unmount")
+	boolFlag(destroyCmd, "n", "dry run")
+	boolFlag(destroyCmd, "p", "print machine-parsable output")
+	boolFlag(destroyCmd, "r", "destroy descendants")
+	boolFlag(destroyCmd, "R", "destroy dependents")
+	boolFlag(destroyCmd, "v", "print verbose information")
+	carapace.Gen(destroyCmd).PositionalAnyCompletion(zfs.ActionDatasets("all"))
+
+	renameCmd := newCommand("rename", "rename a dataset or snapshot")
+	boolFlag(renameCmd, "f", "force unmount")
+	boolFlag(renameCmd, "p", "create parent datasets")
+	boolFlag(renameCmd, "r", "recursively rename snapshots")
+	boolFlag(renameCmd, "u", "do not remount")
+	carapace.Gen(renameCmd).PositionalCompletion(
+		zfs.ActionDatasets("all"),
+		zfs.ActionDatasets("filesystem", "volume").NoSpace(),
+	)
+
+	upgradeCmd := newCommand("upgrade", "manage upgrading the on-disk dataset version")
+	boolFlag(upgradeCmd, "a", "upgrade all datasets")
+	boolFlag(upgradeCmd, "r", "upgrade descendants")
+	boolFlag(upgradeCmd, "v", "display supported versions")
+	carapace.Gen(upgradeCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	snapshotCmd := newCommand("snapshot", "create snapshots")
+	boolFlag(snapshotCmd, "r", "recursively create snapshots")
+	stringFlag(snapshotCmd, "o", "set a snapshot property")
+	carapace.Gen(snapshotCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(snapshotCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume").NoSpace().Suffix("@"))
+
+	rollbackCmd := newCommand("rollback", "roll back to a previous snapshot")
+	boolFlag(rollbackCmd, "f", "force unmount")
+	boolFlag(rollbackCmd, "R", "destroy later snapshots and clones")
+	boolFlag(rollbackCmd, "r", "destroy later snapshots")
+	carapace.Gen(rollbackCmd).PositionalCompletion(zfs.ActionSnapshots())
+
+	holdCmd := newCommand("hold", "add a hold reference to snapshots")
+	boolFlag(holdCmd, "r", "recursively hold snapshots")
+	carapace.Gen(holdCmd).PositionalAnyCompletion(positionalByIndex(
+		carapace.ActionValues(),
+		zfs.ActionSnapshots(),
+	))
+
+	holdsCmd := newCommand("holds", "list hold references on snapshots")
+	boolFlag(holdsCmd, "H", "scripted mode")
+	boolFlag(holdsCmd, "r", "recursively list holds")
+	carapace.Gen(holdsCmd).PositionalAnyCompletion(zfs.ActionSnapshots())
+
+	releaseCmd := newCommand("release", "remove a hold reference from snapshots")
+	boolFlag(releaseCmd, "r", "recursively release holds")
+	carapace.Gen(releaseCmd).PositionalAnyCompletion(positionalByIndex(
+		carapace.ActionValues(),
+		zfs.ActionSnapshots(),
+	))
+
+	diffCmd := newCommand("diff", "display differences between snapshots")
+	boolFlag(diffCmd, "F", "display file type")
+	boolFlag(diffCmd, "H", "scripted mode")
+	boolFlag(diffCmd, "t", "display path change time")
+	carapace.Gen(diffCmd).PositionalAnyCompletion(zfs.ActionSnapshots())
+
+	cloneCmd := newCommand("clone", "create a writable clone of a snapshot")
+	boolFlag(cloneCmd, "p", "create parent datasets")
+	stringFlag(cloneCmd, "o", "set a dataset property")
+	carapace.Gen(cloneCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(cloneCmd).PositionalCompletion(
+		zfs.ActionSnapshots(),
+		zfs.ActionDatasets("filesystem", "volume").NoSpace(),
+	)
+
+	promoteCmd := newCommand("promote", "promote a clone dataset")
+	carapace.Gen(promoteCmd).PositionalCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	sendCmd := newCommand("send", "generate a send stream")
+	boolFlag(sendCmd, "D", "deduplicate the stream")
+	boolFlag(sendCmd, "L", "allow large blocks")
+	boolFlag(sendCmd, "P", "print parsable stream package size")
+	boolFlag(sendCmd, "R", "replicate descendants")
+	boolFlag(sendCmd, "c", "write compressed data")
+	boolFlag(sendCmd, "e", "embed blocks")
+	boolFlag(sendCmd, "h", "include holds")
+	boolFlag(sendCmd, "n", "dry run")
+	boolFlag(sendCmd, "p", "include properties")
+	boolFlag(sendCmd, "s", "resume interrupted send")
+	boolFlag(sendCmd, "v", "verbose output")
+	boolFlag(sendCmd, "w", "raw encrypted send")
+	stringFlag(sendCmd, "i", "incremental source")
+	stringFlag(sendCmd, "I", "incremental source with intermediates")
+	stringFlag(sendCmd, "t", "resume token")
+	carapace.Gen(sendCmd).FlagCompletion(carapace.ActionMap{
+		"I": carapace.Batch(zfs.ActionSnapshots(), zfs.ActionBookmarks()).ToA(),
+		"i": carapace.Batch(zfs.ActionSnapshots(), zfs.ActionBookmarks()).ToA(),
+	})
+	carapace.Gen(sendCmd).PositionalCompletion(carapace.Batch(zfs.ActionSnapshots(), zfs.ActionBookmarks()).ToA())
+
+	receiveCmd := newCommand("receive", "receive a ZFS send stream", "recv")
+	boolFlag(receiveCmd, "F", "force rollback")
+	boolFlag(receiveCmd, "M", "force unmount")
+	boolFlag(receiveCmd, "d", "discard leading path components")
+	boolFlag(receiveCmd, "e", "discard all but the last path component")
+	boolFlag(receiveCmd, "n", "dry run")
+	boolFlag(receiveCmd, "s", "save partially received state")
+	boolFlag(receiveCmd, "u", "do not mount")
+	boolFlag(receiveCmd, "v", "verbose output")
+	stringFlag(receiveCmd, "o", "override a property")
+	stringFlag(receiveCmd, "x", "exclude a property")
+	carapace.Gen(receiveCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+		"x": zfs.ActionDatasetProperties(),
+	})
+	carapace.Gen(receiveCmd).PositionalCompletion(zfs.ActionDatasets("filesystem", "volume").NoSpace())
+
+	bookmarkCmd := newCommand("bookmark", "create a bookmark of a snapshot or bookmark")
+	carapace.Gen(bookmarkCmd).PositionalCompletion(
+		carapace.Batch(zfs.ActionSnapshots(), zfs.ActionBookmarks()).ToA(),
+		zfs.ActionDatasets("filesystem", "volume").NoSpace().Suffix("#"),
+	)
+
+	redactCmd := newCommand("redact", "generate a redaction bookmark")
+	carapace.Gen(redactCmd).PositionalAnyCompletion(carapace.Batch(zfs.ActionSnapshots(), zfs.ActionBookmarks()).ToA())
+
+	getCmd := newCommand("get", "display dataset properties")
+	boolFlag(getCmd, "H", "scripted mode")
+	boolFlag(getCmd, "p", "display exact numeric values")
+	boolFlag(getCmd, "r", "recurse into children")
+	stringFlag(getCmd, "d", "limit recursion depth")
+	stringFlag(getCmd, "o", "output fields")
+	stringFlag(getCmd, "s", "property sources")
+	stringFlag(getCmd, "t", "dataset types")
+	carapace.Gen(getCmd).FlagCompletion(carapace.ActionMap{
+		"o": zfs.ActionGetFields().UniqueList(","),
+		"s": zfs.ActionPropertySources().UniqueList(","),
+		"t": zfs.ActionDatasetTypes().UniqueList(","),
+	})
+	carapace.Gen(getCmd).PositionalAnyCompletion(positionalByIndex(
+		propertyListAction(zfs.ActionDatasetProperties()),
+		zfs.ActionDatasets("all"),
+	))
+
+	setCmd := newCommand("set", "set dataset properties")
+	carapace.Gen(setCmd).PositionalAnyCompletion(positionalByIndex(
+		propertyAssignmentAction(),
+		zfs.ActionDatasets("filesystem", "volume"),
+	))
+
+	inheritCmd := newCommand("inherit", "inherit a dataset property")
+	boolFlag(inheritCmd, "S", "revert to received value")
+	boolFlag(inheritCmd, "r", "recurse into children")
+	carapace.Gen(inheritCmd).PositionalAnyCompletion(positionalByIndex(
+		zfs.ActionDatasetProperties(),
+		zfs.ActionDatasets("filesystem", "volume"),
+	))
+
+	userspaceCmd := newSpaceCommand("userspace", "display user space accounting")
+	groupspaceCmd := newSpaceCommand("groupspace", "display group space accounting")
+	projectspaceCmd := newSpaceCommand("projectspace", "display project space accounting")
+	carapace.Gen(userspaceCmd).PositionalCompletion(zfs.ActionDatasets("filesystem", "snapshot"))
+	carapace.Gen(groupspaceCmd).PositionalCompletion(zfs.ActionDatasets("filesystem", "snapshot"))
+	carapace.Gen(projectspaceCmd).PositionalCompletion(zfs.ActionDatasets("filesystem", "snapshot"))
+
+	mountCmd := newCommand("mount", "mount ZFS file systems")
+	boolFlag(mountCmd, "O", "overlay mount")
+	boolFlag(mountCmd, "a", "mount all available file systems")
+	boolFlag(mountCmd, "l", "load keys for encrypted datasets")
+	boolFlag(mountCmd, "v", "verbose output")
+	stringFlag(mountCmd, "o", "temporary mount options")
+	carapace.Gen(mountCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem"))
+
+	unmountCmd := newCommand("unmount", "unmount ZFS file systems", "umount")
+	boolFlag(unmountCmd, "a", "unmount all ZFS file systems")
+	boolFlag(unmountCmd, "f", "force unmount")
+	boolFlag(unmountCmd, "u", "do not unload keys")
+	carapace.Gen(unmountCmd).PositionalAnyCompletion(carapace.Batch(
+		zfs.ActionDatasets("filesystem"),
+		carapace.ActionDirectories(),
+	).ToA())
+
+	shareCmd := newCommand("share", "share ZFS file systems")
+	boolFlag(shareCmd, "a", "share all file systems")
+	carapace.Gen(shareCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem"))
+
+	unshareCmd := newCommand("unshare", "unshare ZFS file systems")
+	boolFlag(unshareCmd, "a", "unshare all file systems")
+	carapace.Gen(unshareCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem"))
+
+	allowCmd := newCommand("allow", "delegate permissions on a dataset")
+	boolFlag(allowCmd, "c", "set create-time permissions")
+	boolFlag(allowCmd, "d", "set descendant permissions")
+	boolFlag(allowCmd, "e", "set everyone permissions")
+	boolFlag(allowCmd, "g", "set group permissions")
+	boolFlag(allowCmd, "l", "set local permissions")
+	boolFlag(allowCmd, "s", "define a permission set")
+	boolFlag(allowCmd, "u", "set user permissions")
+	carapace.Gen(allowCmd).PositionalAnyCompletion(carapace.Batch(
+		zfs.ActionPermissions(),
+		zfs.ActionDatasets("filesystem", "volume"),
+	).ToA())
+
+	unallowCmd := newCommand("unallow", "remove delegated permissions")
+	boolFlag(unallowCmd, "d", "remove descendant permissions")
+	boolFlag(unallowCmd, "e", "remove everyone permissions")
+	boolFlag(unallowCmd, "g", "remove group permissions")
+	boolFlag(unallowCmd, "l", "remove local permissions")
+	boolFlag(unallowCmd, "r", "remove permissions recursively")
+	boolFlag(unallowCmd, "u", "remove user permissions")
+	carapace.Gen(unallowCmd).PositionalAnyCompletion(carapace.Batch(
+		zfs.ActionPermissions(),
+		zfs.ActionDatasets("filesystem", "volume"),
+	).ToA())
+
+	changeKeyCmd := newCommand("change-key", "add or change an encryption key")
+	boolFlag(changeKeyCmd, "i", "inherit key location")
+	boolFlag(changeKeyCmd, "l", "load the key after changing it")
+	stringFlag(changeKeyCmd, "o", "set an encryption property")
+	carapace.Gen(changeKeyCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(changeKeyCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	loadKeyCmd := newCommand("load-key", "load encryption keys")
+	boolFlag(loadKeyCmd, "a", "load all keys")
+	boolFlag(loadKeyCmd, "n", "dry run")
+	boolFlag(loadKeyCmd, "r", "recursively load keys")
+	stringFlag(loadKeyCmd, "L", "key location")
+	carapace.Gen(loadKeyCmd).FlagCompletion(carapace.ActionMap{
+		"L": carapace.ActionFiles(),
+	})
+	carapace.Gen(loadKeyCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	unloadKeyCmd := newCommand("unload-key", "unload encryption keys")
+	boolFlag(unloadKeyCmd, "a", "unload all keys")
+	boolFlag(unloadKeyCmd, "r", "recursively unload keys")
+	carapace.Gen(unloadKeyCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	programCmd := newCommand("program", "execute a channel program")
+	boolFlag(programCmd, "j", "display JSON output")
+	boolFlag(programCmd, "n", "dry run")
+	stringFlag(programCmd, "t", "terminate after the given timeout")
+	carapace.Gen(programCmd).PositionalCompletion(
+		zfs.ActionDatasets("filesystem", "volume"),
+		carapace.ActionFiles(),
+	)
+
+	projectCmd := newCommand("project", "manage project IDs")
+	boolFlag(projectCmd, "d", "clear project ID")
+	boolFlag(projectCmd, "r", "recurse into directories")
+	boolFlag(projectCmd, "s", "set project ID")
+	boolFlag(projectCmd, "C", "clear inherit flag")
+	boolFlag(projectCmd, "c", "check project ID")
+	carapace.Gen(projectCmd).PositionalAnyCompletion(carapace.ActionFiles())
+
+	rewriteCmd := newCommand("rewrite", "rewrite files without modification")
+	carapace.Gen(rewriteCmd).PositionalAnyCompletion(carapace.ActionFiles())
+
+	jailCmd := newCommand("jail", "attach a dataset to a jail", "zone")
+	carapace.Gen(jailCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	unjailCmd := newCommand("unjail", "detach a dataset from a jail", "unzone")
+	carapace.Gen(unjailCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+
+	waitCmd := newCommand("wait", "wait for background activity to complete")
+	boolFlag(waitCmd, "H", "scripted mode")
+	boolFlag(waitCmd, "p", "display exact numeric values")
+	stringFlag(waitCmd, "t", "activity type")
+	carapace.Gen(waitCmd).FlagCompletion(carapace.ActionMap{
+		"t": zfs.ActionWaitActivities(),
+	})
+	carapace.Gen(waitCmd).PositionalAnyCompletion(zfs.ActionDatasets("filesystem", "volume"))
+}
+
+func newCommand(use string, short string, aliases ...string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Aliases: aliases,
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+
+	carapace.Gen(cmd).Standalone()
+	rootCmd.AddCommand(cmd)
+	return cmd
+}
+
+func newSpaceCommand(use string, short string) *cobra.Command {
+	cmd := newCommand(use, short)
+	boolFlag(cmd, "H", "scripted mode")
+	boolFlag(cmd, "i", "translate SID to POSIX ID")
+	boolFlag(cmd, "n", "display numeric IDs")
+	boolFlag(cmd, "p", "display exact numeric values")
+	stringFlag(cmd, "o", "output fields")
+	stringFlag(cmd, "s", "sort by field")
+	stringFlag(cmd, "S", "sort by field in reverse")
+	stringFlag(cmd, "t", "types to display")
+	carapace.Gen(cmd).FlagCompletion(carapace.ActionMap{
+		"S": zfs.ActionUserSpaceFields(),
+		"o": propertyListAction(zfs.ActionUserSpaceFields()),
+		"s": zfs.ActionUserSpaceFields(),
+		"t": zfs.ActionUserSpaceTypes().UniqueList(","),
+	})
+	return cmd
+}
+
+func boolFlag(cmd *cobra.Command, name string, description string) {
+	cmd.Flags().BoolS(name, name, false, description)
+}
+
+func stringFlag(cmd *cobra.Command, name string, description string) {
+	cmd.Flags().StringS(name, name, "", description)
+}
+
+func propertyListAction(action carapace.Action) carapace.Action {
+	return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
+		return action.Invoke(c).Filter(c.Parts...).ToA().NoSpace()
+	})
+}
+
+func propertyAssignmentAction() carapace.Action {
+	return carapace.ActionMultiPartsN("=", 2, func(c carapace.Context) carapace.Action {
+		switch len(c.Parts) {
+		case 0:
+			return zfs.ActionDatasetProperties().Suffix("=")
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+func positionalByIndex(actions ...carapace.Action) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) < len(actions) {
+			return actions[len(c.Args)]
+		}
+		return actions[len(actions)-1]
+	})
+}

--- a/completers/common/zfs_completer/main.go
+++ b/completers/common/zfs_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/zfs_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/zpool_completer/cmd/root.go
+++ b/completers/common/zpool_completer/cmd/root.go
@@ -1,0 +1,389 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/fs"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/zfs"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/zpool"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "zpool",
+	Short: "configure ZFS storage pools",
+	Long:  "https://openzfs.github.io/openzfs-docs/man/v2.4/8/zpool.8.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("?", "?", false, "display help")
+	rootCmd.Flags().BoolP("version", "V", false, "display version")
+
+	versionCmd := newCommand("version", "display ZFS version")
+	versionCmd.Flags().BoolS("j", "j", false, "display JSON")
+
+	listCmd := newCommand("list", "list storage pools")
+	boolFlag(listCmd, "H", "scripted mode")
+	boolFlag(listCmd, "L", "display real paths for vdevs")
+	boolFlag(listCmd, "P", "display full paths for vdevs")
+	boolFlag(listCmd, "g", "display vdev GUIDs")
+	boolFlag(listCmd, "j", "display JSON")
+	boolFlag(listCmd, "p", "display exact numeric values")
+	boolFlag(listCmd, "v", "display vdev statistics")
+	listCmd.Flags().Bool("json-int", false, "display JSON numbers as integers")
+	listCmd.Flags().Bool("json-pool-key-guid", false, "key JSON pools by GUID")
+	stringFlag(listCmd, "T", "timestamp style")
+	stringFlag(listCmd, "o", "properties to display")
+	carapace.Gen(listCmd).FlagCompletion(carapace.ActionMap{
+		"T": zpool.ActionTimestampStyles(),
+		"o": propertyListAction(zpool.ActionListProperties()),
+	})
+	carapace.Gen(listCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	createCmd := newCommand("create", "create a new storage pool")
+	boolFlag(createCmd, "d", "do not enable features automatically")
+	boolFlag(createCmd, "f", "force use of devices")
+	boolFlag(createCmd, "n", "dry run")
+	stringFlag(createCmd, "R", "alternate root directory")
+	stringFlag(createCmd, "m", "mount point")
+	stringFlag(createCmd, "O", "set a root dataset property")
+	stringFlag(createCmd, "o", "set a pool property")
+	carapace.Gen(createCmd).FlagCompletion(carapace.ActionMap{
+		"O": datasetPropertyAssignmentAction(),
+		"R": carapace.ActionDirectories(),
+		"m": carapace.ActionDirectories(),
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(createCmd).PositionalAnyCompletion(positionalByIndex(
+		carapace.ActionValues(),
+		vdevAction(),
+	))
+
+	addCmd := newCommand("add", "add virtual devices to a pool")
+	boolFlag(addCmd, "L", "display real paths for vdevs")
+	boolFlag(addCmd, "f", "force use of devices")
+	boolFlag(addCmd, "g", "display vdev GUIDs")
+	boolFlag(addCmd, "n", "dry run")
+	stringFlag(addCmd, "o", "set a pool property")
+	carapace.Gen(addCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(addCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		vdevAction(),
+	))
+
+	attachCmd := newCommand("attach", "attach a device to a pool")
+	boolFlag(attachCmd, "f", "force use of device")
+	stringFlag(attachCmd, "o", "set a pool property")
+	carapace.Gen(attachCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(attachCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	checkpointCmd := newCommand("checkpoint", "checkpoint a pool")
+	checkpointCmd.Flags().Bool("discard", false, "discard an existing checkpoint")
+	carapace.Gen(checkpointCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	clearCmd := newCommand("clear", "clear device errors in a pool")
+	boolFlag(clearCmd, "F", "rewind to checkpoint")
+	boolFlag(clearCmd, "n", "dry run")
+	carapace.Gen(clearCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	destroyCmd := newCommand("destroy", "destroy a storage pool")
+	boolFlag(destroyCmd, "f", "force destroy")
+	carapace.Gen(destroyCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	detachCmd := newCommand("detach", "detach a device from a pool")
+	carapace.Gen(detachCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	eventsCmd := newCommand("events", "list recent ZFS events")
+	boolFlag(eventsCmd, "H", "scripted mode")
+	boolFlag(eventsCmd, "c", "clear events")
+	boolFlag(eventsCmd, "f", "follow event stream")
+	boolFlag(eventsCmd, "v", "verbose output")
+
+	exportCmd := newCommand("export", "export pools from the system")
+	boolFlag(exportCmd, "a", "export all pools")
+	boolFlag(exportCmd, "f", "force export")
+	carapace.Gen(exportCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	getCmd := newCommand("get", "retrieve pool properties")
+	boolFlag(getCmd, "H", "scripted mode")
+	boolFlag(getCmd, "p", "display exact numeric values")
+	stringFlag(getCmd, "o", "output fields")
+	carapace.Gen(getCmd).FlagCompletion(carapace.ActionMap{
+		"o": zpool.ActionGetFields().UniqueList(","),
+	})
+	carapace.Gen(getCmd).PositionalAnyCompletion(positionalByIndex(
+		propertyListAction(zpool.ActionPoolProperties()),
+		zpool.ActionPools(),
+	))
+
+	historyCmd := newCommand("history", "display pool command history")
+	boolFlag(historyCmd, "i", "display internal events")
+	boolFlag(historyCmd, "l", "display long format")
+	carapace.Gen(historyCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	importCmd := newCommand("import", "import pools into the system")
+	boolFlag(importCmd, "D", "include destroyed pools")
+	boolFlag(importCmd, "F", "rewind if needed")
+	boolFlag(importCmd, "N", "do not mount datasets")
+	boolFlag(importCmd, "a", "import all pools")
+	boolFlag(importCmd, "f", "force import")
+	boolFlag(importCmd, "l", "load keys")
+	boolFlag(importCmd, "m", "allow missing log devices")
+	boolFlag(importCmd, "n", "dry run")
+	stringFlag(importCmd, "R", "alternate root directory")
+	stringFlag(importCmd, "c", "cache file")
+	stringFlag(importCmd, "d", "device search directory")
+	stringFlag(importCmd, "o", "set a pool property")
+	carapace.Gen(importCmd).FlagCompletion(carapace.ActionMap{
+		"R": carapace.ActionDirectories(),
+		"c": carapace.ActionFiles(),
+		"d": carapace.ActionDirectories(),
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(importCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	initializeCmd := newCommand("initialize", "initialize pool devices")
+	boolFlag(initializeCmd, "c", "cancel initialization")
+	boolFlag(initializeCmd, "s", "suspend initialization")
+	boolFlag(initializeCmd, "u", "uninitialize")
+	boolFlag(initializeCmd, "w", "wait for completion")
+	carapace.Gen(initializeCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	iostatCmd := newCommand("iostat", "display pool I/O statistics")
+	boolFlag(iostatCmd, "H", "scripted mode")
+	boolFlag(iostatCmd, "L", "display real paths for vdevs")
+	boolFlag(iostatCmd, "P", "display full paths for vdevs")
+	boolFlag(iostatCmd, "p", "display exact numeric values")
+	boolFlag(iostatCmd, "r", "display request size histograms")
+	boolFlag(iostatCmd, "v", "display vdev statistics")
+	boolFlag(iostatCmd, "w", "display latency histograms")
+	boolFlag(iostatCmd, "y", "omit the first report")
+	stringFlag(iostatCmd, "T", "timestamp style")
+	stringFlag(iostatCmd, "c", "run a command after each report")
+	carapace.Gen(iostatCmd).FlagCompletion(carapace.ActionMap{
+		"T": zpool.ActionTimestampStyles(),
+	})
+	carapace.Gen(iostatCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	labelclearCmd := newCommand("labelclear", "remove ZFS labels from a device")
+	boolFlag(labelclearCmd, "f", "force label removal")
+	carapace.Gen(labelclearCmd).PositionalAnyCompletion(deviceAction())
+
+	offlineCmd := newCommand("offline", "take devices offline")
+	boolFlag(offlineCmd, "f", "force fault")
+	boolFlag(offlineCmd, "t", "temporarily offline")
+	carapace.Gen(offlineCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	onlineCmd := newCommand("online", "bring devices online")
+	boolFlag(onlineCmd, "e", "expand devices")
+	carapace.Gen(onlineCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	prefetchCmd := newCommand("prefetch", "prefetch pool data")
+	carapace.Gen(prefetchCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	reguidCmd := newCommand("reguid", "generate a new pool GUID")
+	carapace.Gen(reguidCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	removeCmd := newCommand("remove", "remove devices from a pool")
+	boolFlag(removeCmd, "n", "dry run")
+	boolFlag(removeCmd, "p", "display exact numeric values")
+	boolFlag(removeCmd, "w", "wait for removal")
+	carapace.Gen(removeCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	reopenCmd := newCommand("reopen", "reopen pool vdevs")
+	boolFlag(reopenCmd, "n", "dry run")
+	carapace.Gen(reopenCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	replaceCmd := newCommand("replace", "replace a device in a pool")
+	boolFlag(replaceCmd, "f", "force use of device")
+	stringFlag(replaceCmd, "o", "set a pool property")
+	carapace.Gen(replaceCmd).FlagCompletion(carapace.ActionMap{
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(replaceCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	resilverCmd := newCommand("resilver", "start a resilver")
+	carapace.Gen(resilverCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	scrubCmd := newCommand("scrub", "start or resume a scrub")
+	boolFlag(scrubCmd, "p", "pause scrub")
+	boolFlag(scrubCmd, "s", "stop scrub")
+	boolFlag(scrubCmd, "w", "wait for completion")
+	carapace.Gen(scrubCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	setCmd := newCommand("set", "set pool properties")
+	carapace.Gen(setCmd).PositionalAnyCompletion(positionalByIndex(
+		propertyAssignmentAction(),
+		zpool.ActionPools(),
+	))
+
+	splitCmd := newCommand("split", "split a mirrored pool")
+	boolFlag(splitCmd, "g", "display vdev GUIDs")
+	boolFlag(splitCmd, "L", "display real paths for vdevs")
+	boolFlag(splitCmd, "n", "dry run")
+	stringFlag(splitCmd, "R", "alternate root directory")
+	stringFlag(splitCmd, "o", "set a pool property")
+	carapace.Gen(splitCmd).FlagCompletion(carapace.ActionMap{
+		"R": carapace.ActionDirectories(),
+		"o": propertyAssignmentAction(),
+	})
+	carapace.Gen(splitCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		carapace.ActionValues(),
+		deviceAction(),
+	))
+
+	statusCmd := newCommand("status", "display pool health status")
+	boolFlag(statusCmd, "D", "display dedup statistics")
+	boolFlag(statusCmd, "L", "display real paths for vdevs")
+	boolFlag(statusCmd, "P", "display full paths for vdevs")
+	boolFlag(statusCmd, "e", "display slow I/O statistics")
+	boolFlag(statusCmd, "g", "display vdev GUIDs")
+	boolFlag(statusCmd, "j", "display JSON")
+	boolFlag(statusCmd, "s", "display slow vdevs")
+	boolFlag(statusCmd, "v", "verbose output")
+	boolFlag(statusCmd, "x", "display only unhealthy pools")
+	stringFlag(statusCmd, "c", "run vdev script")
+	stringFlag(statusCmd, "t", "health status filter")
+	carapace.Gen(statusCmd).FlagCompletion(carapace.ActionMap{
+		"t": carapace.ActionValues("ONLINE", "DEGRADED", "FAULTED", "OFFLINE", "REMOVED", "UNAVAIL"),
+	})
+	carapace.Gen(statusCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	syncCmd := newCommand("sync", "force dirty data to disk")
+	carapace.Gen(syncCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	trimCmd := newCommand("trim", "initiate TRIM on a pool")
+	boolFlag(trimCmd, "d", "secure trim")
+	boolFlag(trimCmd, "r", "trim assigned ranges")
+	boolFlag(trimCmd, "w", "wait for completion")
+	carapace.Gen(trimCmd).PositionalAnyCompletion(positionalByIndex(
+		zpool.ActionPools(),
+		deviceAction(),
+	))
+
+	upgradeCmd := newCommand("upgrade", "manage pool on-disk format versions")
+	boolFlag(upgradeCmd, "a", "upgrade all pools")
+	boolFlag(upgradeCmd, "v", "display supported versions")
+	stringFlag(upgradeCmd, "V", "upgrade to a specific version")
+	carapace.Gen(upgradeCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	waitCmd := newCommand("wait", "wait for pool background activity")
+	boolFlag(waitCmd, "H", "scripted mode")
+	boolFlag(waitCmd, "p", "display exact numeric values")
+	stringFlag(waitCmd, "t", "activity type")
+	carapace.Gen(waitCmd).FlagCompletion(carapace.ActionMap{
+		"t": zpool.ActionWaitActivities(),
+	})
+	carapace.Gen(waitCmd).PositionalAnyCompletion(zpool.ActionPools())
+
+	ddtpruneCmd := newCommand("ddtprune", "prune deduplication tables")
+	carapace.Gen(ddtpruneCmd).PositionalAnyCompletion(zpool.ActionPools())
+}
+
+func newCommand(use string, short string, aliases ...string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Short:   short,
+		Aliases: aliases,
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+
+	carapace.Gen(cmd).Standalone()
+	rootCmd.AddCommand(cmd)
+	return cmd
+}
+
+func boolFlag(cmd *cobra.Command, name string, description string) {
+	cmd.Flags().BoolS(name, name, false, description)
+}
+
+func stringFlag(cmd *cobra.Command, name string, description string) {
+	cmd.Flags().StringS(name, name, "", description)
+}
+
+func propertyListAction(action carapace.Action) carapace.Action {
+	return carapace.ActionMultiParts(",", func(c carapace.Context) carapace.Action {
+		return action.Invoke(c).Filter(c.Parts...).ToA().NoSpace()
+	})
+}
+
+func propertyAssignmentAction() carapace.Action {
+	return carapace.ActionMultiPartsN("=", 2, func(c carapace.Context) carapace.Action {
+		switch len(c.Parts) {
+		case 0:
+			return zpool.ActionPoolProperties().Suffix("=")
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+func datasetPropertyAssignmentAction() carapace.Action {
+	return carapace.ActionMultiPartsN("=", 2, func(c carapace.Context) carapace.Action {
+		switch len(c.Parts) {
+		case 0:
+			return zfs.ActionDatasetProperties().Suffix("=")
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+func positionalByIndex(actions ...carapace.Action) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if len(c.Args) < len(actions) {
+			return actions[len(c.Args)]
+		}
+		return actions[len(actions)-1]
+	})
+}
+
+func deviceAction() carapace.Action {
+	return carapace.Batch(
+		fs.ActionBlockDevices(),
+		carapace.ActionFiles(),
+	).ToA()
+}
+
+func vdevAction() carapace.Action {
+	return carapace.Batch(
+		zpool.ActionVdevTypes(),
+		fs.ActionBlockDevices(),
+		carapace.ActionFiles(),
+	).ToA()
+}

--- a/completers/common/zpool_completer/main.go
+++ b/completers/common/zpool_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/zpool_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/zfs/dataset.go
+++ b/pkg/actions/tools/zfs/dataset.go
@@ -1,0 +1,51 @@
+package zfs
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionDatasets completes ZFS datasets for the given dataset types.
+func ActionDatasets(types ...string) carapace.Action {
+	if len(types) == 0 {
+		types = []string{"all"}
+	}
+
+	return carapace.ActionExecCommand("zfs", "list", "-H", "-o", "name", "-t", strings.Join(types, ","))(func(output []byte) carapace.Action {
+		return actionValuesFromLines(output).Tag("zfs datasets")
+	})
+}
+
+// ActionSnapshots completes ZFS snapshots.
+func ActionSnapshots() carapace.Action {
+	return ActionDatasets("snapshot").Tag("zfs snapshots")
+}
+
+// ActionBookmarks completes ZFS bookmarks.
+func ActionBookmarks() carapace.Action {
+	return ActionDatasets("bookmark").Tag("zfs bookmarks")
+}
+
+// ActionDatasetTypes completes ZFS dataset types.
+func ActionDatasetTypes() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"filesystem", "file system datasets",
+		"snapshot", "read-only point-in-time datasets",
+		"volume", "block device datasets",
+		"bookmark", "snapshot bookmarks",
+		"all", "all dataset types",
+	).Tag("zfs dataset types")
+}
+
+func actionValuesFromLines(output []byte) carapace.Action {
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+	values := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line != "" {
+			values = append(values, line)
+		}
+	}
+	return carapace.ActionValues(values...)
+}

--- a/pkg/actions/tools/zfs/property.go
+++ b/pkg/actions/tools/zfs/property.go
@@ -1,0 +1,125 @@
+package zfs
+
+import "github.com/carapace-sh/carapace"
+
+// ActionDatasetProperties completes common ZFS dataset properties.
+func ActionDatasetProperties() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"all", "all properties",
+		"available", "space available",
+		"clones", "clone datasets",
+		"compressratio", "compression ratio",
+		"compression", "compression algorithm",
+		"copies", "number of data copies",
+		"creation", "creation time",
+		"dedup", "deduplication setting",
+		"filesystem_count", "descendant filesystem count",
+		"filesystem_limit", "descendant filesystem limit",
+		"guid", "dataset GUID",
+		"logicalreferenced", "logical space referenced",
+		"logicalused", "logical space used",
+		"mountpoint", "mount point",
+		"mounted", "mounted state",
+		"name", "dataset name",
+		"origin", "clone origin",
+		"quota", "space quota",
+		"readonly", "read-only flag",
+		"recordsize", "record size",
+		"referenced", "referenced space",
+		"refquota", "referenced quota",
+		"refreservation", "referenced reservation",
+		"reservation", "minimum reserved space",
+		"setuid", "setuid behavior",
+		"snapdir", "snapshot directory visibility",
+		"snapshot_count", "snapshot count",
+		"snapshot_limit", "snapshot limit",
+		"type", "dataset type",
+		"used", "used space",
+		"usedbychildren", "space used by children",
+		"usedbydataset", "space used by dataset",
+		"usedbyrefreservation", "space used by refreservation",
+		"usedbysnapshots", "space used by snapshots",
+		"volblocksize", "volume block size",
+		"volsize", "volume size",
+		"written", "space written",
+		"xattr", "extended attribute behavior",
+		"zoned", "zone visibility",
+	).Tag("zfs dataset properties")
+}
+
+// ActionGetFields completes zfs get output fields.
+func ActionGetFields() carapace.Action {
+	return carapace.ActionValues("name", "property", "value", "source", "received").Tag("zfs get fields")
+}
+
+// ActionPropertySources completes zfs get property source filters.
+func ActionPropertySources() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"local", "locally set properties",
+		"default", "default property values",
+		"inherited", "inherited property values",
+		"temporary", "temporary property values",
+		"received", "received property values",
+		"none", "properties with no source",
+	).Tag("zfs property sources")
+}
+
+// ActionUserSpaceTypes completes zfs userspace and groupspace type filters.
+func ActionUserSpaceTypes() carapace.Action {
+	return carapace.ActionValues(
+		"all",
+		"posixuser",
+		"smbuser",
+		"posixgroup",
+		"smbgroup",
+		"project",
+	).Tag("zfs userspace types")
+}
+
+// ActionUserSpaceFields completes zfs userspace and groupspace output fields.
+func ActionUserSpaceFields() carapace.Action {
+	return carapace.ActionValues(
+		"type",
+		"name",
+		"used",
+		"quota",
+		"objused",
+		"objquota",
+	).Tag("zfs userspace fields")
+}
+
+// ActionWaitActivities completes zfs wait activity types.
+func ActionWaitActivities() carapace.Action {
+	return carapace.ActionValues("deleteq", "freeing", "initializing", "resilver", "scrub", "trim").Tag("zfs wait activities")
+}
+
+// ActionPermissions completes zfs delegated permissions.
+func ActionPermissions() carapace.Action {
+	return carapace.ActionValues(
+		"allow",
+		"bookmark",
+		"change-key",
+		"clone",
+		"create",
+		"destroy",
+		"diff",
+		"groupquota",
+		"groupused",
+		"hold",
+		"load-key",
+		"mount",
+		"promote",
+		"projectquota",
+		"projectused",
+		"receive",
+		"release",
+		"rename",
+		"rollback",
+		"send",
+		"share",
+		"snapshot",
+		"userprop",
+		"userquota",
+		"userused",
+	).Tag("zfs permissions")
+}

--- a/pkg/actions/tools/zpool/pool.go
+++ b/pkg/actions/tools/zpool/pool.go
@@ -1,0 +1,39 @@
+package zpool
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionPools completes ZFS storage pools.
+func ActionPools() carapace.Action {
+	return carapace.ActionExecCommand("zpool", "list", "-H", "-o", "name")(func(output []byte) carapace.Action {
+		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+		values := make([]string, 0, len(lines))
+		for _, line := range lines {
+			if fields := strings.Fields(line); len(fields) > 0 {
+				values = append(values, fields[0])
+			}
+		}
+		return carapace.ActionValues(values...).Tag("zfs pools")
+	})
+}
+
+// ActionVdevTypes completes zpool virtual device type keywords.
+func ActionVdevTypes() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"mirror", "mirrored vdev",
+		"raidz", "RAID-Z vdev",
+		"raidz1", "single-parity RAID-Z vdev",
+		"raidz2", "double-parity RAID-Z vdev",
+		"raidz3", "triple-parity RAID-Z vdev",
+		"draid", "distributed RAID-Z vdev",
+		"spare", "hot spare vdev",
+		"log", "separate intent log vdev",
+		"cache", "L2ARC cache vdev",
+		"special", "special allocation class vdev",
+		"dedup", "deduplication table vdev",
+	).Tag("zpool vdev types")
+}

--- a/pkg/actions/tools/zpool/property.go
+++ b/pkg/actions/tools/zpool/property.go
@@ -1,0 +1,73 @@
+package zpool
+
+import "github.com/carapace-sh/carapace"
+
+// ActionPoolProperties completes common zpool properties.
+func ActionPoolProperties() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"all", "all properties",
+		"allocated", "allocated space",
+		"altroot", "alternate root directory",
+		"ashift", "sector size exponent",
+		"autoexpand", "automatic pool expansion",
+		"autoreplace", "automatic device replacement",
+		"autotrim", "automatic TRIM behavior",
+		"bootfs", "default bootable dataset",
+		"cachefile", "pool configuration cache file",
+		"capacity", "used capacity percentage",
+		"checkpoint", "checkpoint space",
+		"comment", "pool comment",
+		"compatibility", "feature compatibility set",
+		"dedupratio", "deduplication ratio",
+		"delegation", "delegated administration setting",
+		"expandsize", "expandable space",
+		"failmode", "failure mode",
+		"fragmentation", "fragmentation percentage",
+		"free", "free space",
+		"freeing", "space being freed",
+		"guid", "pool GUID",
+		"health", "pool health",
+		"leaked", "leaked space",
+		"listsnapshots", "snapshot listing behavior",
+		"multihost", "multihost import protection",
+		"name", "pool name",
+		"readonly", "read-only import state",
+		"size", "total pool size",
+		"version", "on-disk version",
+	).Tag("zpool properties")
+}
+
+// ActionListProperties completes zpool list output properties.
+func ActionListProperties() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"name", "pool name",
+		"size", "total pool size",
+		"allocated", "allocated space",
+		"free", "free space",
+		"checkpoint", "checkpoint space",
+		"expandsize", "expandable space",
+		"fragmentation", "fragmentation percentage",
+		"capacity", "used capacity percentage",
+		"dedupratio", "deduplication ratio",
+		"health", "pool health",
+		"altroot", "alternate root directory",
+	).Tag("zpool list properties")
+}
+
+// ActionGetFields completes zpool get output fields.
+func ActionGetFields() carapace.Action {
+	return carapace.ActionValues("name", "property", "value", "source").Tag("zpool get fields")
+}
+
+// ActionTimestampStyles completes zpool timestamp styles.
+func ActionTimestampStyles() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"u", "Unix epoch timestamp",
+		"d", "standard date timestamp",
+	).Tag("zpool timestamp styles")
+}
+
+// ActionWaitActivities completes zpool wait activity types.
+func ActionWaitActivities() carapace.Action {
+	return carapace.ActionValues("discard", "free", "initialize", "replace", "remove", "resilver", "scrub", "trim").Tag("zpool wait activities")
+}


### PR DESCRIPTION
Refs #3365

Adds OpenZFS `zfs` and `zpool` completers.

Coverage includes:
- top-level OpenZFS dataset, snapshot, bookmark, send/receive, encryption, delegation, and pool/vdev commands
- common command flags and flag value completion for dataset types, properties, sources, userspace fields, wait activities, pool properties, timestamp modes, and vdev types
- dynamic dataset, snapshot, bookmark, and pool completion via `zfs list` and `zpool list` when OpenZFS is installed

Validation:
- `gofmt`
- `go generate ./cmd/...`
- `go run ./cmd/carapace-lint completers/common/zfs_completer/cmd/root.go completers/common/zpool_completer/cmd/root.go`
- `go test ./cmd/carapace ./cmd/carapace/cmd/completers ./pkg/actions/tools/zfs ./pkg/actions/tools/zpool ./completers/common/zfs_completer/... ./completers/common/zpool_completer/...`
- `go build -o /tmp/codex-zfs-completer ./completers/common/zfs_completer`
- `go build -o /tmp/codex-zpool-completer ./completers/common/zpool_completer`
- completion smoke checks for top-level commands, static flag values, and fake `zfs`/`zpool` dynamic completions
- `git diff --check`