### PR TITLE
fix zsh interpolation completion parsing

### DIFF
--- a/cmd/carapace/cmd/snippet/zsh.go
+++ b/cmd/carapace/cmd/snippet/zsh.go
@@ -13,11 +13,12 @@ func Zsh(completers []string) string {
 
 function _carapace_completer {
   local command="$(basename $words[1])"
-  local compline=${words[@]:0:$CURRENT}
+  local raw_compline=${words[@]:0:$CURRENT}
+  local compline=${(j: :)${(qq)${words[@]:0:$CURRENT}}}
   local IFS=$'\n'
   local lines
 
-  declare -x CARAPACE_COMPLINE="${words}"
+  declare -x CARAPACE_COMPLINE="${raw_compline}"
   declare -x CARAPACE_ZSH_HASH_DIRS="$(hash -d)"
   declare -x CARAPACE_SHELL=zsh
   declare -x CARAPACE_SHELL_BUILTINS="$(print -roC1 -- ${(k)builtins})"

--- a/cmd/carapace/cmd/snippet/zsh_test.go
+++ b/cmd/carapace/cmd/snippet/zsh_test.go
@@ -1,0 +1,42 @@
+package snippet
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestZshQuotesWordsBeforeXargs(t *testing.T) {
+	snippet := Zsh([]string{"hx"})
+
+	for _, expected := range []string{
+		"local raw_compline=${words[@]:0:$CURRENT}",
+		"local compline=${(j: :)${(qq)${words[@]:0:$CURRENT}}}",
+		`declare -x CARAPACE_COMPLINE="${raw_compline}"`,
+	} {
+		if !strings.Contains(snippet, expected) {
+			t.Fatalf("zsh snippet missing %q", expected)
+		}
+	}
+}
+
+func TestZshQuotedComplineKeepsInterpolationArgument(t *testing.T) {
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("zsh not available")
+	}
+
+	output, err := exec.Command("zsh", "-fc", `
+words=(hx --working-dir "\$(git rev-parse --show-toplevel)" --)
+CURRENT=4
+compline=${(j: :)${(qq)${words[@]:0:$CURRENT}}}
+print -r -- "${compline}''" | xargs -n1 printf '<%s>\n'
+`).CombinedOutput()
+	if err != nil {
+		t.Fatalf("zsh command failed: %v\n%s", err, output)
+	}
+
+	expected := "<hx>\n<--working-dir>\n<$(git rev-parse --show-toplevel)>\n<-->\n"
+	if string(output) != expected {
+		t.Fatalf("unexpected xargs output\nactual:\n%sexpected:\n%s", output, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Quote Zsh completion words before piping the completed line through `xargs`, so shell interpolation bodies stay a single argument.
- Keep `CARAPACE_COMPLINE` on the raw Zsh words for the existing formatting/quoting logic.
- Add focused Zsh snippet coverage for the interpolation/xargs behavior.

Closes #3472.

## Validation
- `go generate ./cmd/...`
- `go test ./cmd/carapace`
- `go test ./cmd/carapace/cmd/snippet ./cmd/carapace/cmd/completers`
- `go build -o /tmp/carapace-bin-local ./cmd/carapace`
- Simulated the previous Zsh/xargs path for `hx --working-dir $(git rev-parse --show-toplevel) --`; it reproduces `unknown flag: --show-toplevel)`.
- Simulated the patched Zsh/xargs path for both `$()` and backtick interpolation; both returned `hx` flag completions without the unknown-flag error.
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30` (`no leaks found`)

## Note
- I also tried `go test ./cmd/...`; locally it fails in unrelated cmd sandbox tests with `carapace resolves to executable in current directory (./carapace)`, so I did not count that as passing validation.