### PR TITLE
mcp: added codegen tool to generate Go code from YAML specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ The `skills/` directory contains detailed guides for carapace library concepts. 
 | `carapace-env` | Environment variable completion (Go definitions, user YAML overrides) |
 | `carapace-scrape` | Generating specs from CLI source code (patch-and-container) |
 | `carapace-integrate` | Integrating carapace into cobra CLIs (PreRun, PreInvoke, bridge) |
+| `carapace-mcp` | MCP server tools (complete, list_macros, codegen), client setup, protocol |
 
 ## Project Structure
 

--- a/cmd/carapace/cmd/mcp/mcp.go
+++ b/cmd/carapace/cmd/mcp/mcp.go
@@ -1,12 +1,14 @@
 package mcp
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -55,6 +57,10 @@ type mcpTool struct {
 type mcpToolCallParams struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+type mcpCodegenRequest struct {
+	Path string `json:"path"`
 }
 
 type mcpCompleteRequest struct {
@@ -181,6 +187,21 @@ func (s *MCPServer) handleRequest(request mcpRequest) (mcpResponse, bool) {
 						"additionalProperties": false,
 					},
 				},
+				{
+					Name:        "codegen",
+					Description: "Generate Go code from a YAML spec file.",
+					InputSchema: map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"path": map[string]any{
+								"type":        "string",
+								"description": "Path to the YAML spec file",
+							},
+						},
+						"required":             []string{"path"},
+						"additionalProperties": false,
+					},
+				},
 			},
 		}
 	case "tools/call":
@@ -202,12 +223,16 @@ func (s *MCPServer) handleToolCall(params json.RawMessage) (map[string]any, erro
 	if err := json.Unmarshal(params, &call); err != nil {
 		return nil, fmt.Errorf("invalid tool call parameters: %w", err)
 	}
-	if call.Name != "complete" && call.Name != "list_macros" {
+	if call.Name != "complete" && call.Name != "list_macros" && call.Name != "codegen" {
 		return nil, fmt.Errorf("unknown tool %q", call.Name)
 	}
 
 	if call.Name == "list_macros" {
 		return s.handleListMacros()
+	}
+
+	if call.Name == "codegen" {
+		return s.handleCodegen(call.Arguments)
 	}
 
 	var request mcpCompleteRequest
@@ -272,6 +297,61 @@ func (s *MCPServer) complete(request mcpCompleteRequest) (string, error) {
 		return "", fmt.Errorf("completion failed: %w\n%s", err, strings.TrimSpace(string(output)))
 	}
 	return strings.TrimRight(string(output), "\r\n"), nil
+}
+
+func (s *MCPServer) handleCodegen(args json.RawMessage) (map[string]any, error) {
+	var request mcpCodegenRequest
+	if err := json.Unmarshal(args, &request); err != nil {
+		return nil, fmt.Errorf("invalid codegen arguments: %w", err)
+	}
+	if request.Path == "" {
+		return nil, errors.New("path is required")
+	}
+
+	absPath := request.Path
+	if !filepath.IsAbs(absPath) {
+		abs, err := filepath.Abs(absPath)
+		if err != nil {
+			return mcpTextResult(err.Error(), true), nil
+		}
+		absPath = abs
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return mcpTextResult(err.Error(), true), nil
+	}
+
+	// Run codegen and capture the printed filenames
+	cmd := exec.Command(executable, "--codegen", absPath)
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return mcpTextResult(fmt.Sprintf("codegen failed: %v\n%s", err, output), true), nil
+	}
+
+	var filenames []string
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasSuffix(line, ".go") {
+			filenames = append(filenames, line)
+		}
+	}
+
+	if len(filenames) == 0 {
+		return mcpTextResult("codegen completed but no files were generated", false), nil
+	}
+
+	sort.Strings(filenames)
+	return map[string]any{
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": toJSON(filenames),
+			},
+		},
+	}, nil
 }
 
 func (s *MCPServer) handleListMacros() (map[string]any, error) {

--- a/cmd/carapace/cmd/mcp/mcp_test.go
+++ b/cmd/carapace/cmd/mcp/mcp_test.go
@@ -41,8 +41,8 @@ func TestMCPInitializeAndListTools(t *testing.T) {
 		t.Fatalf("tools/list result missing")
 	}
 	tools, ok := result["tools"].([]any)
-	if !ok || len(tools) != 2 {
-		t.Fatalf("expected 2 tools, got %#v", result["tools"])
+	if !ok || len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %#v", result["tools"])
 	}
 	tool, ok := tools[0].(map[string]any)
 	if !ok || tool["name"] != "complete" {
@@ -51,6 +51,10 @@ func TestMCPInitializeAndListTools(t *testing.T) {
 	tool1, ok := tools[1].(map[string]any)
 	if !ok || tool1["name"] != "list_macros" {
 		t.Fatalf("expected list_macros tool, got %#v", tools[1])
+	}
+	tool2, ok := tools[2].(map[string]any)
+	if !ok || tool2["name"] != "codegen" {
+		t.Fatalf("expected codegen tool, got %#v", tools[2])
 	}
 }
 
@@ -72,5 +76,23 @@ func TestMCPBatchSkipsNotifications(t *testing.T) {
 	}
 	if responses[0]["id"].(float64) != 1 {
 		t.Fatalf("unexpected response id: %#v", responses[0]["id"])
+	}
+}
+
+func TestMCPCodegenMissingPath(t *testing.T) {
+	input := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"codegen","arguments":{}}}`)
+
+	var output bytes.Buffer
+	s := NewMCPServer("", input, &output)
+	if err := s.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(output.Bytes()), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["error"] == nil {
+		t.Fatalf("expected error for missing path, got: %#v", resp)
 	}
 }

--- a/docs/src/slopware/mcp.md
+++ b/docs/src/slopware/mcp.md
@@ -26,6 +26,7 @@ Simply add it to your [config].
 
 - **complete** Return context‑aware, dynamic completions for shell commands.
 - **list_macros** List available macros and their signatures.
+- **codegen** Generate Go code from a YAML spec file.
 
 [Carapace]:https://carapace.sh
 [config]:https://github.com/charmbracelet/crush#mcps

--- a/skills/carapace-convert/SKILL.md
+++ b/skills/carapace-convert/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: carapace-convert
+description: >
+  Use when user wants to convert a carapace YAML user spec to a native Go completer for carapace-bin.
+  Covers the codegen tool, manual completion wiring, macro-to-Go mapping, and modifier translation.
+  Triggers on: "convert spec", "spec to Go", "yaml to go completer", "carapace convert", "codegen",
+  "generate Go completer", "spec to completer", "convert completion".
+user-invocable: true
+---
+
+# Carapace Spec-to-Go Conversion Guide
+
+Convert a carapace YAML user spec into a native Go completer that can be built into [carapace-bin](https://github.com/carapace-sh/carapace-bin).
+
+## Overview
+
+Conversion has two phases:
+
+1. **Codegen** — generate the cobra command skeleton (flags, subcommands, groups) from the YAML spec
+2. **Completion wiring** — manually translate the `completion` section into Go action code
+
+The codegen tool does **not** produce completion code — it only generates the command structure. The `completion` section of the spec must be translated by hand using the macro and modifier mappings below.
+
+## Step 1: Codegen
+
+Use the carapace MCP `codegen` tool or the CLI equivalent:
+
+```bash
+carapace --codegen path/to/spec.yaml
+```
+
+This produces one or more `.go` files in a temp directory containing:
+- Package declaration (`package cmd`)
+- Cobra command structs (`Use`, `Short`, `GroupID`, `Aliases`, `Hidden`)
+- Flag registrations (`String`, `Bool`, `CountP`, etc.)
+- `Execute()` function (root command only)
+- Subcommand wiring (`AddCommand`)
+
+Copy the generated files into the carapace-bin completer directory (e.g. `cmd/traverse/`).
+
+## Step 2: Add Standandalone Mode
+
+In the `init()` function, add `carapace.Gen(rootCmd).Standalone()` so the completer runs as a standalone completion provider:
+
+```go
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+	// ... flag definitions ...
+}
+```
+
+## Step 3: Translate Completion Actions
+
+Add `FlagCompletion`, `PositionalCompletion`, and/or `PositionalAnyCompletion` calls to `init()`. The mappings below translate YAML spec macros and modifiers to their Go equivalents.
+
+### Core Action Macros
+
+| YAML Macro | Go Equivalent |
+|-----------|---------------|
+| `$files` | `carapace.ActionFiles()` |
+| `$files([.ext])` | `carapace.ActionFiles(".ext")` |
+| `$directories` | `carapace.ActionDirectories()` |
+| `$executables` | `carapace.ActionExecutables()` |
+| `$message(text)` | `carapace.ActionMessage("text")` |
+| `$values` | `carapace.ActionValues(...)` |
+| `$valuesdescribed` | `carapace.ActionValuesDescribed(...)` |
+
+### External Action Macros
+
+External macros (prefixed with `carapace.`) reference actions from carapace-bin packages. Use the `list_macros` MCP tool or `carapace --macro` to find the Go import path and function name.
+
+| YAML Macro | Go Equivalent |
+|-----------|---------------|
+| `$carapace.tools.git.Refs({tags: true})` | `git.ActionRefs(g.RefsOpts{Tags: true})` |
+| `$carapace.tools.git.Tags` | `git.ActionTags()` |
+| `$carapace.os.Users` | `os.ActionUsers()` |
+
+Import the package from the `reference` field in the macro listing (e.g. `github.com/carapace-sh/carapace-bin/pkg/actions/tools/git`).
+
+### Modifier Macros
+
+Modifiers are applied to the preceding action using the `|||` delimiter in specs (generic modifier) or by chaining method calls in Go.
+
+| YAML Modifier | Go Equivalent | Notes |
+|--------------|---------------|-------|
+| `$chdir(path)` | `.Chdir("path")` | Change to literal directory |
+| `$chdir($traverse_macro)` | `.ChdirF(traverse.Xxx)` | See traverse mapping below |
+| `$filter(pattern...)` | `.Filter(pattern...)` | |
+| `$filterargs` | `.FilterArgs()` | |
+| `$list(separator)` | `.List(separator)` | |
+| `$multiparts(chars...)` | `.MultiParts(chars...)` | |
+| `$nospace(chars)` | `.NoSpace(chars...)` | |
+| `$prefix(prefix)` | `.Prefix(prefix)` | |
+| `$retain(pattern...)` | `.Retain(pattern...)` | |
+| `$shift(n)` | `.Shift(n)` | |
+| `$split` | `.Split()` | |
+| `$splitp` | `.SplitP()` | |
+| `$suffix(suffix)` | `.Suffix(suffix)` | |
+| `$suppress(pattern)` | `.Suppress(pattern)` | |
+| `$style(style)` | `.Style(style)` | |
+| `$tag(tag)` | `.Tag(tag)` | |
+| `$uniquelist(separator)` | `.UniqueList(separator)` | |
+| `$usage(text)` | `.Usage(text)` | |
+
+### Traverse Macros
+
+Inside `$chdir()`, the argument can be a traverse macro that resolves a directory at runtime. These map directly to functions in `github.com/carapace-sh/carapace/pkg/traverse`.
+
+| YAML Macro | Go Equivalent | Resolves to |
+|-----------|---------------|-------------|
+| `$chdir($gitdir)` | `.ChdirF(traverse.GitDir)` | `GIT_DIR` env or `.git` dir |
+| `$chdir($gitworktree)` | `.ChdirF(traverse.GitWorkTree)` | `GIT_WORK_TREE` env or parent of `.git` |
+| `$chdir($parent([name1, name2]))` | `.ChdirF(traverse.Parent("name1", "name2"))` | Walks upward to find dir containing named files |
+| `$chdir($tempdir)` | `.ChdirF(traverse.TempDir)` | `os.TempDir()` |
+| `$chdir($usercachedir)` | `.ChdirF(traverse.UserCacheDir)` | `os.UserCacheDir()` |
+| `$chdir($userconfigdir)` | `.ChdirF(traverse.UserConfigDir)` | `os.UserConfigDir()` |
+| `$chdir($userhomedir)` | `.ChdirF(traverse.UserHomeDir)` | `os.UserHomeDir()` |
+| `$chdir($xdgcachehome)` | `.ChdirF(traverse.XdgCacheHome)` | `$XDG_CACHE_HOME` or fallback to `UserCacheDir` |
+| `$chdir($xdgconfighome)` | `.ChdirF(traverse.XdgConfigHome)` | `$XDG_CONFIG_HOME` or fallback to `UserConfigDir` |
+| `$chdir($nixprofile)` | `.ChdirF(traverse.NixProfile)` | Nix profile directory |
+
+### Flag Value References
+
+In YAML specs, flag values are available as `${C_FLAG_<FLAGNAME>}` environment variables (uppercase, set via envsubst). In Go, use `traverse.Flag(cmd.Flag("flagname"))` to resolve the flag value at invoke time:
+
+| YAML | Go |
+|------|----|
+| `$chdir(${C_FLAG_MYDIR})` | `.ChdirF(traverse.Flag(cmd.Flag("mydir")))` |
+| `${C_FLAG_FORMAT}` in macro args | `cmd.Flag("format").Value.String()` in `ActionCallback` |
+
+Prefer `ChdirF(traverse.Flag(...))` over `Chdir(flag.Value.String())` — it resolves the value lazily at invoke time.
+
+### Generic vs Specific Modifier Application
+
+In YAML, the `|||` delimiter controls modifier scope:
+
+| YAML Syntax | Scope | Go Equivalent |
+|-------------|-------|---------------|
+| `["$files", "$chdir(/tmp)"]` | Generic — applies to **all** preceding actions | `carapace.ActionFiles().Chdir("/tmp")` |
+| `["$files \|\|\| $chdir(/tmp)"]` | Specific — applies to **preceding value only** | `carapace.ActionFiles().Chdir("/tmp")` |
+
+In Go, both translate to the same chained method calls since Go actions are composed by chaining.
+
+### Static Values
+
+Static completion values in specs translate to `ActionValues` or `ActionValuesDescribed`:
+
+| YAML | Go |
+|------|----|
+| `["true", "false"]` | `carapace.ActionValues("true", "false")` |
+| `["value\tdescription"]` | `carapace.ActionValuesDescribed("value", "description")` |
+| `["value\tdesc\tblue"]` | `carapace.ActionStyledValuesDescribed("value", "desc", "blue")` |
+
+### Subcommand Completions
+
+For subcommands, create a separate `init()` function in the subcommand file:
+
+```go
+func init() {
+	carapace.Gen(subCmd).FlagCompletion(carapace.ActionMap{
+		"format": carapace.ActionValues("json", "yaml"),
+	})
+
+	carapace.Gen(subCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+
+	carapace.Gen(subCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}
+```
+
+## Complete Example
+
+Given this YAML spec:
+
+```yaml
+name: traverse
+flags:
+  --gitdir=: .git folder
+  --gitworktree=: root of the working directory for a non-bare repository
+  --parent=: first parent directory containing any of the given names/directories
+  --tempdir=: default directory to use for temporary files
+  --usercachedir=: root directory to use for user-specific cached data
+  --userconfigdir=: default root directory to use for user-specific configuration data
+  --userhomedir=: current user's home directory
+  --xdgcachehome=: cache directory (fallback to UserCacheDir)
+  --xdgconfighome=: home directory (fallback to UserConfigDir)
+completion:
+  flag:
+    gitdir: ["$files", "$chdir($gitdir)"]
+    gitworktree: ["$files", "$chdir($gitworktree)"]
+    parent: ["$files", "$chdir($parent([go.mod, go.sum]))"]
+    tempdir: ["$files", "$chdir($tempdir)"]
+    usercachedir: ["$files", "$chdir($usercachedir)"]
+    userconfigdir: ["$files", "$chdir($userconfigdir)"]
+    userhomedir: ["$files", "$chdir($userhomedir)"]
+    xdgcachehome: ["$files", "$chdir($xdgcachehome)"]
+    xdgconfighome: ["$files", "$chdir($xdgconfighome)"]
+```
+
+The converted Go completer:
+
+```go
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/traverse"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "traverse",
+	Short: "",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().String("gitdir", "", ".git folder")
+	rootCmd.Flags().String("gitworktree", "", "root of the working directory for a non-bare repository")
+	rootCmd.Flags().String("parent", "", "first parent directory containing any of the given names/directories")
+	rootCmd.Flags().String("tempdir", "", "default directory to use for temporary files")
+	rootCmd.Flags().String("usercachedir", "", "root directory to use for user-specific cached data")
+	rootCmd.Flags().String("userconfigdir", "", "default root directory to use for user-specific configuration data")
+	rootCmd.Flags().String("userhomedir", "", "current user's home directory")
+	rootCmd.Flags().String("xdgcachehome", "", "cache directory (fallback to UserCacheDir)")
+	rootCmd.Flags().String("xdgconfighome", "", "home directory (fallback to UserConfigDir)")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"gitdir":       carapace.ActionFiles().ChdirF(traverse.GitDir),
+		"gitworktree":  carapace.ActionFiles().ChdirF(traverse.GitWorkTree),
+		"parent":       carapace.ActionFiles().ChdirF(traverse.Parent("go.mod", "go.sum")),
+		"tempdir":      carapace.ActionFiles().ChdirF(traverse.TempDir),
+		"usercachedir": carapace.ActionFiles().ChdirF(traverse.UserCacheDir),
+		"userconfigdir": carapace.ActionFiles().ChdirF(traverse.UserConfigDir),
+		"userhomedir":  carapace.ActionFiles().ChdirF(traverse.UserHomeDir),
+		"xdgcachehome": carapace.ActionFiles().ChdirF(traverse.XdgCacheHome),
+		"xdgconfighome": carapace.ActionFiles().ChdirF(traverse.XdgConfigHome),
+	})
+}
+```
+
+## Relationship to Other Skills
+
+| Skill | When to use instead of this skill |
+|-------|----------------------------------|
+| **carapace-spec** | Writing YAML user specs — the *source* format for conversion |
+| **carapace-macro** | Looking up macro signatures and formatting macro arguments in YAML |
+| **carapace-action** | Creating/modifying Go actions that become macros in the converted completer |
+| **carapace-scrape** | Generating YAML specs from CLI source code — typically the step *before* conversion |
+| **carapace-integrate** | Integrating carapace into an existing cobra app — use when the app already exists in Go |
+| **carapace-mcp** | Using the `codegen` and `list_macros` MCP tools during conversion |

--- a/skills/carapace-macro/SKILL.md
+++ b/skills/carapace-macro/SKILL.md
@@ -14,7 +14,7 @@ Macros are completion actions identified by a `$`-prefixed name, optionally taki
 
 ## Retrieving Available Macros
 
-Use the carapace MCP tool `list_macros` to get all available macros with their names, descriptions, and argument signatures.
+Use the carapace MCP tool `list_macros` to get all available macros with their names, descriptions, and argument signatures. For MCP server setup and protocol details, see the **carapace-mcp** skill.
 
 Each entry has:
 

--- a/skills/carapace-mcp/SKILL.md
+++ b/skills/carapace-mcp/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: carapace-mcp
+description: >
+  Use when user needs to understand, configure, or use the carapace MCP server — including
+  tool descriptions, input schemas, response formats, CLI equivalents, and MCP client setup.
+  Covers the three tools (complete, list_macros, codegen), the JSON-RPC protocol, stdio transport,
+  and how MCP tools map to carapace CLI flags. Triggers on: "carapace mcp", "MCP server",
+  "MCP tools", "carapace MCP", "complete tool", "list_macros tool", "codegen tool",
+  "configure MCP", "MCP setup".
+user-invocable: true
+---
+
+# Carapace MCP Server Guide
+
+The carapace MCP server exposes shell completion capabilities to AI assistants and other MCP clients via the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+## Starting the Server
+
+The MCP server runs over stdio (JSON-RPC 2.0) and is started with:
+
+```bash
+carapace --mcp
+```
+
+The server reads JSON-RPC requests from stdin and writes responses to stdout. It supports both single requests and batch requests (JSON arrays). Notifications (requests without an `id`) are silently skipped.
+
+## Client Configuration
+
+### Crush
+
+Add to `crush.json`:
+
+```json
+{
+  "mcp": {
+    "carapace": {
+      "type": "stdio",
+      "command": "carapace",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+### Other MCP Clients
+
+Any MCP client that supports stdio transport can connect. The server name is `carapace` and it reports protocol version `2024-11-05`.
+
+## Protocol
+
+The server implements JSON-RPC 2.0 with these methods:
+
+| Method | Description |
+|--------|-------------|
+| `initialize` | Returns server info and capabilities |
+| `tools/list` | Returns the three tool definitions |
+| `tools/call` | Executes a tool by name |
+
+Capabilities: `{tools: {}}` — only tools are supported (no resources, no prompts).
+
+## Tools
+
+### `complete` — Shell Command Completion
+
+Returns context‑aware, dynamic completions for shell commands.
+
+**Input Schema:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `args` | `string[]` | Yes | Command line arguments to complete |
+
+**How it works:**
+
+The first element in `args` is the command name (must be a known completer, not a flag). The remaining elements are the arguments to complete, including the partial word being completed. The server invokes `carapace <command> export <args...>` internally and returns the raw completion output.
+
+**Constraints:**
+
+- `args` must contain at least 2 elements (command + argument to complete)
+- Command must not start with `-` (flags are not completer names)
+- Arguments must not contain NUL bytes (`\0`)
+
+**Response:** Plain text containing the completion output (one completion candidate per line). On error, the response has `isError: true` with the error message as text.
+
+**Examples:**
+
+```json
+// Complete git branches after "git checkout "
+{"args": ["git", "checkout", ""]}
+
+// Complete docker subcommands
+{"args": ["docker", ""]}
+
+// Complete kubectl flags for get pods
+{"args": ["kubectl", "get", "pods", "-"]}
+```
+
+**CLI equivalent:** `carapace <command> export <args...>`
+
+### `list_macros` — Available Macros
+
+Lists all available carapace macros with their names, signatures, descriptions, and Go source references.
+
+**Input Schema:** No parameters (empty object).
+
+**Response:** JSON array of macro objects as text:
+
+```json
+[
+  {
+    "name": "carapace.tools.git.Refs",
+    "signature": "{localbranches: false, remotebranches: false, tags: false}",
+    "description": "complete refs",
+    "reference": "github.com/carapace-sh/carapace-bin/pkg/actions/tools/git#ActionRefs"
+  },
+  {
+    "name": "carapace.tools.git.Tags",
+    "signature": "—",
+    "description": "complete tags",
+    "reference": "github.com/carapace-sh/carapace-bin/pkg/actions/tools/git#ActionTags"
+  }
+]
+```
+
+**Fields:**
+
+| Field | Description |
+|-------|-------------|
+| `name` | Fully qualified macro name with `carapace.` prefix (e.g. `carapace.tools.git.Refs`) |
+| `signature` | Argument signature — see carapace-macro skill for format details. `—` (em dash) means no arguments (MacroN) |
+| `description` | Short description of what the macro completes |
+| `reference` | Go import path with `#FunctionName` for looking up source code |
+
+**Use cases:**
+
+- Discover which macros exist before using them in YAML specs or Go code
+- Look up argument signatures to format macro calls correctly
+- Find the Go source reference to understand parameters in detail
+
+**CLI equivalent:** `carapace --macro`
+
+### `codegen` — Generate Go Code from YAML Spec
+
+Generates Go completer source code from a carapace YAML spec file. This is useful for converting a user spec into a native Go completer that can be built into carapace-bin.
+
+**Input Schema:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | `string` | Yes | Path to the YAML spec file (relative or absolute) |
+
+**How it works:**
+
+1. Resolves `path` to an absolute path (relative paths are resolved from the server's working directory)
+2. Invokes `carapace --codegen <path>` internally
+3. Scans the output for `.go` filenames that were generated
+4. Returns a sorted JSON array of generated file paths
+
+**Response:** JSON array of generated `.go` file paths as text:
+
+```json
+["cmd/root.go", "cmd/cache.go"]
+```
+
+On error (missing path, invalid spec, codegen failure), the response has `isError: true` with the error message as text.
+
+**CLI equivalent:** `carapace --codegen <path>`
+
+## MCP Tool to CLI Flag Mapping
+
+| MCP Tool | CLI Command | Notes |
+|----------|-------------|-------|
+| `complete` | `carapace <cmd> export <args...>` | Shells out to the same executable |
+| `list_macros` | `carapace --macro` | Iterates `actions.Macros` map |
+| `codegen` | `carapace --codegen <path>` | Shells out to the same executable |
+
+## Relationship to Other Skills
+
+| Skill | When to use instead of this skill |
+|-------|----------------------------------|
+| `carapace-macro` | Formatting macro arguments in specs/YAML, understanding MacroN/MacroI/MacroV types |
+| `carapace-spec` | Writing YAML spec files (input for codegen) |
+| `carapace-action` | Creating/modifying shared Go actions that become macros |
+| `carapace-scrape` | Generating specs from CLI source code |
+| `carapace-integrate` | Integrating carapace library into cobra-based CLIs |
+
+## Error Handling
+
+The MCP server returns errors in two ways:
+
+1. **JSON-RPC errors** — For protocol-level failures (unknown method, invalid tool call parameters). Uses standard JSON-RPC error codes:
+   - `-32601` — Method not found
+   - `-32602` — Invalid params
+
+2. **Tool errors** — For tool execution failures (command not found, invalid arguments, codegen failures). Returned as `isError: true` with the error message in the text content.

--- a/skills/carapace-mcp/SKILL.md
+++ b/skills/carapace-mcp/SKILL.md
@@ -72,7 +72,7 @@ Returns context‑aware, dynamic completions for shell commands.
 
 **How it works:**
 
-The first element in `args` is the command name (must be a known completer, not a flag). The remaining elements are the arguments to complete, including the partial word being completed. The server invokes `carapace <command> export <args...>` internally and returns the raw completion output.
+The first element in `args` is the command name (not a flag). The remaining elements are the arguments to complete, including the partial word being completed. The server invokes `carapace <command> export <args...>` internally and returns the raw completion output.
 
 **Constraints:**
 

--- a/skills/carapace-scrape/SKILL.md
+++ b/skills/carapace-scrape/SKILL.md
@@ -231,7 +231,7 @@ ${UserConfigDir}/carapace/specs/<command>.yaml
 
 ## Next Steps
 
-To convert a scraped YAML spec to a native Go completer, use the `codegen` MCP tool (see **carapace-mcp** skill).
+To convert a scraped YAML spec to a native Go completer, see the **carapace-convert** skill.
 
 ## Reference Repositories
 

--- a/skills/carapace-scrape/SKILL.md
+++ b/skills/carapace-scrape/SKILL.md
@@ -229,6 +229,10 @@ ${UserConfigDir}/carapace/specs/<command>.yaml
 - **Build dependencies** — the tool must be buildable (dependencies must resolve)
 - **Plugin approach** — for some tools (like oclif), a plugin must be installed first
 
+## Next Steps
+
+To convert a scraped YAML spec to a native Go completer, use the `codegen` MCP tool (see **carapace-mcp** skill).
+
 ## Reference Repositories
 
 - [scrape](https://github.com/carapace-sh/scrape) — Docker-based scraping for Docker CLI, kubectl, gh, etc.

--- a/skills/carapace-spec/SKILL.md
+++ b/skills/carapace-spec/SKILL.md
@@ -155,7 +155,7 @@ documentation:
 
 ## Macros
 
-Macros are `$`-prefixed completion actions used in completion arrays. For full details on macro types, formatting, and how to look up available macros, see the **carapace-macro** skill.
+Macros are `$`-prefixed completion actions used in completion arrays. For full details on macro types, formatting, and how to look up available macros, see the **carapace-macro** skill. To convert a spec to a native Go completer, use the `codegen` MCP tool (see **carapace-mcp** skill).
 
 ### Quick Reference
 

--- a/skills/carapace-spec/SKILL.md
+++ b/skills/carapace-spec/SKILL.md
@@ -155,7 +155,7 @@ documentation:
 
 ## Macros
 
-Macros are `$`-prefixed completion actions used in completion arrays. For full details on macro types, formatting, and how to look up available macros, see the **carapace-macro** skill. To convert a spec to a native Go completer, use the `codegen` MCP tool (see **carapace-mcp** skill).
+Macros are `$`-prefixed completion actions used in completion arrays. For full details on macro types, formatting, and how to look up available macros, see the **carapace-macro** skill. To convert a spec to a native Go completer, see the **carapace-convert** skill.
 
 ### Quick Reference
 


### PR DESCRIPTION
Adds a `codegen` MCP tool that takes a path to a YAML spec file,
runs the existing code generator (`carapace --codegen <path>`), and
returns the list of generated `.go` files in the temp directory.

Assisted-by: Crush:glm-5.1
