### PR TITLE
Add osc clap bridge completer

### DIFF
--- a/completers/common/osc_completer/cmd/root.go
+++ b/completers/common/osc_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "osc",
+	Short:              "OpenStack client rewritten in Rust",
+	Long:               "https://github.com/gtema/openstack",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionClap("osc"),
+	)
+}

--- a/completers/common/osc_completer/main.go
+++ b/completers/common/osc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/osc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Fixes #2975.

## Summary
- add an `osc` completer for the Rust OpenStack client
- bridge to `clap_complete::CompleteEnv` through the existing `bridge.ActionClap("osc")` protocol

## Notes
- upstream `gtema/openstack` defines the `osc` binary in `openstack_cli` and calls `CompleteEnv::with_factory(openstack_cli::Cli::command).try_complete(...)`, which matches the existing carapace clap bridge

## Tests
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go generate ./cmd/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go test ./cmd/carapace ./cmd/carapace/cmd/completers ./completers/common/osc_completer/...`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go build -o /tmp/codex-osc-completer ./completers/common/osc_completer`
- `PATH=/tmp/codex-go-toolchain/go/bin:$PATH go run ./cmd/carapace-lint completers/common/osc_completer/cmd/root.go`
- `git diff --check`
- fake `osc complete ...` smoke test through `/tmp/codex-osc-completer _carapace bash osc ""`