### PR TITLE
Add dnf5 completer

### DIFF
--- a/completers/linux/dnf5_completer/cmd/root.go
+++ b/completers/linux/dnf5_completer/cmd/root.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	dnf "github.com/carapace-sh/carapace-bin/completers/linux/dnf_completer/cmd"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "dnf5",
+	Short: "DNF5 is a package manager for RPM-based Linux distributions",
+	Long:  "https://github.com/rpm-software-management/dnf5",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return dnf.ExecuteWithUse("dnf5")
+}

--- a/completers/linux/dnf5_completer/main.go
+++ b/completers/linux/dnf5_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/linux/dnf5_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/linux/dnf_completer/cmd/root.go
+++ b/completers/linux/dnf_completer/cmd/root.go
@@ -13,6 +13,11 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error {
+	return ExecuteWithUse("dnf")
+}
+
+func ExecuteWithUse(use string) error {
+	rootCmd.Use = use
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
## Summary

- add a `dnf5` completer entrypoint that reuses the existing `dnf`/DNF5 command tree
- add `ExecuteWithUse` to the `dnf` completer so wrappers can set the root command name without duplicating the generated subcommands

This keeps the `dnf` and `dnf5` completions in sync while exposing the command requested in #2774.

Fixes #2774

## Validation

- Checked the GitHub compare diff: only the `dnf` root wrapper and new `dnf5_completer` files changed.
- Local `go test` was not run because this environment does not have `go`/`gofmt` installed in PATH.
