### PR TITLE
Complete changed files for git checkout

### DIFF
--- a/completers/common/git_completer/cmd/checkout.go
+++ b/completers/common/git_completer/cmd/checkout.go
@@ -65,7 +65,11 @@ func init() {
 			if strings.HasPrefix(c.Value, ".") {
 				return git.ActionRefDiffs()
 			}
-			return git.ActionRefs(git.RefOption{}.Default())
+			return carapace.Batch(
+				git.ActionRemoteBranchNames(""),
+				git.ActionRefs(git.RefOption{}.Default()),
+				git.ActionRefDiffs(),
+			).ToA()
 		}),
 	)
 


### PR DESCRIPTION
Updates `git checkout` completion so the first positional argument includes changed files in addition to refs. This lets typed file prefixes such as `git checkout AG<TAB>` complete modified files, while keeping branch/ref completions available.

I also included remote branch shorthand names in the same first-position batch, so `git checkout r<TAB>` can suggest `remote_branch` without forcing `origin/remote_branch`.

Validation:
- `go test ./completers/common/git_completer`
- `go run ./cmd/carapace-lint completers/common/git_completer/cmd/checkout.go`
- `go generate ./cmd/...`
- built a local `carapace` binary, created a temporary Git repo with modified `AGENTS.md`, and confirmed `carapace git export git checkout AG` returns `AGENTS.md` tagged as a changed file

Closes #3310.
Related to #2937.