### PR TITLE
skill: added carapace-setup and carapace-choice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ The `skills/` directory contains detailed guides for carapace library concepts. 
 | `carapace-env` | Environment variable completion (Go definitions, user YAML overrides) |
 | `carapace-scrape` | Generating specs from CLI source code (patch-and-container) |
 | `carapace-integrate` | Integrating carapace into cobra CLIs (PreRun, PreInvoke, bridge) |
+| `carapace-setup` | Shell integration, environment variables, overlays, extensions |
+| `carapace-choice` | Choices, variants, bridges (implicit shell + explicit framework), completer resolution |
 | `carapace-mcp` | MCP server tools (complete, list_macros, codegen), client setup, protocol |
 
 ## Project Structure

--- a/skills/carapace-choice/SKILL.md
+++ b/skills/carapace-choice/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: carapace-choice
+description: >
+  Use when user needs to understand or configure carapace completer choices, variants,
+  bridges (implicit shell bridges and explicit framework bridges), or completer resolution
+  priority. Covers CARAPACE_BRIDGES, --choice, --list, group priority, and how to select
+  a specific completer variant for a command. Triggers on: "carapace choice", "completer variant",
+  "select completer", "carapace bridge", "CARAPACE_BRIDGES", "implicit bridge", "framework bridge".
+user-invocable: true
+---
+
+# Carapace Choices, Variants & Bridges
+
+How carapace resolves which completer to use when multiple sources exist for the same command.
+
+## Completer Sources
+
+A single command can have completers from multiple sources:
+
+| Source | Location | Group |
+|--------|----------|-------|
+| Native Go completers | `completers/` (built-in) | `common`, `unix`, `linux`, `darwin`, `bsd`, `windows`, `android` |
+| User YAML specs | `${UserConfigDir}/carapace/specs/` | `user` |
+| System YAML specs | `${UserConfigDir}/carapace/specs/` | `system` |
+| Known bridges | hardcoded in `bridges.go` (~80 commands) | `bridge` |
+| Shell bridges | enabled via `CARAPACE_BRIDGES` | `bridge` |
+| Overlays | `${UserConfigDir}/carapace/overlays/` | modifies existing variant |
+
+## Group Priority
+
+When multiple groups provide a completer for the same command, they resolve in this order (highest wins):
+
+1. **`user`** — user YAML specs
+2. **`system`** — system YAML specs
+3. **OS-specific** (`linux`, `darwin`, `windows`, `android`, `bsd`) — matches current OS
+4. **`unix`** — Unix-like
+5. **`common`** — cross-platform
+6. **`bridge`** — lowest priority
+
+A **choice** (set via `--choice`) overrides all of the above — see [Choices](#choices) below.
+
+Within the same group, variants are ordered alphabetically by name.
+
+## Listing Variants
+
+```sh
+carapace --list {command}       # list all variants for a command
+carapace --list @{group}       # list completers in a group
+carapace --list gh@bridge      # list bridge variants for 'gh'
+```
+
+## Choices
+
+When multiple variants exist for a command, use `--choice` to select the preferred one:
+
+```sh
+carapace --choice {name}[/{variant}][@{group}]
+```
+
+Examples:
+
+```sh
+# Prefer bsd sed over the default
+carapace --choice sed@bsd
+
+# Prefer a specific tldr variant
+carapace --choice tldr/tldr-python-client
+
+# Use the cobra bridge for gh instead of the native completer
+carapace --choice gh/cobra@bridge
+```
+
+Choices are persisted as simple text files in `${UserConfigDir}/carapace/choices/`:
+
+```
+carapace/
+└── choices/
+    ├── sed              # content: sed@bsd
+    └── tldr             # content: tldr/tldr-python-client
+```
+
+To remove a choice, delete the file: `rm ~/.config/carapace/choices/gh`
+
+A choice gives that variant the **highest priority**, overriding all group ordering.
+
+## Bridges
+
+Bridges delegate completion to another engine when carapace lacks a native completer.
+
+### Implicit Bridges (Shell-Based)
+
+Enabled via `CARAPACE_BRIDGES`. These discover any command that has completion registered in the source shell:
+
+```sh
+export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'
+```
+
+| Bridge | What it uses | Notes |
+|--------|-------------|-------|
+| `zsh` | Zsh's completion system | Requires zsh installed |
+| `fish` | Fish's completion system | Requires fish installed |
+| `bash` | Bash's completion system | Requires bash and completions loaded |
+| `inshellisense` | [inshellisense](https://github.com/microsoft/inshellisense) | Requires inshellisense installed |
+
+Default order: `zsh,fish,bash,inshellisense`. The completer list is **cached** — clear with `carapace --clear-cache` after installing new shells or commands.
+
+> Shell bridges should be a fallback — framework bridges produce better completions with less overhead.
+
+### Explicit Bridges (Framework-Based)
+
+These must be set explicitly via `--choice` or a user spec because carapace **doesn't auto-detect** which framework a tool was built with by default. For example, carapace doesn't know that `gh` (GitHub CLI) uses cobra — you must tell it. (There is an experimental `bridge.Detect()` function in carapace-bridge that probes a command to auto-detect its framework, but it is not used at runtime.)
+
+**Via choice:**
+```sh
+carapace --choice gh/cobra@bridge
+```
+
+**Via user spec** (in `${UserConfigDir}/carapace/specs/gh.yaml`):
+```yaml
+# yaml-language-server: $schema=https://carapace.sh/schemas/command.json
+name: gh
+description: GitHub CLI
+parsing: disabled
+completion:
+  positionalany: ["$carapace.bridge.Cobra([gh])"]
+```
+
+### Known Bridges
+
+carapace-bin includes a hardcoded map of ~80 commands with their known framework (in `cmd/carapace/cmd/completers/bridges.go`). These are low-priority `bridge` group defaults — a native completer or user choice always overrides them.
+
+Full list of bridge types:
+
+| Bridge | Framework/Source | Macro |
+|--------|-----------------|-------|
+| `argcomplete` | [kislyuk/argcomplete](https://github.com/kislyuk/argcomplete) | `$carapace.bridge.Argcomplete([cmd])` |
+| `argcomplete_v1` | argcomplete (legacy) | `$carapace.bridge.ArgcompleteV1([cmd])` |
+| `aws` | [aws/aws-cli](https://github.com/aws/aws-cli) | `$carapace.bridge.Aws([cmd])` |
+| `bash` | [bash](https://www.gnu.org/software/bash/) | `$carapace.bridge.Bash([cmd])` |
+| `carapace` | [carapace-sh/carapace](https://github.com/carapace-sh/carapace) | `$carapace.bridge.Carapace([cmd])` |
+| `carapace-bin` | carapace-bin registry | `$carapace.bridge.CarapaceBin([cmd])` |
+| `clap` | [clap-rs/clap](https://github.com/clap-rs/clap) (experimental) | `$carapace.bridge.Clap([cmd])` |
+| `click` | [pallets/click](https://github.com/pallets/click) | `$carapace.bridge.Click([cmd])` |
+| `cobra` | [spf13/cobra](https://github.com/spf13/cobra) | `$carapace.bridge.Cobra([cmd])` |
+| `complete` | [posener/complete](https://github.com/posener/complete) | `$carapace.bridge.Complete([cmd])` |
+| `fish` | [fish](https://fishshell.com/) | `$carapace.bridge.Fish([cmd])` |
+| `gcloud` | [Google Cloud SDK](https://docs.cloud.google.com/sdk/gcloud) | `$carapace.bridge.Gcloud([cmd])` |
+| `inshellisense` | [inshellisense](https://github.com/microsoft/inshellisense) | `$carapace.bridge.Inshellisense([cmd])` |
+| `jj` | [jj-vcs](https://www.jj-vcs.dev) | `$carapace.bridge.Jj([cmd])` |
+| `kingpin` | [alecthomas/kingpin](https://github.com/alecthomas/kingpin) | `$carapace.bridge.Kingpin([cmd])` |
+| `kitten` | [kitty](https://sw.kovidgoyal.net/kitty/) | `$carapace.bridge.Kitten([cmd])` |
+| `powershell` | [powershell](https://microsoft.com/powershell) | `$carapace.bridge.Powershell([cmd])` |
+| `urfavecli` | [urfave/cli](https://github.com/urfave/cli) | `$carapace.bridge.Urfavecli([cmd])` |
+| `urfavecli_v1` | urfave/cli (legacy) | `$carapace.bridge.UrfavecliV1([cmd])` |
+| `yargs` | [yargs/yargs](https://github.com/yargs/yargs) | `$carapace.bridge.Yargs([cmd])` |
+| `zsh` | [zsh](https://www.zsh.org/) | `$carapace.bridge.Zsh([cmd])` |
+
+Custom shell bridge configurations can be placed in `${UserConfigDir}/carapace/bridge/`.
+
+### How Bridge Resolution Works
+
+The `ActionBridge` function (from carapace-bridge) resolves completions at runtime:
+
+1. **Check choices first** — looks up `~/.config/carapace/choices/<name>`; if a choice exists with `group == "bridge"` (or empty), uses its variant as the bridge type
+2. **Fall back to `CARAPACE_BRIDGES`** — iterates the env var in order, checking if the command is known to each shell bridge (bash, fish, zsh, inshellisense)
+3. **Return empty** — if neither yields a match, returns no completions
+
+### Determining the Right Bridge
+
+An agent can look up a tool's framework by:
+1. Checking the tool's dependencies (e.g. `go list -m` for Go tools, `pip show` for Python)
+2. Searching the tool's source code for framework imports (e.g. `import "github.com/spf13/cobra"`)
+3. Checking the tool's documentation or `--help` output for framework clues
+4. Checking the hardcoded map in `cmd/carapace/cmd/completers/bridges.go` for known mappings
+5. Using the experimental `bridge.Detect()` function from carapace-bridge, which probes a command to auto-detect its completion framework by testing each bridge type
+
+Common framework signatures:
+- **Cobra** (Go): `import "github.com/spf13/cobra"`, completion command `cmd completion <shell>`
+- **Click** (Python): `import click`, `@click.command()`
+- **Argcomplete** (Python): `import argcomplete`, `argcomplete.autocomplete(parser)`
+- **urfave/cli** (Go): `import "github.com/urfave/cli/v2"`, `cli.App{}`
+- **Yargs** (Node.js): `require('yargs')`, `yargs.command(...)`
+- **Clap** (Rust): `use clap::Parser`, `#[derive(Parser)]`
+- **Gcloud** (Python): uses argcomplete internally — check for `gcloud` binary and `CLOUDSDK_*` env vars
+
+## Troubleshooting
+
+- **Completions not appearing after install**: Run `carapace --clear-cache` to refresh the completer list.
+- **Wrong completer used**: Check `carapace --list <cmd>` to see variants, then use `--choice` to override.
+- **Bridge completions empty**: Ensure the target shell/framework is installed and completions are registered in it.
+- **Changes not taking effect**: Restart your shell or re-source the init snippet.

--- a/skills/carapace-setup/SKILL.md
+++ b/skills/carapace-setup/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: carapace-setup
+description: >
+  Use when user needs to set up, configure, or troubleshoot carapace shell completion —
+  including per-shell integration, environment variables, overlays, and extensions.
+  For choices/variants/bridges, use the carapace-choice skill instead.
+  Triggers on: "setup carapace", "configure carapace", "carapace setup", "shell completion setup",
+  "add completion to shell", "carapace env vars", "carapace overlay", "carapace extension".
+user-invocable: true
+---
+
+# Carapace Setup & Configuration
+
+## Install
+
+Download from [releases](https://github.com/carapace-sh/carapace-bin/releases) and add `carapace` to PATH.
+
+| Method | Command |
+|--------|---------|
+| Homebrew | `brew install carapace` |
+| AUR | `pamac install carapace-bin` |
+| Mise | `mise use -g carapace@latest` |
+| Nix | `nix-shell -p carapace` |
+| Scoop | `scoop install extras/carapace-bin` |
+| Winget | `winget install -e --id rsteube.Carapace` |
+| Termux | `pkg install carapace` |
+| DEB | `apt-get update && apt-get install carapace-bin` (from [fury.io](https://rsteube.fury.site/)) |
+| RPM | `yum install carapace-bin` (from [fury.io](https://rsteube.fury.site/)) |
+
+## Shell Integration
+
+The config directory is `${UserConfigDir}/carapace/`:
+
+| OS | Path |
+|----|------|
+| Linux | `~/.config/carapace/` |
+| macOS | `~/Library/Application Support/carapace/` |
+| Windows | `%APPDATA%\carapace\` |
+
+> On **all** OSes, carapace respects `$XDG_CONFIG_HOME` for its config directory.
+
+The `CARAPACE_BRIDGES` line is optional — see the **carapace-choice** skill for bridge details.
+
+### Bash
+
+```sh
+# ~/.bashrc
+export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense' # optional
+source <(carapace _carapace)
+```
+
+### Zsh
+
+```sh
+# ${UserConfigDir}/zsh/.zshrc
+autoload -U compinit && compinit
+export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense' # optional
+zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
+source <(carapace _carapace)
+```
+
+Group order: `zstyle ':completion:*:git:*' group-order 'main commands' 'alias commands' 'external commands'`
+
+### Fish
+
+```sh
+# ${UserConfigDir}/fish/config.fish
+set -Ux CARAPACE_BRIDGES 'zsh,fish,bash,inshellisense' # optional
+carapace _carapace | source
+```
+
+### Elvish
+
+```sh
+# ${UserConfigDir}/elvish/rc.elv
+set-env CARAPACE_BRIDGES 'zsh,fish,bash,inshellisense' # optional
+eval (carapace _carapace|slurp)
+```
+
+### Nushell
+
+```sh
+# ${UserConfigDir}/nushell/env.nu
+$env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense' # optional
+mkdir $"($nu.cache-dir)"
+carapace _carapace nushell | save --force $"($nu.cache-dir)/carapace.nu"
+
+# ${UserConfigDir}/nushell/config.nu
+source $"($nu.cache-dir)/carapace.nu"
+```
+
+### Powershell
+
+```powershell
+# ${UserConfigDir}/powershell/Microsoft.PowerShell_profile.ps1
+$env:CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense' # optional
+Set-PSReadLineOption -Colors @{ "Selection" = "`e[7m" }
+Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
+carapace _carapace | Out-String | Invoke-Expression
+```
+
+> `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` is **required**. Without it, raw ANSI escape codes appear. If using `Set-PSReadLineOption -EditMode Emacs`, place it **before** the key handler.
+
+### Oil
+
+```sh
+# ${UserConfigDir}/oil/oshrc
+export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense' # optional
+source <(carapace _carapace)
+```
+
+### Xonsh
+
+```sh
+# ${UserConfigDir}/xonsh/rc.xsh
+$CARAPACE_BRIDGES='zsh,fish,bash,inshellisense' # optional
+$COMPLETIONS_CONFIRM=True
+exec($(carapace _carapace))
+```
+
+### Tcsh
+
+```sh
+# ~/.tcshrc
+setenv CARAPACE_BRIDGES 'zsh,fish,bash,inshellisense' # optional
+set autolist
+eval `carapace _carapace`
+```
+
+### Cmd (via clink)
+
+```lua
+-- ~/AppData/Local/clink/carapace.lua
+load(io.popen('carapace _carapace cmd-clink'):read("*a"))()
+```
+
+Requires [clink](https://chrisant996.github.io/clink/).
+
+## Environment Variables
+
+Set all variables **before** sourcing the carapace init snippet.
+
+### CARAPACE_BRIDGES
+
+Comma-separated implicit bridge sources. Enables completion for commands carapace lacks a native completer for, by delegating to the shell's own completion. Default order: `zsh,fish,bash,inshellisense`. See the **carapace-choice** skill for full bridge details.
+
+### CARAPACE_EXCLUDES
+
+Comma-separated completer names to exclude: `export CARAPACE_EXCLUDES='git,docker'`
+
+### CARAPACE_COLOR
+
+Whether to output color (default: enabled).
+
+### CARAPACE_DESCRIPTION_LENGTH
+
+Maximum description length in completions.
+
+### CARAPACE_ENV
+
+Register `get-env`/`set-env`/`unset-env` shell functions for env var completion. `0` = disabled, `1` = enabled (default).
+
+### CARAPACE_HIDDEN
+
+Show hidden commands/flags. `0` = disabled (default), `1` = enabled, `2` = enabled including `_carapace`.
+
+### CARAPACE_LENIENT
+
+Allow unknown flags. `0` = disabled (default), `1` = enabled. Overlays implicitly set this.
+
+### CARAPACE_LOG
+
+Enable logging. `0` = disabled (default), `1` = enabled.
+
+### CARAPACE_MATCH
+
+Case-insensitive matching. `0` = case sensitive (default), `1` = case insensitive.
+
+### CARAPACE_MERGEFLAGS
+
+Merge flags to single tag group. `0` = disabled, `1` = enabled (enabled by default in Zsh).
+
+### CARAPACE_NOSPACE
+
+Suffixes that prevent space after completion. `*` = match all (no space after any value).
+
+### CARAPACE_TOOLTIP
+
+Enable tooltip style. `0` = disabled (default), `1` = enabled. Only affects Powershell.
+
+### CARAPACE_UNFILTERED
+
+Skip final filtering step. Enables fuzzy completion in Fish, but only works for (mostly) static values. `0` = disabled (default), `1` = enabled.
+
+## Overlays
+
+YAML files in `${UserConfigDir}/carapace/overlays/` are merged on top of an existing completer at runtime, adding flags/subcommands without replacing it:
+
+```yaml
+# ${UserConfigDir}/carapace/overlays/doctl.yaml
+name: doctl
+persistentflags:
+  --output=: Desired output format [text|json]
+completion:
+  flag:
+    output: [text, json]
+```
+
+Overlays implicitly set `CARAPACE_LENIENT`.
+
+## Extensions
+
+Extensions are standalone completer binaries that carapace-bin discovers automatically when on `PATH`. They use the carapace bridge protocol to provide richer completion than the built-in completer.
+
+### carapace-aws
+
+The only extension currently: [carapace-sh/carapace-aws](https://github.com/carapace-sh/carapace-aws).
+
+Provides enriched AWS CLI completion by parsing [botocore](https://github.com/boto/botocore) service definitions (descriptions, colored highlighting, custom completions). Falls back to the official `aws_completer` for undefined completions.
+
+**Setup**: Install `carapace-aws` and ensure it's on `PATH`. The built-in `aws` completer in carapace-bin automatically delegates to `carapace-aws` when detected:
+
+```go
+// completers/common/aws_completer/cmd/root.go
+if _, err := exec.LookPath("carapace-aws"); err == nil {
+    return bridge.ActionCarapace("carapace-aws")
+}
+return bridge.ActionAws("aws")
+```
+
+No configuration needed — just install and it takes effect.


### PR DESCRIPTION
carapace-setup covers shell integration, environment variables, overlays, and extensions.
carapace-choice covers choices, variants, bridges, and completer resolution priority.

Assisted-by: Crush:glm-5.1
