### PR TITLE
mount: avoid linux-only completions on darwin

### DIFF
--- a/pkg/actions/fs/blockdevice.go
+++ b/pkg/actions/fs/blockdevice.go
@@ -3,6 +3,10 @@ package fs
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
 
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace/pkg/style"
@@ -20,16 +24,53 @@ type blockdevice struct {
 	Uuid         string
 }
 
+var darwinDiskIdentifierRegex = regexp.MustCompile(`^disk[0-9]+(s[0-9]+)*$`)
+
 func actionBlockdevices(f func(blockdevices []blockdevice) carapace.Action) carapace.Action {
-	return carapace.ActionExecCommand("lsblk", "--json", "-o", "KNAME,LABEL,PARTLABEL,PARTUUID,PATH,SIZE,PARTTYPENAME,TYPE,UUID")(func(output []byte) carapace.Action {
-		var b struct {
-			Blockdevices []blockdevice
+	switch runtime.GOOS {
+	case "linux":
+		return carapace.ActionExecCommand("lsblk", "--json", "-o", "KNAME,LABEL,PARTLABEL,PARTUUID,PATH,SIZE,PARTTYPENAME,TYPE,UUID")(func(output []byte) carapace.Action {
+			var b struct {
+				Blockdevices []blockdevice
+			}
+			if err := json.Unmarshal(output, &b); err != nil {
+				return carapace.ActionMessage(err.Error())
+			}
+			return f(b.Blockdevices)
+		})
+	case "darwin":
+		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return f(darwinBlockdevices())
+		})
+	default:
+		return f(nil)
+	}
+}
+
+func darwinBlockdevices() []blockdevice {
+	entries, err := os.ReadDir("/dev")
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return darwinBlockdevicesFromNames(names)
+}
+
+func darwinBlockdevicesFromNames(names []string) []blockdevice {
+	blockdevices := make([]blockdevice, 0)
+	for _, name := range names {
+		if !darwinDiskIdentifierRegex.MatchString(name) {
+			continue
 		}
-		if err := json.Unmarshal(output, &b); err != nil {
-			return carapace.ActionMessage(err.Error())
-		}
-		return f(b.Blockdevices)
-	})
+		blockdevices = append(blockdevices, blockdevice{
+			Kname: name,
+			Path:  "/dev/" + name,
+		})
+	}
+	return blockdevices
 }
 
 // ActionBlockDevices completes block devices
@@ -40,7 +81,7 @@ func ActionBlockDevices() carapace.Action {
 	return actionBlockdevices(func(blockdevices []blockdevice) carapace.Action {
 		vals := make([]string, 0)
 		for _, b := range blockdevices {
-			vals = append(vals, b.Path, fmt.Sprintf("%v %v", b.Size, b.Parttypename))
+			vals = append(vals, b.Path, strings.TrimSpace(fmt.Sprintf("%v %v", b.Size, b.Parttypename)))
 		}
 		return carapace.ActionValuesDescribed(vals...).StyleF(style.ForPath)
 	}).Tag("block devices")

--- a/pkg/actions/fs/mount.go
+++ b/pkg/actions/fs/mount.go
@@ -2,11 +2,17 @@ package fs
 
 import (
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace/pkg/style"
 )
+
+type mountEntry struct {
+	source string
+	target string
+}
 
 // ActionMounts completes file system mounts
 //
@@ -14,17 +20,67 @@ import (
 //	/dev (dev)
 func ActionMounts() carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		switch runtime.GOOS {
+		case "darwin", "freebsd", "netbsd", "openbsd":
+			return actionMountsFromMountCommand()
+		default:
+			return actionMountsFromProc()
+		}
+	}).Tag("mounts")
+}
+
+func actionMountsFromMountCommand() carapace.Action {
+	return carapace.ActionExecCommand("mount")(func(output []byte) carapace.Action {
+		return actionMountEntries(parseMountOutput(string(output)))
+	})
+}
+
+func actionMountsFromProc() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 		content, err := os.ReadFile("/proc/mounts")
 		if err != nil {
 			return carapace.ActionMessage(err.Error())
 		}
-		lines := strings.Split(string(content), "\n")
-		vals := make([]string, 0)
-		for _, line := range lines {
-			if fields := strings.Fields(line); len(fields) > 1 {
-				vals = append(vals, strings.Replace(fields[1], `\040`, " ", -1), fields[0])
-			}
+		return actionMountEntries(parseProcMounts(string(content)))
+	})
+}
+
+func parseProcMounts(content string) []mountEntry {
+	lines := strings.Split(content, "\n")
+	entries := make([]mountEntry, 0)
+	for _, line := range lines {
+		if fields := strings.Fields(line); len(fields) > 1 {
+			entries = append(entries, mountEntry{
+				source: fields[0],
+				target: strings.Replace(fields[1], `\040`, " ", -1),
+			})
 		}
-		return carapace.ActionValuesDescribed(vals...).StyleF(style.ForPath)
-	}).Tag("mounts")
+	}
+	return entries
+}
+
+func parseMountOutput(output string) []mountEntry {
+	lines := strings.Split(output, "\n")
+	entries := make([]mountEntry, 0)
+	for _, line := range lines {
+		source, target, ok := strings.Cut(line, " on ")
+		if !ok {
+			continue
+		}
+		target, _, ok = strings.Cut(target, " (")
+		if !ok {
+			continue
+		}
+		entries = append(entries, mountEntry{source: source, target: target})
+	}
+	return entries
+}
+
+func actionMountEntries(entries []mountEntry) carapace.Action {
+	vals := make([]string, 0)
+	for _, entry := range entries {
+		vals = append(vals, entry.target, entry.source)
+		vals = append(vals, entry.source, entry.target)
+	}
+	return carapace.ActionValuesDescribed(vals...).StyleF(style.ForPath)
 }

--- a/pkg/actions/fs/mount_test.go
+++ b/pkg/actions/fs/mount_test.go
@@ -1,0 +1,46 @@
+package fs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProcMounts(t *testing.T) {
+	input := "/dev/sda1 /boot/efi vfat rw 0 0\n" +
+		"tmpfs /run/user/1000/gvfs\\040mount fuse rw 0 0\n"
+
+	want := []mountEntry{
+		{source: "/dev/sda1", target: "/boot/efi"},
+		{source: "tmpfs", target: "/run/user/1000/gvfs mount"},
+	}
+	if got := parseProcMounts(input); !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseProcMounts() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseMountOutput(t *testing.T) {
+	input := "/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)\n" +
+		"map auto_home on /System/Volumes/Data/home (autofs, automounted, nobrowse)\n" +
+		"not a mount line\n"
+
+	want := []mountEntry{
+		{source: "/dev/disk3s1s1", target: "/"},
+		{source: "map auto_home", target: "/System/Volumes/Data/home"},
+	}
+	if got := parseMountOutput(input); !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMountOutput() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDarwinBlockdevicesFromNames(t *testing.T) {
+	names := []string{"disk0", "disk0s1", "rdisk0", "diskarbitrationd", "disk3s1s1"}
+
+	want := []blockdevice{
+		{Kname: "disk0", Path: "/dev/disk0"},
+		{Kname: "disk0s1", Path: "/dev/disk0s1"},
+		{Kname: "disk3s1s1", Path: "/dev/disk3s1s1"},
+	}
+	if got := darwinBlockdevicesFromNames(names); !reflect.DeepEqual(got, want) {
+		t.Fatalf("darwinBlockdevicesFromNames() = %#v, want %#v", got, want)
+	}
+}

--- a/pkg/actions/tools/mount/source.go
+++ b/pkg/actions/tools/mount/source.go
@@ -1,6 +1,8 @@
 package mount
 
 import (
+	"runtime"
+
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/fs"
 )
@@ -8,10 +10,12 @@ import (
 // ActionSources completes sources
 func ActionSources() carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		return carapace.Batch(
+		actions := []carapace.Action{
 			fs.ActionBlockDevices(),
 			carapace.ActionFiles(),
-			carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+		}
+		if runtime.GOOS == "linux" {
+			actions = append(actions, carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
 					return carapace.ActionValuesDescribed(
@@ -40,7 +44,8 @@ func ActionSources() carapace.Action {
 				default:
 					return carapace.ActionValues()
 				}
-			}),
-		).ToA()
+			}))
+		}
+		return carapace.Batch(actions...).ToA()
 	}).Tag("sources")
 }


### PR DESCRIPTION
Fixes #3094.

## Summary
- use `mount` output instead of `/proc/mounts` for Darwin/BSD mountpoint completions
- complete Darwin block devices from `/dev/disk*` instead of invoking Linux-only `lsblk`
- hide Linux-only `LABEL=`, `UUID=`, `PARTLABEL=`, `PARTUUID=`, and `ID=` source forms off Linux
- add parser coverage for proc mounts, BSD mount output, and Darwin disk device names

## Tests
- `go test ./pkg/actions/fs ./pkg/actions/tools/mount`
- `go test ./pkg/actions/... ./completers/common/mount_completer/... ./completers/common/umount_completer/...`
- `go run ./cmd/carapace umount zsh umount ""`
- `go run ./cmd/carapace mount zsh mount ""`
- `env CARAPACE_COLOR=1 go test ./...` currently fails in `cmd/carapace/cmd` because local test resolution finds `./carapace`; touched packages pass.