### PR TITLE
feat(completers): add zig completer

### DIFF
--- a/completers/common/zig_completer/cmd/ar.go
+++ b/completers/common/zig_completer/cmd/ar.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var arCmd = &cobra.Command{
+	Use:                "ar",
+	Short:              "Use Zig as a drop-in archiver",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func init() {
+	carapace.Gen(arCmd).Standalone()
+
+	rootCmd.AddCommand(arCmd)
+
+	carapace.Gen(arCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/ast-check.go
+++ b/completers/common/zig_completer/cmd/ast-check.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var astCheckCmd = &cobra.Command{
+	Use:   "ast-check",
+	Short: "Look for simple compile errors in any set of files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(astCheckCmd).Standalone()
+
+	rootCmd.AddCommand(astCheckCmd)
+
+	carapace.Gen(astCheckCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".zig"),
+	)
+}

--- a/completers/common/zig_completer/cmd/build-exe.go
+++ b/completers/common/zig_completer/cmd/build-exe.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var buildExeCmd = &cobra.Command{
+	Use:   "build-exe",
+	Short: "Create executable from source or object files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(buildExeCmd).Standalone()
+
+	addBuildFlags(buildExeCmd)
+	rootCmd.AddCommand(buildExeCmd)
+
+	carapace.Gen(buildExeCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".zig", ".c", ".cpp", ".o", ".a"),
+	)
+}

--- a/completers/common/zig_completer/cmd/build-lib.go
+++ b/completers/common/zig_completer/cmd/build-lib.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var buildLibCmd = &cobra.Command{
+	Use:   "build-lib",
+	Short: "Create library from source or object files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(buildLibCmd).Standalone()
+
+	addBuildFlags(buildLibCmd)
+	rootCmd.AddCommand(buildLibCmd)
+
+	carapace.Gen(buildLibCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".zig", ".c", ".cpp", ".o", ".a"),
+	)
+}

--- a/completers/common/zig_completer/cmd/build-obj.go
+++ b/completers/common/zig_completer/cmd/build-obj.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var buildObjCmd = &cobra.Command{
+	Use:   "build-obj",
+	Short: "Create object from source or object files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(buildObjCmd).Standalone()
+
+	addBuildFlags(buildObjCmd)
+	rootCmd.AddCommand(buildObjCmd)
+
+	carapace.Gen(buildObjCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".zig", ".c", ".cpp", ".o", ".a"),
+	)
+}

--- a/completers/common/zig_completer/cmd/build.go
+++ b/completers/common/zig_completer/cmd/build.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var buildCmd = &cobra.Command{
+	Use:                "build",
+	Short:              "Build project from build.zig",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func init() {
+	carapace.Gen(buildCmd).Standalone()
+
+	rootCmd.AddCommand(buildCmd)
+
+	carapace.Gen(buildCmd).PositionalAnyCompletion(
+		carapace.Batch(
+			carapace.ActionValues(
+				"-Doptimize=Debug",
+				"-Doptimize=ReleaseSafe",
+				"-Doptimize=ReleaseFast",
+				"-Doptimize=ReleaseSmall",
+				"-Dtarget=native",
+				"-Dtarget=x86_64-linux",
+				"-Dtarget=x86_64-linux-gnu",
+				"-Dtarget=x86_64-linux-musl",
+				"-Dtarget=x86_64-windows",
+				"-Dtarget=x86_64-windows-gnu",
+				"-Dtarget=x86_64-windows-msvc",
+				"-Dtarget=x86_64-macos",
+				"-Dtarget=aarch64-linux",
+				"-Dtarget=aarch64-linux-gnu",
+				"-Dtarget=aarch64-linux-musl",
+				"-Dtarget=aarch64-macos",
+				"-Dtarget=aarch64-windows",
+				"-Dtarget=wasm32-wasi",
+				"-Dtarget=wasm32-freestanding",
+			),
+			carapace.ActionValues(
+				"--help",
+				"--build-file",
+				"--cache-dir",
+				"--global-cache-dir",
+				"--zig-lib-dir",
+				"--prefix",
+				"--prefix-lib-dir",
+				"--prefix-exe-dir",
+				"--prefix-include-dir",
+				"--release",
+				"--verbose",
+				"--summary",
+				"--prominent-compile-errors",
+				"--watch",
+				"--fetch",
+			),
+		).ToA(),
+	)
+}

--- a/completers/common/zig_completer/cmd/c++.go
+++ b/completers/common/zig_completer/cmd/c++.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var cxxCmd = &cobra.Command{
+	Use:                "c++",
+	Short:              "Use Zig as a drop-in C++ compiler",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func init() {
+	carapace.Gen(cxxCmd).Standalone()
+
+	rootCmd.AddCommand(cxxCmd)
+
+	carapace.Gen(cxxCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/cc.go
+++ b/completers/common/zig_completer/cmd/cc.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var ccCmd = &cobra.Command{
+	Use:                "cc",
+	Short:              "Use Zig as a drop-in C compiler",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func init() {
+	carapace.Gen(ccCmd).Standalone()
+
+	rootCmd.AddCommand(ccCmd)
+
+	carapace.Gen(ccCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/env.go
+++ b/completers/common/zig_completer/cmd/env.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Print lib path, std path, cache directory, and version",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(envCmd).Standalone()
+
+	rootCmd.AddCommand(envCmd)
+}

--- a/completers/common/zig_completer/cmd/fetch.go
+++ b/completers/common/zig_completer/cmd/fetch.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var fetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Copy a package into the global cache and print its hash",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(fetchCmd).Standalone()
+
+	fetchCmd.Flags().StringP("global-cache-dir", "", "", "Override path to global Zig cache directory")
+	fetchCmd.Flags().Bool("debug-hash", false, "Print verbose hash information to stdout")
+	fetchCmd.Flags().Bool("save", false, "Add the fetched package to build.zig.zon")
+	fetchCmd.Flags().String("save-exact", "", "Add the fetched package to build.zig.zon, pinned to the precise URL")
+	fetchCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(fetchCmd)
+
+	carapace.Gen(fetchCmd).FlagCompletion(carapace.ActionMap{
+		"global-cache-dir": carapace.ActionDirectories(),
+	})
+
+	carapace.Gen(fetchCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/flags.go
+++ b/completers/common/zig_completer/cmd/flags.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+// addBuildFlags registers common build flags shared by `zig build-exe`,
+// `zig build-lib`, and `zig build-obj`.
+func addBuildFlags(c *cobra.Command) {
+	c.Flags().StringP("name", "", "", "Override root name")
+	c.Flags().StringP("target", "", "", "<arch><sub>-<os>-<abi>")
+	c.Flags().StringP("mcpu", "", "", "Specify target CPU and feature set")
+	c.Flags().StringP("O", "", "", "Choose what to optimize for")
+	c.Flags().Bool("strip", false, "Omit debug symbols")
+	c.Flags().Bool("single-threaded", false, "Code assumes there is only one thread")
+	c.Flags().Bool("static", false, "Output will be statically linked")
+	c.Flags().Bool("dynamic", false, "Force output to be dynamically linked")
+	c.Flags().Bool("dynamic-linker", false, "Set the dynamic interpreter path")
+	c.Flags().StringP("femit-bin", "", "", "Output machine code")
+	c.Flags().StringP("femit-asm", "", "", "Output assembly code")
+	c.Flags().StringP("femit-llvm-ir", "", "", "Output the LLVM IR")
+	c.Flags().StringP("femit-h", "", "", "Output a C header file")
+	c.Flags().BoolP("help", "h", false, "Print help")
+
+	carapace.Gen(c).FlagCompletion(carapace.ActionMap{
+		"O": carapace.ActionValues(
+			"Debug",
+			"ReleaseSafe",
+			"ReleaseFast",
+			"ReleaseSmall",
+		),
+	})
+}

--- a/completers/common/zig_completer/cmd/fmt.go
+++ b/completers/common/zig_completer/cmd/fmt.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var fmtCmd = &cobra.Command{
+	Use:   "fmt",
+	Short: "Reformat Zig source into canonical form",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(fmtCmd).Standalone()
+
+	fmtCmd.Flags().Bool("check", false, "List non-conforming files and exit with an error if the list is non-empty")
+	fmtCmd.Flags().Bool("ast-check", false, "Run zig ast-check on every file")
+	fmtCmd.Flags().Bool("color", false, "Enable or disable colored error messages")
+	fmtCmd.Flags().Bool("stdin", false, "Format code from stdin; output to stdout")
+	fmtCmd.Flags().StringP("exclude", "", "", "Exclude file or directory from formatting")
+	fmtCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(fmtCmd)
+
+	carapace.Gen(fmtCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(".zig"),
+	)
+}

--- a/completers/common/zig_completer/cmd/init-exe.go
+++ b/completers/common/zig_completer/cmd/init-exe.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var initExeCmd = &cobra.Command{
+	Use:   "init-exe",
+	Short: "Initialize a `zig build` application in the current directory",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(initExeCmd).Standalone()
+
+	rootCmd.AddCommand(initExeCmd)
+}

--- a/completers/common/zig_completer/cmd/init-lib.go
+++ b/completers/common/zig_completer/cmd/init-lib.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var initLibCmd = &cobra.Command{
+	Use:   "init-lib",
+	Short: "Initialize a `zig build` library in the current directory",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(initLibCmd).Standalone()
+
+	rootCmd.AddCommand(initLibCmd)
+}

--- a/completers/common/zig_completer/cmd/init.go
+++ b/completers/common/zig_completer/cmd/init.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a Zig package in the current directory",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(initCmd).Standalone()
+
+	initCmd.Flags().Bool("strip", false, "Omit debug symbols")
+	initCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(initCmd)
+}

--- a/completers/common/zig_completer/cmd/ld.go
+++ b/completers/common/zig_completer/cmd/ld.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var ldCmd = &cobra.Command{
+	Use:                "ld",
+	Short:              "Use Zig as a drop-in linker",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func init() {
+	carapace.Gen(ldCmd).Standalone()
+
+	rootCmd.AddCommand(ldCmd)
+
+	carapace.Gen(ldCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/libc.go
+++ b/completers/common/zig_completer/cmd/libc.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var libcCmd = &cobra.Command{
+	Use:   "libc",
+	Short: "Display native libc paths file or validate one",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(libcCmd).Standalone()
+
+	libcCmd.Flags().StringP("target", "", "", "<arch><sub>-<os>-<abi>")
+	libcCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(libcCmd)
+
+	carapace.Gen(libcCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/objcopy.go
+++ b/completers/common/zig_completer/cmd/objcopy.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var objcopyCmd = &cobra.Command{
+	Use:   "objcopy",
+	Short: "Copy and translate object files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(objcopyCmd).Standalone()
+
+	objcopyCmd.Flags().StringP("output-target", "O", "", "Format of the output file")
+	objcopyCmd.Flags().StringP("only-section", "j", "", "Remove all but <section>")
+	objcopyCmd.Flags().Bool("strip-debug", false, "Remove debugging symbols only")
+	objcopyCmd.Flags().Bool("strip-all", false, "Remove all symbols")
+	objcopyCmd.Flags().Bool("only-keep-debug", false, "Strip a file, but keep debug sections")
+	objcopyCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(objcopyCmd)
+
+	carapace.Gen(objcopyCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/common/zig_completer/cmd/root.go
+++ b/completers/common/zig_completer/cmd/root.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "zig",
+	Short: "Programming language designed for robustness, optimality, and clarity",
+	Long:  "https://ziglang.org/",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "Print help")
+	rootCmd.Flags().BoolP("version", "v", false, "Print version")
+}

--- a/completers/common/zig_completer/cmd/run.go
+++ b/completers/common/zig_completer/cmd/run.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Create executable and run immediately",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(runCmd).Standalone()
+
+	runCmd.Flags().StringP("femit-bin", "", "", "Output machine code")
+	runCmd.Flags().String("name", "", "Override root name")
+	runCmd.Flags().Bool("strip", false, "Omit debug symbols")
+	runCmd.Flags().StringP("target", "", "", "<arch><sub>-<os>-<abi>")
+	runCmd.Flags().StringP("mcpu", "", "", "Specify target CPU and feature set")
+	runCmd.Flags().StringP("O", "", "", "Choose what to optimize for")
+	runCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(runCmd)
+
+	carapace.Gen(runCmd).FlagCompletion(carapace.ActionMap{
+		"O": carapace.ActionValues(
+			"Debug",
+			"ReleaseSafe",
+			"ReleaseFast",
+			"ReleaseSmall",
+		),
+	})
+
+	carapace.Gen(runCmd).PositionalCompletion(
+		carapace.ActionFiles(".zig"),
+	)
+}

--- a/completers/common/zig_completer/cmd/targets.go
+++ b/completers/common/zig_completer/cmd/targets.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var targetsCmd = &cobra.Command{
+	Use:   "targets",
+	Short: "List available compilation targets",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(targetsCmd).Standalone()
+
+	rootCmd.AddCommand(targetsCmd)
+}

--- a/completers/common/zig_completer/cmd/test.go
+++ b/completers/common/zig_completer/cmd/test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Perform unit testing",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(testCmd).Standalone()
+
+	testCmd.Flags().StringP("test-filter", "", "", "Skip tests that do not match any filter")
+	testCmd.Flags().StringP("test-name-prefix", "", "", "Prefix all tests with given string")
+	testCmd.Flags().Bool("test-cmd-bin", false, "Appends test binary path to test-cmd argv")
+	testCmd.Flags().Bool("test-evented-io", false, "Runs the test in evented I/O mode")
+	testCmd.Flags().Bool("test-no-exec", false, "Compiles test binary without running it")
+	testCmd.Flags().StringP("name", "", "", "Override root name")
+	testCmd.Flags().Bool("strip", false, "Omit debug symbols")
+	testCmd.Flags().StringP("target", "", "", "<arch><sub>-<os>-<abi>")
+	testCmd.Flags().StringP("mcpu", "", "", "Specify target CPU and feature set")
+	testCmd.Flags().StringP("O", "", "", "Choose what to optimize for")
+	testCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(testCmd)
+
+	carapace.Gen(testCmd).FlagCompletion(carapace.ActionMap{
+		"O": carapace.ActionValues(
+			"Debug",
+			"ReleaseSafe",
+			"ReleaseFast",
+			"ReleaseSmall",
+		),
+	})
+
+	carapace.Gen(testCmd).PositionalCompletion(
+		carapace.ActionFiles(".zig"),
+	)
+}

--- a/completers/common/zig_completer/cmd/translate-c.go
+++ b/completers/common/zig_completer/cmd/translate-c.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var translateCCmd = &cobra.Command{
+	Use:   "translate-c",
+	Short: "Convert C code to Zig code",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(translateCCmd).Standalone()
+
+	translateCCmd.Flags().StringP("target", "", "", "<arch><sub>-<os>-<abi>")
+	translateCCmd.Flags().StringP("cflags", "", "", "Set extra flags for the C compiler")
+	translateCCmd.Flags().BoolP("help", "h", false, "Print help")
+
+	rootCmd.AddCommand(translateCCmd)
+
+	carapace.Gen(translateCCmd).PositionalCompletion(
+		carapace.ActionFiles(".c", ".h"),
+	)
+}

--- a/completers/common/zig_completer/cmd/version.go
+++ b/completers/common/zig_completer/cmd/version.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version number and exit",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(versionCmd).Standalone()
+
+	rootCmd.AddCommand(versionCmd)
+}

--- a/completers/common/zig_completer/main.go
+++ b/completers/common/zig_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/zig_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary

Adds a new completer for [Zig](https://ziglang.org/), porting the subcommands and common flags from the upstream [shell-completions](https://codeberg.org/ziglang/shell-completions) project.

Covered subcommands:
- `build`, `build-exe`, `build-lib`, `build-obj` (with common build flags shared via `flags.go`, including `-Doptimize=...` and `-Dtarget=...` values)
- `init`, `init-exe`, `init-lib`
- `run`, `test`, `fmt` (with `.zig` file completion)
- `cc`, `c++`, `ar`, `ld`, `objcopy` (drop-in C/C++/archiver/linker/objcopy tools)
- `translate-c`, `ast-check`, `fetch`, `libc`
- `version`, `env`, `targets`

## Test plan

- [x] `go build ./completers/common/zig_completer/...`
- [x] `go test ./completers/common/zig_completer/...`
- [x] `gofmt -l ./completers/common/zig_completer/` produces no output
- [x] `carapace-lint completers/common/zig_completer/` produces no output
- [x] `go run ./completers/common/zig_completer/ _carapace bash zig ""` lists all subcommands

Fixes #3419.

/claim #3419