### PR TITLE
zsh: preserve command substitutions during completion

### DIFF
--- a/cmd/carapace/cmd/snippet/zsh.go
+++ b/cmd/carapace/cmd/snippet/zsh.go
@@ -13,7 +13,7 @@ func Zsh(completers []string) string {
 
 function _carapace_completer {
   local command="$(basename $words[1])"
-  local compline=${words[@]:0:$CURRENT}
+  local -a carapace_words=("${(@Q)${words[@]:0:$CURRENT}}")
   local IFS=$'\n'
   local lines
 
@@ -23,14 +23,8 @@ function _carapace_completer {
   declare -x CARAPACE_SHELL_BUILTINS="$(print -roC1 -- ${(k)builtins})"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(print -l ${(ok)functions})"
 
-  # shellcheck disable=SC2086,SC2154,SC2155
-  lines="$(echo "${compline}''" | xargs carapace "${command}" zsh 2>/dev/null)"
-  if [ $? -eq 1 ]; then
-    lines="$(echo "${compline}'" | xargs carapace "${command}" zsh 2>/dev/null)"
-    if [ $? -eq 1 ]; then
-      lines="$(echo "${compline}\"" | xargs carapace "${command}" zsh 2>/dev/null)"
-    fi
-  fi
+  # Use zsh's parsed words so command substitutions stay single arguments.
+  lines="$(carapace "${command}" zsh "${carapace_words[@]}" 2>/dev/null)"
 
   local zstyle message data
   IFS=$'\001' read -r -d '' zstyle message data <<<"${lines}"

--- a/cmd/carapace/cmd/snippet/zsh_test.go
+++ b/cmd/carapace/cmd/snippet/zsh_test.go
@@ -1,0 +1,68 @@
+package snippet
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestZshCommandSubstitutionWords(t *testing.T) {
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("zsh not available")
+	}
+
+	tests := map[string]string{
+		"dollar_parens": "$(git rev-parse --show-toplevel)",
+		"backticks":     "`git rev-parse --show-toplevel`",
+	}
+
+	for name, substitution := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			argsPath := filepath.Join(dir, "args")
+			scriptPath := filepath.Join(dir, "complete.zsh")
+
+			script := strings.Join([]string{
+				`compdef() { :; }`,
+				`zstyle() { :; }`,
+				`_message() { :; }`,
+				`_describe() { :; }`,
+				`carapace() { print -r -l -- "$@" >| "$CARAPACE_TEST_ARGS"; }`,
+				Zsh([]string{"hx"}),
+				`words=(hx --working-dir '` + substitution + `' --)`,
+				`CURRENT=4`,
+				`curcontext=carapace-test`,
+				`_carapace_completer`,
+			}, "\n")
+
+			if err := os.WriteFile(scriptPath, []byte(script), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command("zsh", "-f", scriptPath)
+			cmd.Env = append(os.Environ(), "CARAPACE_TEST_ARGS="+argsPath)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("zsh completion failed: %v\n%s", err, output)
+			}
+
+			content, err := os.ReadFile(argsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := strings.TrimSuffix(string(content), "\n")
+			want := strings.Join([]string{
+				"hx",
+				"zsh",
+				"hx",
+				"--working-dir",
+				substitution,
+				"--",
+			}, "\n")
+			if got != want {
+				t.Fatalf("args mismatch:\nwant:\n%s\n\ngot:\n%s", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3472.

### Summary
- pass zsh parsed words directly to carapace instead of rebuilding the line through xargs
- unquote zsh words before forwarding them so normal quoted arguments still arrive as argv values
- add a regression test for $() and backtick command substitutions

### Tests
- go generate ./cmd/...
- go test -v ./cmd/carapace/cmd/snippet

Note: go test ./cmd/carapace/cmd fails locally for existing sandbox expectations unrelated to this change: it reports carapace resolving to ./carapace and xterm style output differences.