### PR TITLE
feat: add osc completer

### DIFF
--- a/completers/common/osc_completer/cmd/root.go
+++ b/completers/common/osc_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "osc",
+	Short:              "OpenStack client written in Rust",
+	Long:               "https://gtema.github.io/openstack/",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionClap("osc"),
+	)
+}

--- a/completers/common/osc_completer/main.go
+++ b/completers/common/osc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/osc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Closes #2975.

## Summary
- add a common `osc` completer
- bridge to the Rust clap completion interface via `bridge.ActionClap("osc")`

## Verification
- `go test ./completers/common/osc_completer/...`
- `go run ./cmd/carapace-lint completers/common/osc_completer/cmd/*.go`
- `go generate ./cmd/...`
- `go install -tags force_all ./cmd/carapace`
- `go test ./cmd/carapace-lint ./cmd/carapace-generate ./cmd/carapace-parse ./cmd/carapace-shim ./cmd/carapace`