### PR TITLE
feat: add launchctl completer

### DIFF
--- a/completers/darwin/launchctl_completer/cmd/action/action.go
+++ b/completers/darwin/launchctl_completer/cmd/action/action.go
@@ -1,0 +1,142 @@
+package action
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/carapace-sh/carapace/pkg/style"
+)
+
+// ActionDomains completes launchd target domains.
+func ActionDomains() carapace.Action {
+	return carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
+		switch len(c.Parts) {
+		case 0:
+			return carapace.ActionValuesDescribed(
+				"system", "system-wide domain",
+				"user", "per-user domain",
+				"gui", "GUI user domain",
+				"session", "audit session domain",
+				"pid", "process domain",
+			).Suffix("/").StyleF(style.ForKeyword)
+		case 1:
+			switch c.Parts[0] {
+			case "user", "gui":
+				return ActionUserIds()
+			case "pid":
+				return ps.ActionProcessIds()
+			default:
+				return carapace.ActionValues()
+			}
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+// ActionServiceTargets completes launchd target specifiers, including services
+// under the current domain when launchctl can list them.
+func ActionServiceTargets() carapace.Action {
+	return carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
+		switch len(c.Parts) {
+		case 0:
+			return carapace.ActionValuesDescribed(
+				"system", "system-wide domain",
+				"user", "per-user domain",
+				"gui", "GUI user domain",
+				"session", "audit session domain",
+				"pid", "process domain",
+			).Suffix("/").StyleF(style.ForKeyword)
+		case 1:
+			switch c.Parts[0] {
+			case "system":
+				return ActionServices("system")
+			case "user", "gui":
+				return carapace.Batch(
+					ActionUserIds().Invoke(c).Suffix("/").ToA(),
+					ActionServices(c.Parts[0]),
+				).ToA()
+			case "pid":
+				return ps.ActionProcessIds().Invoke(c).Suffix("/").ToA()
+			default:
+				return carapace.ActionValues()
+			}
+		case 2:
+			switch c.Parts[0] {
+			case "user", "gui", "pid":
+				return ActionServices(strings.Join(c.Parts, "/"))
+			default:
+				return carapace.ActionValues()
+			}
+		default:
+			return carapace.ActionValues()
+		}
+	})
+}
+
+// ActionServices completes services in the current GUI domain.
+func ActionCurrentServices() carapace.Action {
+	uid := strconv.Itoa(os.Getuid())
+	return carapace.Batch(
+		ActionServices("gui/"+uid),
+		ActionServices("user/"+uid),
+		ActionServices("system"),
+	).ToA()
+}
+
+// ActionServices completes launchd service labels for a domain.
+func ActionServices(domain string) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		output, err := exec.Command("launchctl", "print", domain).Output()
+		if err != nil {
+			return carapace.ActionValues()
+		}
+
+		vals := make([]string, 0)
+		inServices := false
+		for _, line := range strings.Split(string(output), "\n") {
+			trimmed := strings.TrimSpace(line)
+			switch {
+			case trimmed == "services = {":
+				inServices = true
+				continue
+			case inServices && trimmed == "}":
+				inServices = false
+			case inServices:
+				fields := strings.Fields(trimmed)
+				if len(fields) == 0 {
+					continue
+				}
+				service := fields[len(fields)-1]
+				if strings.Contains(service, ".") {
+					vals = append(vals, service)
+				}
+			}
+		}
+
+		return carapace.ActionValues(vals...)
+	}).Tag("launchd services").Uid("launchctl", "services", "domain", domain)
+}
+
+// ActionUserIds completes local user ids.
+func ActionUserIds() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		content, err := os.ReadFile("/etc/passwd")
+		if err != nil {
+			return carapace.ActionValues(strconv.Itoa(os.Getuid()))
+		}
+
+		vals := make([]string, 0)
+		for _, entry := range strings.Split(string(content), "\n") {
+			fields := strings.Split(entry, ":")
+			if len(fields) > 4 {
+				vals = append(vals, fields[2], fields[0])
+			}
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	}).Tag("user ids").Uid("os", "uid")
+}

--- a/completers/darwin/launchctl_completer/cmd/root.go
+++ b/completers/darwin/launchctl_completer/cmd/root.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/darwin/launchctl_completer/cmd/action"
+	actionos "github.com/carapace-sh/carapace-bin/pkg/actions/os"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "launchctl",
+	Short: "Manage launchd agents and daemons",
+	Long:  "https://www.unix.com/man_page/osx/1/launchctl/",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.AddGroup(
+		&cobra.Group{ID: "domain", Title: "Domain Commands"},
+		&cobra.Group{ID: "service", Title: "Service Commands"},
+		&cobra.Group{ID: "legacy", Title: "Legacy Commands"},
+		&cobra.Group{ID: "manager", Title: "Manager Commands"},
+		&cobra.Group{ID: "other", Title: "Other Commands"},
+	)
+
+	addDomainCommand("bootstrap", "Bootstraps a domain or service into a domain")
+	addDomainCommand("bootout", "Tears down a domain or removes a service from a domain")
+	addServiceCommand("enable", "Enables an existing service")
+	addServiceCommand("disable", "Disables an existing service")
+	addServiceCommand("kickstart", "Forces an existing service to start")
+	addServiceCommand("attach", "Attach the system's debugger to a service")
+	addServiceCommand("debug", "Configures the next invocation of a service for debugging")
+	addServiceCommand("blame", "Prints the reason a service is running")
+	addServiceCommand("print", "Prints a description of a domain or service")
+
+	addCommand("kill", "Sends a signal to the service instance", "service", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(
+			ps.ActionKillSignals(),
+			action.ActionServiceTargets(),
+		)
+	})
+	addCommand("print-cache", "Prints information about the service cache", "service", nil)
+	addCommand("print-disabled", "Prints which services are disabled", "service", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(action.ActionDomains())
+	})
+	addCommand("print-token", "Prints service identifier given an xpc event token", "service", nil)
+
+	addCommand("plist", "Prints a property list embedded in a binary", "other", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(carapace.ActionFiles())
+	})
+	addCommand("procinfo", "Prints port information about a process", "other", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(ps.ActionProcessIds())
+	})
+	addCommand("hostinfo", "Prints port information about the host", "other", nil)
+	addCommand("resolveport", "Resolves a port name from a process to an endpoint in launchd", "other", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(ps.ActionProcessIds())
+	})
+	addCommand("limit", "Reads or modifies launchd's resource limits", "other", nil)
+	addCommand("examine", "Runs the specified analysis tool against launchd", "other", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(carapace.ActionExecutables())
+	})
+	addCommand("config", "Modifies persistent launchd domain configuration", "domain", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(
+			carapace.ActionValues("system", "user"),
+			carapace.ActionValues("umask", "path"),
+		)
+	})
+	addCommand("dumpstate", "Dumps launchd state to stdout", "manager", nil)
+	addCommand("dumpjpcategory", "Dumps jetsam properties category for all services", "manager", nil)
+	addCommand("reboot", "Initiates a system reboot of the specified type", "manager", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(carapace.ActionValues("system", "userspace", "halt", "logout", "apps"))
+	})
+	addCommand("bootshell", "Brings the system up from single-user mode with a console shell", "manager", nil)
+
+	addLegacyFileCommand("load", "Bootstraps a service or directory of services")
+	addLegacyFileCommand("unload", "Unloads a service or directory of services")
+	addLegacyServiceCommand("remove", "Unloads the specified service name")
+	addLegacyServiceCommand("list", "Lists information about services")
+	addLegacyServiceCommand("start", "Starts the specified service")
+	addLegacyServiceCommand("stop", "Stops the specified service if it is running")
+
+	addCommand("setenv", "Sets an environment variable for all services within the domain", "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(actionos.ActionEnvironmentVariables())
+	})
+	addCommand("unsetenv", "Unsets an environment variable from within launchd", "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(actionos.ActionEnvironmentVariables())
+	})
+	addCommand("getenv", "Gets the value of an environment variable from within launchd", "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(actionos.ActionEnvironmentVariables())
+	})
+	addCommand("bsexec", "Execute a program in another process' bootstrap context", "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(ps.ActionProcessIds(), carapace.ActionExecutables())
+	})
+	addCommand("asuser", "Execute a program in the bootstrap context of a given user", "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(action.ActionUserIds(), carapace.ActionExecutables())
+	})
+	addCommand("reload-atf", "Reloads the active trial factors", "legacy", nil)
+	addCommand("submit", "Submit a basic job from the command line", "legacy", nil)
+	addCommand("managerpid", "Prints the PID of the launchd controlling the session", "manager", nil)
+	addCommand("manageruid", "Prints the UID of the current launchd session", "manager", nil)
+	addCommand("managername", "Prints the name of the current launchd session", "manager", nil)
+	addCommand("error", "Prints a description of an error", "other", nil)
+	addCommand("variant", "Prints the launchd variant", "manager", nil)
+	addCommand("version", "Prints the launchd version", "manager", nil)
+	addCommand("help", "Prints the usage for a given subcommand", "other", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(actionSubcommands())
+	})
+}
+
+func addCommand(name string, short string, groupID string, configure func(*cobra.Command)) {
+	cmd := &cobra.Command{
+		Use:     name,
+		Short:   short,
+		GroupID: groupID,
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+	rootCmd.AddCommand(cmd)
+	if configure != nil {
+		configure(cmd)
+	}
+}
+
+func addDomainCommand(name string, short string) {
+	addCommand(name, short, "domain", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(action.ActionDomains())
+		carapace.Gen(cmd).PositionalAnyCompletion(carapace.ActionFiles(".plist"))
+	})
+}
+
+func addServiceCommand(name string, short string) {
+	addCommand(name, short, "service", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(action.ActionServiceTargets())
+	})
+}
+
+func addLegacyFileCommand(name string, short string) {
+	addCommand(name, short, "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalAnyCompletion(carapace.ActionFiles(".plist"))
+	})
+}
+
+func addLegacyServiceCommand(name string, short string) {
+	addCommand(name, short, "legacy", func(cmd *cobra.Command) {
+		carapace.Gen(cmd).PositionalCompletion(action.ActionCurrentServices())
+	})
+}
+
+func actionSubcommands() carapace.Action {
+	values := make([]string, 0)
+	for _, cmd := range rootCmd.Commands() {
+		values = append(values, cmd.Name(), cmd.Short)
+	}
+	return carapace.ActionValuesDescribed(values...)
+}

--- a/completers/darwin/launchctl_completer/main.go
+++ b/completers/darwin/launchctl_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/darwin/launchctl_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Closes #3360.\n\n## Summary\n- add a Darwin launchctl completer with grouped subcommands from launchctl help\n- complete launchd domains, user ids, process ids, plist files, signals, environment variables, and live service labels from launchctl print\n\n## Verification\n- go build ./completers/darwin/launchctl_completer/...\n- go run ./cmd/carapace-lint completers/darwin/launchctl_completer/cmd/action/*.go completers/darwin/launchctl_completer/cmd/*.go\n- go generate ./cmd/...\n- go install -tags force_all ./cmd/carapace\n- go test ./cmd/carapace-lint ./cmd/carapace-generate ./cmd/carapace-parse ./cmd/carapace-shim ./cmd/carapace\n- smoke: CARAPACE_COMPLINE='launchctl ' carapace launchctl zsh launchctl ''\n- smoke: CARAPACE_COMPLINE='launchctl kill ' carapace launchctl zsh launchctl kill ''\n- smoke: CARAPACE_COMPLINE='launchctl print gui/501/' carapace launchctl zsh launchctl print gui/501/