### PR TITLE
fix: Default() and strings.ReplaceAll in pkg/actions

### DIFF
--- a/pkg/actions/fs/jar.go
+++ b/pkg/actions/fs/jar.go
@@ -22,7 +22,7 @@ func ActionJarFileClasses(file string) carapace.Action {
 			for _, f := range reader.File {
 				if strings.HasSuffix(f.Name, ".class") {
 					name := strings.TrimPrefix(f.Name, "BOOT-INF/classes/")
-					name = strings.Replace(name, "/", ".", -1)
+					name = strings.ReplaceAll(name, "/", ".")
 					name = strings.TrimSuffix(name, ".class")
 					vals = append(vals, name)
 				}

--- a/pkg/actions/fs/mount.go
+++ b/pkg/actions/fs/mount.go
@@ -22,7 +22,7 @@ func ActionMounts() carapace.Action {
 		vals := make([]string, 0)
 		for _, line := range lines {
 			if fields := strings.Fields(line); len(fields) > 1 {
-				vals = append(vals, strings.Replace(fields[1], `\040`, " ", -1), fields[0])
+				vals = append(vals, strings.ReplaceAll(fields[1], `\040`, " "), fields[0])
 			}
 		}
 		return carapace.ActionValuesDescribed(vals...).StyleF(style.ForPath)

--- a/pkg/actions/net/net.go
+++ b/pkg/actions/net/net.go
@@ -63,6 +63,10 @@ type IncludedDevices struct {
 	Wimax       bool
 }
 
+func (i IncludedDevices) Default() IncludedDevices {
+	return AllDevices
+}
+
 func (i IncludedDevices) Includes(deviceType string) bool {
 	include := map[string]bool{
 		"ethernet":     i.Ethernet,

--- a/pkg/actions/tools/adb/user.go
+++ b/pkg/actions/tools/adb/user.go
@@ -17,7 +17,7 @@ func ActionUsers() carapace.Action {
 
 		vals := make([]string, 0)
 		for _, line := range lines[1:] {
-			line = strings.Replace(line, "\r", "", -1)
+			line = strings.ReplaceAll(line, "\r", "")
 			if r.MatchString(line) {
 				matches := r.FindStringSubmatch(line)
 				vals = append(vals, matches[1], matches[2])

--- a/pkg/actions/tools/docker/compose/service.go
+++ b/pkg/actions/tools/docker/compose/service.go
@@ -79,7 +79,7 @@ type ContainerOpts struct {
 	Exited     bool
 }
 
-func (o *ContainerOpts) Default() {
+func (o ContainerOpts) Default() ContainerOpts {
 	o.Paused = true
 	o.Restarting = true
 	o.Removing = true
@@ -87,6 +87,7 @@ func (o *ContainerOpts) Default() {
 	o.Dead = true
 	o.Created = true
 	o.Exited = true
+	return o
 }
 
 func (o ContainerOpts) includeState(s string) bool {

--- a/pkg/actions/tools/mvn/mvn.go
+++ b/pkg/actions/tools/mvn/mvn.go
@@ -40,7 +40,7 @@ type artifact struct {
 }
 
 func (a artifact) Location(repository string) string {
-	return fmt.Sprintf("%v/%v/%v/%v/%v-%v.jar", repository, strings.Replace(a.GroupId, ".", "/", -1), a.ArtifactId, a.Version, a.ArtifactId, a.Version)
+	return fmt.Sprintf("%v/%v/%v/%v/%v-%v.jar", repository, strings.ReplaceAll(a.GroupId, ".", "/"), a.ArtifactId, a.Version, a.ArtifactId, a.Version)
 }
 
 type project struct {

--- a/pkg/actions/tools/tea/issue.go
+++ b/pkg/actions/tools/tea/issue.go
@@ -39,6 +39,11 @@ type IssueOpts struct {
 	Closed bool
 }
 
+func (o IssueOpts) Default() IssueOpts {
+	o.Open = true
+	return o
+}
+
 // ActionIssues completes issues
 func ActionIssues(opts IssueOpts) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {

--- a/pkg/actions/tools/tea/pullrequest.go
+++ b/pkg/actions/tools/tea/pullrequest.go
@@ -44,6 +44,11 @@ type PullrequestOpts struct {
 	Closed bool
 }
 
+func (o PullrequestOpts) Default() PullrequestOpts {
+	o.Open = true
+	return o
+}
+
 // ActionPullrequests completes pull requests
 func ActionPullrequests(opts PullrequestOpts) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {

--- a/pkg/actions/tools/vagrant/plugin.go
+++ b/pkg/actions/tools/vagrant/plugin.go
@@ -12,6 +12,12 @@ type PluginOpts struct {
 	Global bool
 }
 
+func (o PluginOpts) Default() PluginOpts {
+	o.Local = true
+	o.Global = true
+	return o
+}
+
 // ActionPlugins completes plugins
 func ActionPlugins(opts PluginOpts) carapace.Action {
 	return carapace.ActionExecCommand("vagrant", "plugin", "list", "--local")(func(output []byte) carapace.Action {


### PR DESCRIPTION
- Fix docker/compose ContainerOpts.Default() signature: pointer receiver
  with void return doesn't satisfy spec.Default interface, causing
  MacroI without args to return empty results
- Add Default() to net.IncludedDevices so ActionDevices MacroI without
  args returns all device types instead of none
- Add Default() to tea.PullrequestOpts and tea.IssueOpts so MacroI
  without args defaults to Open issues/PRs instead of empty results
- Add Default() to vagrant.PluginOpts so MacroI without args returns
  both local and global plugins instead of none
- Replace strings.Replace with -1 count with strings.ReplaceAll in
  fs/jar, fs/mount, adb/user, mvn/mvn

Assisted-by: Crush:glm-5.1
