### PR TITLE
Add kcl completer

### DIFF
--- a/completers/common/kcl_completer/cmd/root.go
+++ b/completers/common/kcl_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "kcl",
+	Short:              "KCL command line interface",
+	Long:               "https://kcl-lang.io",
+	DisableFlagParsing: true,
+	Run:                func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCobra("kcl"),
+	)
+}

--- a/completers/common/kcl_completer/main.go
+++ b/completers/common/kcl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/kcl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Adds a `kcl` completer using the Cobra bridge, matching the approach suggested in #3242.

Validation:
- `go test ./completers/common/kcl_completer`
- `go run ./cmd/carapace-lint completers/common/kcl_completer/cmd/root.go`
- `go generate ./cmd/...`

Closes #3242.