### PR TITLE
Support CARAPACE_SPEC_PATH for custom specs

### DIFF
--- a/cmd/carapace/cmd/completers/completers.go
+++ b/cmd/carapace/cmd/completers/completers.go
@@ -264,6 +264,28 @@ func AddSpecs(m completer.CompleterMap, parse bool) error {
 		return err
 	}
 	m.Merge(specs)
+
+	for _, specPath := range filepath.SplitList(os.Getenv("CARAPACE_SPEC_PATH")) {
+		if specPath == "" {
+			continue
+		}
+
+		info, err := os.Stat(specPath)
+		switch {
+		case os.IsNotExist(err):
+			continue
+		case err != nil:
+			return err
+		case info.IsDir():
+			specs, err = completer.ReadSpecs(specPath, "user", parse)
+		default:
+			specs, err = completer.ReadSpec(specPath, "user", parse)
+		}
+		if err != nil {
+			return err
+		}
+		m.Merge(specs)
+	}
 	return nil
 }
 
@@ -306,14 +328,35 @@ func specDescription(name string) (string, error) {
 		return "", err
 	}
 
-	content, err := os.ReadFile(fmt.Sprintf("%v/carapace/specs/%v.yaml", confDir, name))
+	paths := []string{filepath.Join(confDir, "carapace", "specs", name+".yaml")}
+	for _, specPath := range filepath.SplitList(os.Getenv("CARAPACE_SPEC_PATH")) {
+		if specPath == "" {
+			continue
+		}
+		if info, err := os.Stat(specPath); err == nil && info.IsDir() {
+			paths = append(paths, filepath.Join(specPath, name+".yaml"))
+		} else {
+			paths = append(paths, specPath)
+		}
+	}
+
+	var content []byte
+	for _, path := range paths {
+		content, err = os.ReadFile(path)
+		if err == nil {
+			break
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+	}
 	if err != nil {
 		return "", err
 	}
+
 	var s struct {
 		Description string
 	}
-
 	err = yaml.Unmarshal(content, &s)
 	if err != nil {
 		return "", err

--- a/cmd/carapace/cmd/root.go
+++ b/cmd/carapace/cmd/root.go
@@ -52,6 +52,7 @@ var rootCmd = &cobra.Command{
   Some completions are cached at [%v/carapace].
   Config is written to [%v/carapace].
   Specs are loaded from [%v/carapace/specs].
+  Additional specs can be loaded from CARAPACE_SPEC_PATH.
   `, suppressErr(xdg.UserCacheDir), suppressErr(xdg.UserConfigDir), suppressErr(xdg.UserConfigDir)),
 	Args:               cobra.MinimumNArgs(1),
 	DisableFlagParsing: true,

--- a/pkg/completer/read.go
+++ b/pkg/completer/read.go
@@ -121,6 +121,60 @@ func ReadSpecs(dir, group string, parse bool) (CompleterMap, error) {
 	return m, nil
 }
 
+func ReadSpec(path, group string, parse bool) (CompleterMap, error) {
+	var err error
+	if path, err = filepath.Abs(path); err != nil {
+		return nil, err
+	}
+
+	m := make(CompleterMap)
+	if filepath.Ext(path) != ".yaml" {
+		return m, nil
+	}
+
+	_spec := struct {
+		Name        string
+		Description string
+	}{
+		Name: strings.TrimSuffix(filepath.Base(path), ".yaml"),
+	}
+
+	if !parse {
+		m[_spec.Name] = append(m[_spec.Name], Completer{
+			Name:    _spec.Name,
+			Group:   group,
+			Spec:    path,
+			Execute: complete(_spec.Name, spec.ActionSpec(path)),
+		})
+		return m, nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m, nil
+		}
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal(content, &_spec); err != nil {
+		return nil, err
+	}
+
+	if filepath.Base(path) != _spec.Name+".yaml" {
+		return nil, fmt.Errorf("spec filename %#v does not match name %#v", filepath.Base(path), _spec.Name)
+	}
+
+	m[_spec.Name] = append(m[_spec.Name], Completer{
+		Name:        _spec.Name,
+		Description: _spec.Description,
+		Group:       group,
+		Spec:        path,
+		Execute:     complete(_spec.Name, spec.ActionSpec(path)),
+	})
+	return m, nil
+}
+
 // TODO duplicated from cmd/carapace/cmd/completer/
 func complete(name string, action carapace.Action) func() error {
 	return func() error {

--- a/pkg/completer/read_test.go
+++ b/pkg/completer/read_test.go
@@ -1,0 +1,43 @@
+package completer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadSpec(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cmd.yaml")
+	if err := os.WriteFile(path, []byte("name: cmd\ndescription: test command\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	specs, err := ReadSpec(path, "user", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches := specs["cmd"]
+	if len(matches) != 1 {
+		t.Fatalf("expected one spec, got %d", len(matches))
+	}
+	if matches[0].Description != "test command" {
+		t.Fatalf("unexpected description: %q", matches[0].Description)
+	}
+	if matches[0].Spec != path {
+		t.Fatalf("unexpected spec path: %q", matches[0].Spec)
+	}
+}
+
+func TestReadSpecFilenameMustMatchName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cmd.yaml")
+	if err := os.WriteFile(path, []byte("name: other\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ReadSpec(path, "user", true); err == nil {
+		t.Fatal("expected filename/name mismatch error")
+	}
+}


### PR DESCRIPTION
Adds support for a user-controlled `CARAPACE_SPEC_PATH` path list when loading carapace specs.

Behavior:
- keeps loading `${UserConfigDir}/carapace/specs` as before
- additionally loads specs from each `CARAPACE_SPEC_PATH` entry
- supports both spec directories and direct `cmd.yaml` file entries
- uses `filepath.SplitList`, so the separator follows the current OS
- includes direct spec-file tests and updates help text

This implements the environment-variable option proposed in #3361. Users can export `CARAPACE_SPEC_PATH` in their shell so generated completion callbacks inherit it naturally.

Validation:
- `go test ./pkg/completer ./cmd/carapace/cmd/completers`
- live check: created a temp spec directory, set `CARAPACE_SPEC_PATH`, and confirmed `go run ./cmd/carapace --list --names` listed the custom command

Closes #3361.