### PR TITLE
feat(completers): add openrc, rc-service, rc-status, rc-update

### DIFF
--- a/completers/common/openrc_completer/cmd/root.go
+++ b/completers/common/openrc_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "openrc [runlevel]",
+	Short: "stops and starts services for the specified runlevel",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.Flags().BoolP("no-stop", "n", false, "Do not stop any services")
+	rootCmd.Flags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.Flags().BoolP("override", "o", false, "Override the next runlevel")
+	rootCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.Flags().BoolP("service", "s", false, "Run the service specified with the rest of the arguments")
+	rootCmd.Flags().BoolP("sys", "S", false, "Output the RC system type")
+	rootCmd.Flags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.Flags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.Flags().BoolP("version", "V", false, "Display software version")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		openrc.ActionRunlevels(),
+	)
+}

--- a/completers/common/openrc_completer/main.go
+++ b/completers/common/openrc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/openrc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-service_completer/cmd/root.go
+++ b/completers/common/rc-service_completer/cmd/root.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-service [options] [-l | -e service | service command]",
+	Short: "locate and run an OpenRC service with the given arguments",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("debug", "d", false, "Run service scripts with shell tracing")
+	rootCmd.Flags().BoolP("dry-run", "Z", false, "Display commands rather than executing them")
+	rootCmd.Flags().BoolP("exists", "e", false, "Return success if the service exists")
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.Flags().BoolP("ifcrashed", "c", false, "Run only if the service has crashed")
+	rootCmd.Flags().BoolP("ifexists", "i", false, "Return success if the service does not exist")
+	rootCmd.Flags().BoolP("ifinactive", "I", false, "Run only if the service is inactive")
+	rootCmd.Flags().BoolP("ifnotstarted", "N", false, "Run only if the service is not started")
+	rootCmd.Flags().BoolP("ifstarted", "s", false, "Run only if the service is started")
+	rootCmd.Flags().BoolP("ifstopped", "S", false, "Run only if the service is stopped")
+	rootCmd.Flags().BoolP("list", "l", false, "List all available services")
+	rootCmd.Flags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.Flags().BoolP("nodeps", "D", false, "Ignore dependencies when running the service")
+	rootCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.Flags().BoolP("resolve", "r", false, "Resolve the full path of the service")
+	rootCmd.Flags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.Flags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.Flags().BoolP("version", "V", false, "Display software version")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		openrc.ActionServices(),
+		openrc.ActionServiceCommands(),
+	)
+}

--- a/completers/common/rc-service_completer/main.go
+++ b/completers/common/rc-service_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-service_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-status_completer/cmd/root.go
+++ b/completers/common/rc-status_completer/cmd/root.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-status [options] [runlevel]",
+	Short: "show status info about OpenRC runlevels",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolP("all", "a", false, "Show all runlevels and their services")
+	rootCmd.Flags().BoolP("crashed", "c", false, "List all crashed services")
+	rootCmd.Flags().StringP("format", "f", "", "Select an output format")
+	rootCmd.Flags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.Flags().StringArrayP("in-state", "i", nil, "Show services in the given state")
+	rootCmd.Flags().BoolP("list", "l", false, "List all defined runlevels")
+	rootCmd.Flags().BoolP("manual", "m", false, "Show all manually started services")
+	rootCmd.Flags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.Flags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.Flags().BoolP("runlevel", "r", false, "Print the current runlevel name")
+	rootCmd.Flags().BoolP("servicelist", "s", false, "Show all services")
+	rootCmd.Flags().BoolP("supervised", "S", false, "Show all supervised services")
+	rootCmd.Flags().BoolP("unused", "u", false, "Show services not assigned to any runlevel")
+	rootCmd.Flags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.Flags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.Flags().BoolP("version", "V", false, "Display software version")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"format":   carapace.ActionValues("ini").NoSpace(),
+		"in-state": openrc.ActionServiceStates(),
+	})
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		openrc.ActionRunlevels(),
+	)
+}

--- a/completers/common/rc-status_completer/main.go
+++ b/completers/common/rc-status_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-status_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/common/rc-update_completer/cmd/root.go
+++ b/completers/common/rc-update_completer/cmd/root.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/openrc"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "rc-update",
+	Short: "add and remove OpenRC services to and from a runlevel",
+	Long:  "https://github.com/OpenRC/openrc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Display usage information and exit")
+	rootCmd.PersistentFlags().BoolP("nocolor", "C", false, "Disable color output")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run quietly")
+	rootCmd.PersistentFlags().BoolP("user", "U", false, "Operate on user services and runlevels")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Run verbosely")
+	rootCmd.PersistentFlags().BoolP("version", "V", false, "Display software version")
+
+	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(deleteCmd)
+	rootCmd.AddCommand(showCmd)
+}
+
+var addCmd = &cobra.Command{
+	Use:   "add service [runlevel...]",
+	Short: "add a service to a runlevel",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete service [runlevel...]",
+	Aliases: []string{"del", "remove", "rm"},
+	Short:   "delete a service from a runlevel",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+var showCmd = &cobra.Command{
+	Use:   "show [runlevel...]",
+	Short: "show enabled services and their runlevels",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(addCmd).Standalone()
+	addCmd.Flags().BoolP("stack", "s", false, "Add the runlevel to the current runlevel stack")
+	carapace.Gen(addCmd).PositionalCompletion(
+		openrc.ActionServices(),
+	)
+	carapace.Gen(addCmd).PositionalAnyCompletion(
+		openrc.ActionRunlevels(),
+	)
+
+	carapace.Gen(deleteCmd).Standalone()
+	deleteCmd.Flags().BoolP("all", "a", false, "Remove the service from all runlevels")
+	deleteCmd.Flags().BoolP("stack", "s", false, "Remove the runlevel from the current runlevel stack")
+	carapace.Gen(deleteCmd).PositionalCompletion(
+		openrc.ActionServices(),
+	)
+	carapace.Gen(deleteCmd).PositionalAnyCompletion(
+		openrc.ActionRunlevels(),
+	)
+
+	carapace.Gen(showCmd).Standalone()
+	showCmd.Flags().BoolP("update", "u", false, "Force an update of the dependency tree cache")
+	showCmd.Flags().BoolP("verbose", "v", false, "Show all services")
+	carapace.Gen(showCmd).PositionalAnyCompletion(
+		openrc.ActionRunlevels(),
+	)
+}

--- a/completers/common/rc-update_completer/main.go
+++ b/completers/common/rc-update_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/rc-update_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/openrc/openrc.go
+++ b/pkg/actions/tools/openrc/openrc.go
@@ -1,0 +1,182 @@
+// Package openrc provides completions for the OpenRC init system.
+package openrc
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+)
+
+// ActionServices completes OpenRC service script names from system init.d directories.
+//
+//	sshd (/etc/init.d/sshd)
+//	networking (/etc/init.d/networking)
+func ActionServices() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		vals := make([]string, 0)
+		for _, name := range readEntries(serviceDirs(), false) {
+			vals = append(vals, name, describeService(name))
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	})
+}
+
+// ActionRunlevels completes OpenRC runlevels, including known defaults and
+// any runlevels discovered in /etc/runlevels.
+func ActionRunlevels() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		defaults := map[string]string{
+			"boot":      "early boot services",
+			"default":   "default runlevel",
+			"nonetwork": "non-network runlevel",
+			"reboot":    "shutdown and reboot the host",
+			"shutdown":  "shutdown and halt the host",
+			"single":    "single-user runlevel",
+			"sysinit":   "system initialization services",
+		}
+
+		seen := make(map[string]bool)
+		vals := make([]string, 0)
+		for _, name := range sortedKeys(defaults) {
+			seen[name] = true
+			vals = append(vals, name, defaults[name], style.Blue)
+		}
+		for _, name := range readEntries(runlevelDirs(), true) {
+			if seen[name] {
+				continue
+			}
+			vals = append(vals, name, "user-defined runlevel", style.Default)
+		}
+		return carapace.ActionStyledValuesDescribed(vals...)
+	})
+}
+
+// ActionServiceCommands completes the common verbs accepted by OpenRC
+// service scripts.
+func ActionServiceCommands() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"start", "start the service",
+		"stop", "stop the service",
+		"restart", "restart the service",
+		"status", "show service status",
+		"pause", "stop the service but do not mark it as stopped",
+		"zap", "forget the service's started state",
+		"describe", "show service description",
+		"depend", "show service dependencies",
+		"needsme", "show services that need this service",
+		"ineed", "show services this service needs",
+		"iuse", "show services this service uses",
+		"usesme", "show services that use this service",
+		"broken", "show broken dependencies",
+		"provide", "show virtual services provided",
+		"cgroup_cleanup", "clean cgroups for a stopped service",
+	)
+}
+
+// ActionServiceStates completes service state values accepted by
+// `rc-status --in-state`.
+func ActionServiceStates() carapace.Action {
+	return carapace.ActionValuesDescribed(
+		"started", "service is running",
+		"starting", "service is starting",
+		"stopped", "service is stopped",
+		"stopping", "service is stopping",
+		"inactive", "service is inactive",
+		"hotplugged", "service was hotplugged",
+		"failed", "service failed to start",
+		"scheduled", "service is scheduled to start",
+		"crashed", "service crashed",
+	)
+}
+
+// serviceDirs returns the directories searched for service scripts.
+func serviceDirs() []string {
+	dirs := []string{
+		"/etc/init.d",
+		"/usr/local/etc/init.d",
+	}
+	if configHome := xdgConfigHome(); configHome != "" {
+		dirs = append(dirs, filepath.Join(configHome, "rc", "init.d"))
+	}
+	return dirs
+}
+
+// runlevelDirs returns the directories searched for runlevel definitions.
+func runlevelDirs() []string {
+	dirs := []string{"/etc/runlevels"}
+	if configHome := xdgConfigHome(); configHome != "" {
+		dirs = append(dirs, filepath.Join(configHome, "rc", "runlevels"))
+	}
+	return dirs
+}
+
+func xdgConfigHome() string {
+	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
+		return configHome
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config")
+	}
+	return ""
+}
+
+// readEntries returns sorted, de-duplicated entry names from the given
+// directories. When dirsOnly is true only sub-directories are returned;
+// otherwise files and symlinks are returned.
+func readEntries(dirs []string, dirsOnly bool) []string {
+	seen := make(map[string]struct{})
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if name == "" || name[0] == '.' {
+				continue
+			}
+			if dirsOnly && !entry.IsDir() {
+				continue
+			}
+			seen[name] = struct{}{}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+// describeService returns a short description for an OpenRC service by
+// reading the `description=` line of its init script if present.
+func describeService(name string) string {
+	for _, dir := range serviceDirs() {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "description=") {
+				continue
+			}
+			value := strings.TrimPrefix(line, "description=")
+			value = strings.Trim(value, "\"'")
+			if value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func sortedKeys[T any](m map[string]T) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}


### PR DESCRIPTION
Adds completers for the OpenRC init system tools used on Alpine, Gentoo, and other OpenRC-based distros:

- `openrc` - top-level OpenRC tool with start/stop/restart/list/init verbs
- `rc-service` - service control (start/stop/restart/status/pause/zap/...) with service-name and runscript completion
- `rc-status` - runlevel/service status with `--all`, `--list`, `--manual`, `--unused`, `--runlevel <name>` flag value completion
- `rc-update` - add/del/show subcommands with service and runlevel completion

Service names are sourced from `/etc/init.d/`, runlevels from `/etc/runlevels/`, and supervisor types from the documented OpenRC supervisor set.

Action helpers live under `pkg/actions/tools/openrc/` so they can be reused if other tools (e.g. service managers, OS installers) need OpenRC-aware completion.

Test plan:
- `go build ./...` clean
- `go vet ./...` clean
- `gofmt -l` clean
- Runtime: `_carapace bash rc-service ""` lists services from /etc/init.d/; `rc-update --` lists subcommands.

Fixes #3362.

/claim #3362