### PR TITLE
feat: add kcl completer

### DIFF
--- a/completers/common/kcl_completer/cmd/root.go
+++ b/completers/common/kcl_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "kcl",
+	Short:              "KCL configuration and policy language CLI",
+	Long:               "https://www.kcl-lang.io/docs/tools/cli/kcl/overview",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCobra("kcl"),
+	)
+}

--- a/completers/common/kcl_completer/main.go
+++ b/completers/common/kcl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/kcl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Closes #3242.

## Summary
- add a common `kcl` completer
- bridge to KCL's Cobra completion support via `bridge.ActionCobra("kcl")`

## Verification
- `go test ./completers/common/kcl_completer/...`
- `go run ./cmd/carapace-lint completers/common/kcl_completer/cmd/*.go`
- `go generate ./cmd/...`
- `go install -tags force_all ./cmd/carapace`
- `go test ./cmd/carapace-lint ./cmd/carapace-generate ./cmd/carapace-parse ./cmd/carapace-shim ./cmd/carapace`