### PR TITLE
optimize go generate

### DIFF
--- a/cmd/carapace-generate/cmd/completers.go
+++ b/cmd/carapace-generate/cmd/completers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace-bin/cmd/carapace-generate/pkg/completer"
@@ -41,7 +40,7 @@ var completersCmd = &cobra.Command{
 			if err := os.WriteFile(f.Value.String(), []byte(s), 0644); err != nil {
 				return err
 			}
-			return exec.Command("go", "fmt", f.Value.String()).Run()
+			return nil
 		}
 		fmt.Println(s)
 		return nil

--- a/cmd/carapace-generate/cmd/completers.go
+++ b/cmd/carapace-generate/cmd/completers.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"go/format"
 	"os"
 
 	"github.com/carapace-sh/carapace"
@@ -37,7 +38,11 @@ var completersCmd = &cobra.Command{
 		}
 
 		if f := cmd.Flag("output"); f.Changed {
-			if err := os.WriteFile(f.Value.String(), []byte(s), 0644); err != nil {
+			formatted, err := format.Source([]byte(s))
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(f.Value.String(), formatted, 0644); err != nil {
 				return err
 			}
 			return nil

--- a/cmd/carapace-generate/cmd/conditions.go
+++ b/cmd/carapace-generate/cmd/conditions.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -29,7 +28,7 @@ var conditionsCmd = &cobra.Command{
 			if err := os.WriteFile(f.Value.String(), []byte(s), 0644); err != nil {
 				return err
 			}
-			return exec.Command("go", "fmt", f.Value.String()).Run()
+			return nil
 		}
 		fmt.Println(s)
 		return nil

--- a/cmd/carapace-generate/cmd/conditions.go
+++ b/cmd/carapace-generate/cmd/conditions.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"go/format"
 	"io/fs"
 	"log"
 	"os"
@@ -25,7 +26,11 @@ var conditionsCmd = &cobra.Command{
 		}
 
 		if f := cmd.Flag("output"); f.Changed {
-			if err := os.WriteFile(f.Value.String(), []byte(s), 0644); err != nil {
+			formatted, err := format.Source([]byte(s))
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(f.Value.String(), formatted, 0644); err != nil {
 				return err
 			}
 			return nil

--- a/cmd/carapace-generate/cmd/generate_all.go
+++ b/cmd/carapace-generate/cmd/generate_all.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/carapace-sh/carapace"
+	genCompleter "github.com/carapace-sh/carapace-bin/cmd/carapace-generate/pkg/completer"
+	"github.com/carapace-sh/carapace-bin/pkg/completer"
+	"github.com/carapace-sh/carapace-bridge/pkg/choices"
+	"github.com/spf13/cobra"
+)
+
+var generateAllCmd = &cobra.Command{
+	Use:   "generate-all DIR",
+	Short: "",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := args[0]
+		if err := genCompleter.Optimize(dir); err != nil {
+			return err
+		}
+
+		allCompleters, err := genCompleter.ReadCompleters(dir, "force_all")
+		if err != nil {
+			return err
+		}
+
+		allReleaseCompleters, err := genCompleter.ReadCompleters(dir+"_release", "force_all")
+		if err != nil {
+			return err
+		}
+
+		type target struct {
+			tag     string
+			goos    string
+			release bool
+			output  string
+		}
+
+		targets := []target{
+			{"!release && !force_all &&  android", "android", false, "cmd/completers/completers_termux.go"},
+			{"!release && !force_all && !android", "linux", false, "cmd/completers/completers_linux.go"},
+			{"!release && !force_all", "darwin", false, "cmd/completers/completers_darwin.go"},
+			{"!release && !force_all", "freebsd", false, "cmd/completers/completers_freebsd.go"},
+			{"!release && !force_all", "netbsd", false, "cmd/completers/completers_netbsd.go"},
+			{"!release && !force_all", "openbsd", false, "cmd/completers/completers_openbsd.go"},
+			{"!release && !force_all", "windows", false, "cmd/completers/completers_windows.go"},
+			{"!release &&  force_all", "force_all", false, "cmd/completers/completers_all.go"},
+			{"release && !force_all &&  android", "android", true, "cmd/completers/completers_release_termux.go"},
+			{"release && !force_all && !android", "freebsd", true, "cmd/completers/completers_release_freebsd.go"},
+			{"release && !force_all && !android", "linux", true, "cmd/completers/completers_release_linux.go"},
+			{"release && !force_all && !android", "netbsd", true, "cmd/completers/completers_release_netbsd.go"},
+			{"release && !force_all && !android", "openbsd", true, "cmd/completers/completers_release_openbsd.go"},
+			{"release && !force_all", "darwin", true, "cmd/completers/completers_release_darwin.go"},
+			{"release && !force_all", "windows", true, "cmd/completers/completers_release_windows.go"},
+			{"release &&  force_all", "force_all", true, "cmd/completers/completers_release_all.go"},
+		}
+
+		for _, t := range targets {
+			var base completer.CompleterMap
+			if t.release {
+				base = allReleaseCompleters
+			} else {
+				base = allCompleters
+			}
+
+			filtered := filterByGoos(base, t.goos)
+			s := filtered.Format("completers", t.tag)
+			if err := os.WriteFile(t.output, []byte(s), 0644); err != nil {
+				return err
+			}
+			if err := exec.Command("go", "fmt", t.output).Run(); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+func filterByGoos(all completer.CompleterMap, goos string) completer.CompleterMap {
+	groups := map[string][]string{
+		"android":   {"common", "unix", "linux", "android"},
+		"darwin":    {"common", "unix", "bsd", "darwin"},
+		"freebsd":   {"common", "unix", "bsd", "freebsd"},
+		"linux":     {"common", "unix", "linux"},
+		"netbsd":    {"common", "unix", "bsd", "netbsd"},
+		"openbsd":   {"common", "unix", "bsd", "openbsd"},
+		"windows":   {"common", "windows"},
+		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd"},
+	}
+
+	filtered := make(completer.CompleterMap)
+	for _, group := range groups[goos] {
+		filtered.Merge(all.Filter(choices.Choice{Group: group}))
+	}
+	return filtered
+}
+
+func init() {
+	carapace.Gen(generateAllCmd).Standalone()
+
+	rootCmd.AddCommand(generateAllCmd)
+
+	carapace.Gen(generateAllCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/cmd/carapace-generate/cmd/generate_all.go
+++ b/cmd/carapace-generate/cmd/generate_all.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"os"
-	"os/exec"
 
 	"github.com/carapace-sh/carapace"
 	genCompleter "github.com/carapace-sh/carapace-bin/cmd/carapace-generate/pkg/completer"
@@ -68,9 +67,6 @@ var generateAllCmd = &cobra.Command{
 			filtered := filterByGoos(base, t.goos)
 			s := filtered.Format("completers", t.tag)
 			if err := os.WriteFile(t.output, []byte(s), 0644); err != nil {
-				return err
-			}
-			if err := exec.Command("go", "fmt", t.output).Run(); err != nil {
 				return err
 			}
 		}

--- a/cmd/carapace-generate/cmd/generate_all.go
+++ b/cmd/carapace-generate/cmd/generate_all.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"go/format"
 	"os"
 
 	"github.com/carapace-sh/carapace"
@@ -66,7 +68,11 @@ var generateAllCmd = &cobra.Command{
 
 			filtered := filterByGoos(base, t.goos)
 			s := filtered.Format("completers", t.tag)
-			if err := os.WriteFile(t.output, []byte(s), 0644); err != nil {
+			formatted, err := format.Source([]byte(s))
+			if err != nil {
+				return fmt.Errorf("formatting %s: %w", t.output, err)
+			}
+			if err := os.WriteFile(t.output, formatted, 0644); err != nil {
 				return err
 			}
 		}

--- a/cmd/carapace-generate/cmd/macros.go
+++ b/cmd/carapace-generate/cmd/macros.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/carapace-sh/carapace"
 	spec "github.com/carapace-sh/carapace-spec"
@@ -40,7 +39,7 @@ var macrosCmd = &cobra.Command{
 			if err := os.WriteFile(f.Value.String(), []byte(s), 0644); err != nil {
 				return err
 			}
-			return exec.Command("go", "fmt", f.Value.String()).Run()
+			return nil
 		}
 		fmt.Println(s)
 		return nil

--- a/cmd/carapace-generate/cmd/macros.go
+++ b/cmd/carapace-generate/cmd/macros.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"go/format"
 	"os"
 
 	"github.com/carapace-sh/carapace"
@@ -36,7 +37,11 @@ var macrosCmd = &cobra.Command{
 		}
 
 		if f := cmd.Flag("output"); f.Changed {
-			if err := os.WriteFile(f.Value.String(), []byte(s), 0644); err != nil {
+			formatted, err := format.Source([]byte(s))
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(f.Value.String(), formatted, 0644); err != nil {
 				return err
 			}
 			return nil

--- a/cmd/carapace/main.go
+++ b/cmd/carapace/main.go
@@ -11,23 +11,7 @@ var commit, date string
 var version = "develop"
 
 //go:generate go build -o ../carapace-generate/carapace-generate ../carapace-generate
-//go:generate ../carapace-generate/carapace-generate copy ../../completers
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all &&  android" ../../completers android           --output cmd/completers/completers_termux.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all && !android" ../../completers linux             --output cmd/completers/completers_linux.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers darwin            --output cmd/completers/completers_darwin.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers freebsd           --output cmd/completers/completers_freebsd.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers netbsd            --output cmd/completers/completers_netbsd.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers openbsd           --output cmd/completers/completers_openbsd.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers windows           --output cmd/completers/completers_windows.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release &&  force_all"             ../../completers force_all         --output cmd/completers/completers_all.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all &&  android" ../../completers_release android   --output cmd/completers/completers_release_termux.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release freebsd   --output cmd/completers/completers_release_freebsd.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release linux     --output cmd/completers/completers_release_linux.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release netbsd    --output cmd/completers/completers_release_netbsd.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release openbsd   --output cmd/completers/completers_release_openbsd.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all"             ../../completers_release darwin    --output cmd/completers/completers_release_darwin.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all"             ../../completers_release windows   --output cmd/completers/completers_release_windows.go
-//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release &&  force_all"             ../../completers_release force_all --output cmd/completers/completers_release_all.go
+//go:generate ../carapace-generate/carapace-generate generate-all ../../completers
 //go:generate ../carapace-generate/carapace-generate macros --code github.com/carapace-sh/carapace-bin/pkg/actions github.com/carapace-sh/carapace-bridge/pkg/actions --output ../../pkg/actions/actions_generated.go
 //go:generate ../carapace-generate/carapace-generate conditions ../../pkg/conditions --output ../../pkg/conditions/conditions_generated.go
 func main() {

--- a/cmd/carapace/main.go
+++ b/cmd/carapace/main.go
@@ -10,25 +10,26 @@ import (
 var commit, date string
 var version = "develop"
 
-//go:generate go run ../carapace-generate copy ../../completers
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all &&  android" ../../completers android           --output cmd/completers/completers_termux.go
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all && !android" ../../completers linux             --output cmd/completers/completers_linux.go
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all"             ../../completers darwin            --output cmd/completers/completers_darwin.go
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all"             ../../completers freebsd           --output cmd/completers/completers_freebsd.go
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all"             ../../completers netbsd            --output cmd/completers/completers_netbsd.go
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all"             ../../completers openbsd           --output cmd/completers/completers_openbsd.go
-//go:generate go run ../carapace-generate completers --code --tag "!release && !force_all"             ../../completers windows           --output cmd/completers/completers_windows.go
-//go:generate go run ../carapace-generate completers --code --tag "!release &&  force_all"             ../../completers force_all         --output cmd/completers/completers_all.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all &&  android" ../../completers_release android   --output cmd/completers/completers_release_termux.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release freebsd   --output cmd/completers/completers_release_freebsd.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release linux     --output cmd/completers/completers_release_linux.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release netbsd    --output cmd/completers/completers_release_netbsd.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release openbsd   --output cmd/completers/completers_release_openbsd.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all"             ../../completers_release darwin    --output cmd/completers/completers_release_darwin.go
-//go:generate go run ../carapace-generate completers --code --tag  "release && !force_all"             ../../completers_release windows   --output cmd/completers/completers_release_windows.go
-//go:generate go run ../carapace-generate completers --code --tag  "release &&  force_all"             ../../completers_release force_all --output cmd/completers/completers_release_all.go
-//go:generate go run ../carapace-generate macros --code github.com/carapace-sh/carapace-bin/pkg/actions github.com/carapace-sh/carapace-bridge/pkg/actions --output ../../pkg/actions/actions_generated.go
-//go:generate go run ../carapace-generate conditions ../../pkg/conditions --output ../../pkg/conditions/conditions_generated.go
+//go:generate go build -o ../carapace-generate/carapace-generate ../carapace-generate
+//go:generate ../carapace-generate/carapace-generate copy ../../completers
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all &&  android" ../../completers android           --output cmd/completers/completers_termux.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all && !android" ../../completers linux             --output cmd/completers/completers_linux.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers darwin            --output cmd/completers/completers_darwin.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers freebsd           --output cmd/completers/completers_freebsd.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers netbsd            --output cmd/completers/completers_netbsd.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers openbsd           --output cmd/completers/completers_openbsd.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release && !force_all"             ../../completers windows           --output cmd/completers/completers_windows.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag "!release &&  force_all"             ../../completers force_all         --output cmd/completers/completers_all.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all &&  android" ../../completers_release android   --output cmd/completers/completers_release_termux.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release freebsd   --output cmd/completers/completers_release_freebsd.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release linux     --output cmd/completers/completers_release_linux.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release netbsd    --output cmd/completers/completers_release_netbsd.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all && !android" ../../completers_release openbsd   --output cmd/completers/completers_release_openbsd.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all"             ../../completers_release darwin    --output cmd/completers/completers_release_darwin.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release && !force_all"             ../../completers_release windows   --output cmd/completers/completers_release_windows.go
+//go:generate ../carapace-generate/carapace-generate completers --code --tag  "release &&  force_all"             ../../completers_release force_all --output cmd/completers/completers_release_all.go
+//go:generate ../carapace-generate/carapace-generate macros --code github.com/carapace-sh/carapace-bin/pkg/actions github.com/carapace-sh/carapace-bridge/pkg/actions --output ../../pkg/actions/actions_generated.go
+//go:generate ../carapace-generate/carapace-generate conditions ../../pkg/conditions --output ../../pkg/conditions/conditions_generated.go
 func main() {
 	if strings.Contains(version, "SNAPSHOT") {
 		version += fmt.Sprintf(" (%v) [%v]", date, commit)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/carapace-sh/carapace-jjlex v0.0.7
 	github.com/carapace-sh/carapace-selfupdate v0.0.10
 	github.com/carapace-sh/carapace-shlex v1.1.1
-	github.com/carapace-sh/carapace-spec v1.5.4
+	github.com/carapace-sh/carapace-spec v1.5.5
 	github.com/pelletier/go-toml v1.9.5
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/carapace-sh/carapace-selfupdate v0.0.10 h1:ZvutqGwVvSj6TmI/tLcort63JD
 github.com/carapace-sh/carapace-selfupdate v0.0.10/go.mod h1:4RavsY8l/RFtA9UXluUnEM5DF7zUkknMeRe/VN8QCGY=
 github.com/carapace-sh/carapace-shlex v1.1.1 h1:ccmNeetAYZOk4IcV36youFDsXusT9uCNW2Njkw+QS+Q=
 github.com/carapace-sh/carapace-shlex v1.1.1/go.mod h1:lJ4ZsdxytE0wHJ8Ta9S7Qq0XpjgjU0mdfCqiI2FHx7M=
-github.com/carapace-sh/carapace-spec v1.5.4 h1:9SooYpWpd23vhoE2WgPKcSqhuC9IP/lOixg2ghk6RuY=
-github.com/carapace-sh/carapace-spec v1.5.4/go.mod h1:sCHRUZj8+2ZS3oX8Pxdz0Im2fG1MlKuvNq/d3BqvX4k=
+github.com/carapace-sh/carapace-spec v1.5.5 h1:ju8Ppkmw337Qt0I24Jv8j19RTo6aXUAvBCGNZ7AhgAc=
+github.com/carapace-sh/carapace-spec v1.5.5/go.mod h1:sCHRUZj8+2ZS3oX8Pxdz0Im2fG1MlKuvNq/d3BqvX4k=
 github.com/carapace-sh/ssh_config v1.4.1-0.20260319075335-4f04016b8b4b h1:f4NGFmIRWxmaQIVX8vt2pEJdFLjz3qwoQWqMxhKjlBI=
 github.com/carapace-sh/ssh_config v1.4.1-0.20260319075335-4f04016b8b4b/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/pkg/completer/completermap.go
+++ b/pkg/completer/completermap.go
@@ -52,17 +52,17 @@ func (c CompleterMap) Filter(filter choices.Choice) CompleterMap {
 }
 
 func (c CompleterMap) Format(pkg, tag string) string {
+	var tagLine string
 	if tag != "" {
-		tag = fmt.Sprintf("//go:build %s\n", tag)
+		tagLine = fmt.Sprintf("//go:build %s\n\n", tag)
 	}
 	return fmt.Sprintf(`%spackage %s
 
 import (
-	"github.com/carapace-sh/carapace-bin/pkg/completer"
 %s)
 
 %s
-`, tag, pkg, c.FormatImports(), c.FormatCompleters())
+`, tagLine, pkg, c.FormatImports(), c.FormatCompleters())
 }
 
 func (c CompleterMap) Merge(other CompleterMap) {
@@ -78,6 +78,7 @@ func (c CompleterMap) Merge(other CompleterMap) {
 
 func (c CompleterMap) FormatImports() string {
 	s := make([]string, 0)
+	s = append(s, fmt.Sprintf("\t%q", "github.com/carapace-sh/carapace-bin/pkg/completer"))
 	for _, group := range c {
 		for _, completer := range group {
 			s = append(s, completer.FormatImport())


### PR DESCRIPTION
- **optimize go:generate by building carapace-generate once**
- **add generate-all subcommand to scan completers directory once**
- **updated carapace-spec**
- **remove redundant go fmt calls from code generators**
