### PR TITLE
Accept paru new flags at root

### DIFF
--- a/completers/linux/paru_completer/cmd/root.go
+++ b/completers/linux/paru_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/linux/paru_completer/cmd/common"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/paru"
 	"github.com/carapace-sh/carapace-bin/pkg/util/embed"
 	"github.com/spf13/cobra"
@@ -9,10 +10,11 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "paru",
-	Short: "Feature packed AUR helper",
-	Long:  "https://github.com/Morganamilo/paru",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:                "paru",
+	Short:              "Feature packed AUR helper",
+	Long:               "https://github.com/Morganamilo/paru",
+	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	Run:                func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
@@ -26,6 +28,7 @@ func init() {
 	rootCmd.Flags().Bool("gendb", false, "Generates development package DB used for updating")
 	rootCmd.Flags().BoolP("help", "h", false, "show help")
 	rootCmd.Flags().BoolP("version", "V", false, "show version")
+	common.AddNewFlags(rootCmd)
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {


### PR DESCRIPTION
Adds Paru's shared "new" options to the root command as well as the subcommands, so options such as `--sudoflags` are known before a subcommand-style flag like `-Q` is selected. The root command also whitelists unknown flags so embedded subcommand flags can still be handled by the existing subcommand-as-flags logic.

Validation:
- `go test ./completers/linux/paru_completer`
- `go run ./cmd/carapace-lint completers/linux/paru_completer/cmd/root.go`
- `go generate ./cmd/...`
- `go run -tags force_all ./cmd/carapace paru export paru --su` returns `--sudo`, `--sudoflags`, and `--sudoloop`
- `go run -tags force_all ./cmd/carapace paru export paru -Q --su` returns the same sudo-related flags
- `go run -tags force_all ./cmd/carapace paru export paru --sudoflags "-S" -Q --su` exits without the reported unknown-flag error and returns remaining sudo-related flags

Closes #2963.