### PR TITLE
consolidate usage skills into composite carapace skill with routing table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 A shell completion registry powered by [carapace](https://github.com/carapace-sh/carapace). This is **not** the carapace library itself — it aggregates completers from multiple sources, resolves which variant to use per command, exposes shared actions as macros, and provides a runtime for spec-based completions.
 
-For carapace library concepts (actions, macros, specs, integration, scraping), see the skills in `skills/`.
+For carapace library concepts (actions, macros, specs, integration, scraping), see the **carapace** skill in `skills/carapace/`.
 
 ## Commands
 
@@ -26,19 +26,20 @@ This project provides a carapace MCP server. When working here, use it:
 - **`list_macros`** / **`carapace_carapace_list_macros`** — Look up available macros, their signatures, and descriptions before referencing them in code or specs
 - **`carapace_carapace_complete`** — Test completion output for any completer
 
-The `skills/` directory contains detailed guides for carapace library concepts. **Use them** when working on the corresponding aspects:
+The `skills/carapace/` directory contains the composite carapace skill with detailed guides. **Use it** when working on the corresponding aspects. The SKILL.md entry point routes to the right sub-resource:
 
-| Skill | When to use |
-|-------|-------------|
-| `carapace-action` | Creating/modifying shared actions, naming, opts, Uid/QueryF, modifiers |
-| `carapace-spec` | Writing YAML completion spec files |
-| `carapace-macro` | Macro types, formatting, signature lookup, cross-executive macros |
-| `carapace-env` | Environment variable completion (Go definitions, user YAML overrides) |
-| `carapace-scrape` | Generating specs from CLI source code (patch-and-container) |
-| `carapace-integrate` | Integrating carapace into cobra CLIs (PreRun, PreInvoke, bridge) |
-| `carapace-setup` | Shell integration, environment variables, overlays, extensions |
-| `carapace-choice` | Choices, variants, bridges (implicit shell + explicit framework), completer resolution |
-| `carapace-mcp` | MCP server tools (complete, list_macros, codegen), client setup, protocol |
+| Sub-resource | When to use |
+|-------------|-------------|
+| `references/action.md` | Creating/modifying shared actions, naming, opts, Uid/QueryF, modifiers |
+| `references/spec.md` | Writing YAML completion spec files |
+| `references/macro.md` | Macro types, formatting, signature lookup, cross-executive macros |
+| `references/env.md` | Environment variable completion (Go definitions, user YAML overrides) |
+| `references/scrape.md` | Generating specs from CLI source code (patch-and-container) |
+| `references/integrate.md` | Integrating carapace into cobra CLIs (PreRun, PreInvoke, bridge) |
+| `references/setup.md` | Shell integration, environment variables, overlays, extensions |
+| `references/choice.md` | Choices, variants, bridges (implicit shell + explicit framework), completer resolution |
+| `references/mcp.md` | MCP server tools (complete, list_macros, codegen), client setup, protocol |
+| `references/convert.md` | Converting YAML specs to native Go completers |
 
 ## Project Structure
 
@@ -69,7 +70,10 @@ pkg/
   util/                   # Utility functions
   completer/              # Completer registry helpers
 internal/condition/       # Internal condition logic
-skills/                   # Crush skill definitions for carapace library concepts
+skills/
+  carapace/               Composite skill for carapace library concepts
+    SKILL.md                Entry point with routing table
+    references/             Sub-resources loaded on demand
 docs/                     # mdBook documentation
 .docker/                  # Docker Compose services for distro testing
 ```
@@ -112,7 +116,7 @@ YAML files in `~/.config/carapace/overlays/` are merged on top of an existing co
 
 ### Environment Variable Definitions
 
-See the `carapace-env` skill for details on built-in Go definitions (`pkg/actions/env/`) and user YAML overrides (`~/.config/carapace/variables/`).
+See `references/env.md` in the carapace skill for details on built-in Go definitions (`pkg/actions/env/`) and user YAML overrides (`~/.config/carapace/variables/`).
 
 ## How This Project Differs from Normal Carapace Usage
 
@@ -137,7 +141,7 @@ completers/common/bat_completer/
 | Package | domain name (`git`, `net`) | `action` |
 | Doc comments | Full format with examples | Typically none |
 | Cobra awareness | No `*cobra.Command` params | Often takes `*cobra.Command` |
-| Uid/QueryF | Yes (see `carapace-action` skill) | Typically no |
+| Uid/QueryF | Yes (see `references/action.md` in carapace skill) | Typically no |
 | Exposed as macro | Yes | No |
 | Reusability | Any completer can import | Only within its own completer |
 
@@ -182,7 +186,7 @@ for m, f := range actions.Macros {
 spec.Register(rootCmd)
 ```
 
-In this project, macros use the `tools.<tool>.<Action>` naming pattern (e.g. `tools.git.Changes`). For macro type mapping and registration, see the `carapace-macro` and `carapace-action` skills.
+In this project, macros use the `tools.<tool>.<Action>` naming pattern (e.g. `tools.git.Changes`). For macro type mapping and registration, see `references/macro.md` and `references/action.md` in the carapace skill.
 
 ### Bridge Actions as Completer Glue
 
@@ -193,11 +197,11 @@ bridge.ActionCarapaceBin("kubectl")  // delegate to another carapace-bin complet
 bridge.ActionCarapaceBin().Split()   // complete within a command-string flag value
 ```
 
-For bridge details, see the `carapace-integrate` skill. Available bridges are registered as macros (e.g. `bridge.CarapaceBin`, `bridge.Bash`, `bridge.Argcomplete`).
+For bridge details, see `references/integrate.md` in the carapace skill. Available bridges are registered as macros (e.g. `bridge.CarapaceBin`, `bridge.Bash`, `bridge.Argcomplete`).
 
 ### Uid / QueryF
 
-See the `carapace-action` skill for details on `UidF` (per-value identity) and `QueryF` (completion kind for result updates). Some tool packages in `pkg/actions/tools/` define a package-level `Uid()` helper that both share for URL construction.
+See `references/action.md` in the carapace skill for details on `UidF` (per-value identity) and `QueryF` (completion kind for result updates). Some tool packages in `pkg/actions/tools/` define a package-level `Uid()` helper that both share for URL construction.
 
 ### Project-Specific Styles
 

--- a/skills/carapace/SKILL.md
+++ b/skills/carapace/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: carapace
+description: >
+  Use when working with carapace shell completion — integrating into CLIs, writing YAML specs,
+  creating custom actions, looking up macros, setting up shell completion, configuring
+  choices/bridges, or using the MCP server.
+user-invocable: true
+---
+
+# Carapace Usage Reference
+
+Reference for using [carapace](https://carapace.sh) shell completion — integrating into CLIs, writing specs, creating actions, and configuring completions.
+
+## Sub-Resources
+
+Load the reference that matches your task. When in doubt, load multiple references.
+
+| Keywords | Reference |
+|----------|----------|
+| Integrate carapace, cobra, PreRun, PreInvoke, bridge, standalone mode, flag config, non-POSIX flags | [references/integrate.md](references/integrate.md) |
+| Custom actions, ActionValues, ActionCallback, ActionExecCommand, modifiers, naming, caching, batch, MultiParts, UID, tags | [references/action.md](references/action.md) |
+| YAML spec, user spec, flags, subcommands, parsing modes, completion, macros, modifiers, runnable specs | [references/spec.md](references/spec.md) |
+| Macro format, MacroN, MacroI, MacroV, $files, macro signatures, modifier chaining | [references/macro.md](references/macro.md) |
+| Choices, variants, bridges, CARAPACE_BRIDGES, --choice, --list, group priority | [references/choice.md](references/choice.md) |
+| Setup, shell integration, environment variables, overlays, extensions, install | [references/setup.md](references/setup.md) |
+| Environment variable completion, env YAML, conditions, ActionNames, ActionValues | [references/env.md](references/env.md) |
+| Convert spec to Go, codegen, macro-to-Go mapping, modifier translation | [references/convert.md](references/convert.md) |
+| Scrape spec, generate from source, Docker, supported frameworks, patch-and-container | [references/scrape.md](references/scrape.md) |
+| MCP server, complete tool, list_macros tool, codegen tool, JSON-RPC, stdio transport | [references/mcp.md](references/mcp.md) |
+
+## Quick Guide
+
+- **How do I add carapace to my cobra CLI?** → [references/integrate.md](references/integrate.md)
+- **How do I create a custom completion action?** → [references/action.md](references/action.md)
+- **How do I write a YAML user spec?** → [references/spec.md](references/spec.md)
+- **How do I format macro arguments?** → [references/macro.md](references/macro.md)
+- **How do completers/bridges/choices work?** → [references/choice.md](references/choice.md)
+- **How do I set up shell completion?** → [references/setup.md](references/setup.md)
+- **How do I add environment variable completions?** → [references/env.md](references/env.md)
+- **How do I convert a spec to a native Go completer?** → [references/convert.md](references/convert.md)
+- **How do I generate a spec from CLI source code?** → [references/scrape.md](references/scrape.md)
+- **How do I use the MCP server?** → [references/mcp.md](references/mcp.md)
+
+## Cross-Project References
+
+For internal library development (Action API internals, traverse engine, shell formatters, style system), use the **carapace-dev** skill (in the carapace repo).

--- a/skills/carapace/references/action.md
+++ b/skills/carapace/references/action.md
@@ -1,12 +1,3 @@
----
-name: carapace-action
-description: >
-  Use when user needs to create, modify, combine, tag, or assign UIDs to custom carapace actions.
-  Covers action naming, suffix, batch, tag, uid, and common patterns from carapace-bin.
-  Triggers on: "create action", "custom action", "carapace action", "action modifier", "combine actions".
-user-invocable: true
----
-
 # Carapace Custom Actions Guide
 
 Create and modify shell completion actions in [carapace](https://carapace.sh) using Go.

--- a/skills/carapace/references/choice.md
+++ b/skills/carapace/references/choice.md
@@ -1,14 +1,3 @@
----
-name: carapace-choice
-description: >
-  Use when user needs to understand or configure carapace completer choices, variants,
-  bridges (implicit shell bridges and explicit framework bridges), or completer resolution
-  priority. Covers CARAPACE_BRIDGES, --choice, --list, group priority, and how to select
-  a specific completer variant for a command. Triggers on: "carapace choice", "completer variant",
-  "select completer", "carapace bridge", "CARAPACE_BRIDGES", "implicit bridge", "framework bridge".
-user-invocable: true
----
-
 # Carapace Choices, Variants & Bridges
 
 How carapace resolves which completer to use when multiple sources exist for the same command.

--- a/skills/carapace/references/convert.md
+++ b/skills/carapace/references/convert.md
@@ -1,13 +1,3 @@
----
-name: carapace-convert
-description: >
-  Use when user wants to convert a carapace YAML user spec to a native Go completer for carapace-bin.
-  Covers the codegen tool, manual completion wiring, macro-to-Go mapping, and modifier translation.
-  Triggers on: "convert spec", "spec to Go", "yaml to go completer", "carapace convert", "codegen",
-  "generate Go completer", "spec to completer", "convert completion".
-user-invocable: true
----
-
 # Carapace Spec-to-Go Conversion Guide
 
 Convert a carapace YAML user spec into a native Go completer that can be built into [carapace-bin](https://github.com/carapace-sh/carapace-bin).
@@ -252,9 +242,9 @@ func init() {
 
 | Skill | When to use instead of this skill |
 |-------|----------------------------------|
-| **carapace-spec** | Writing YAML user specs — the *source* format for conversion |
-| **carapace-macro** | Looking up macro signatures and formatting macro arguments in YAML |
-| **carapace-action** | Creating/modifying Go actions that become macros in the converted completer |
-| **carapace-scrape** | Generating YAML specs from CLI source code — typically the step *before* conversion |
-| **carapace-integrate** | Integrating carapace into an existing cobra app — use when the app already exists in Go |
-| **carapace-mcp** | Using the `codegen` and `list_macros` MCP tools during conversion |
+| **references/spec.md** | Writing YAML user specs — the *source* format for conversion |
+| **references/macro.md** | Looking up macro signatures and formatting macro arguments in YAML |
+| **references/action.md** | Creating/modifying Go actions that become macros in the converted completer |
+| **references/scrape.md** | Generating YAML specs from CLI source code — typically the step *before* conversion |
+| **references/integrate.md** | Integrating carapace into an existing cobra app — use when the app already exists in Go |
+| **references/mcp.md** | Using the `codegen` and `list_macros` MCP tools during conversion |

--- a/skills/carapace/references/env.md
+++ b/skills/carapace/references/env.md
@@ -1,15 +1,3 @@
----
-name: carapace-env
-description: >
-  Use when user needs to create, modify, or understand carapace environment variable
-  completion definitions — either Go-based (pkg/actions/env) or user YAML specs
-  (~/.config/carapace/variables). Covers variable registration, conditions,
-  completion actions, and YAML override format. Triggers on: "env completion",
-  "environment variable completion", "carapace env", "env variable definition",
-  "custom env variables", "variables yaml".
-user-invocable: true
----
-
 # Carapace Environment Variable Completion Guide
 
 Define and customize environment variable name and value completions in [carapace](https://carapace.sh).

--- a/skills/carapace/references/integrate.md
+++ b/skills/carapace/references/integrate.md
@@ -1,12 +1,3 @@
----
-name: carapace-integrate
-description: >
-  Use when user wants to integrate the carapace library into an existing cobra-based CLI application.
-  Covers PreRun/PreInvoke for command structure and directory changes, action composition, carapace-bridge for external completions, and carapace-spec for exposing actions.
-  Triggers on: "integrate carapace", "add completions to cobra", "carapace library integration", "cobra completion with carapace", "carapace PreRun", or similar.
-user-invocable: true
----
-
 # Integrating Carapace into Cobra-based CLI Applications
 
 This guide covers integrating [carapace](https://github.com/carapace-sh/carapace) as a library into existing applications using [cobra](https://github.com/spf13/cobra).

--- a/skills/carapace/references/macro.md
+++ b/skills/carapace/references/macro.md
@@ -1,20 +1,10 @@
----
-name: carapace-macro
-description: >
-  Use when user needs to look up, format, or understand carapace macros — how to retrieve available
-  macros from the MCP tool, how macro arguments are formatted in user specs (YAML) and in Go
-  (spec.ActionMacro), and the three macro types (MacroN/MacroI/MacroV). Triggers on: "macro format",
-  "carapace macro", "list macros", "macro signature", "ActionMacro", "MacroN", "MacroI", "MacroV".
-user-invocable: true
----
-
 # Carapace Macro Format Guide
 
 Macros are completion actions identified by a `$`-prefixed name, optionally taking arguments in parentheses. They are used in user specs (YAML) and in Go code via `spec.ActionMacro`.
 
 ## Retrieving Available Macros
 
-Use the carapace MCP tool `list_macros` to get all available macros with their names, descriptions, and argument signatures. For MCP server setup and protocol details, see the **carapace-mcp** skill.
+Use the carapace MCP tool `list_macros` to get all available macros with their names, descriptions, and argument signatures. For MCP server setup and protocol details, see the **references/mcp.md** skill.
 
 Each entry has:
 

--- a/skills/carapace/references/mcp.md
+++ b/skills/carapace/references/mcp.md
@@ -1,15 +1,3 @@
----
-name: carapace-mcp
-description: >
-  Use when user needs to understand, configure, or use the carapace MCP server — including
-  tool descriptions, input schemas, response formats, CLI equivalents, and MCP client setup.
-  Covers the three tools (complete, list_macros, codegen), the JSON-RPC protocol, stdio transport,
-  and how MCP tools map to carapace CLI flags. Triggers on: "carapace mcp", "MCP server",
-  "MCP tools", "carapace MCP", "complete tool", "list_macros tool", "codegen tool",
-  "configure MCP", "MCP setup".
-user-invocable: true
----
-
 # Carapace MCP Server Guide
 
 The carapace MCP server exposes shell completion capabilities to AI assistants and other MCP clients via the [Model Context Protocol](https://modelcontextprotocol.io/).

--- a/skills/carapace/references/scrape.md
+++ b/skills/carapace/references/scrape.md
@@ -1,12 +1,3 @@
----
-name: carapace-scrape
-description: >
-  Use when the user wants to create a carapace user spec by scraping/generating it from the source code
-  of a CLI tool. Covers supported frameworks, the patch-and-container approach, and how to run the scraper.
-  Triggers on: "scrape spec", "generate spec from source", "carapace scrape", "spec scraper", or any request to generate completions by parsing source code.
-user-invocable: true
----
-
 # Carapace Spec Scraping Guide
 
 Generate carapace user specs by injecting a spec generator into CLI tools with available source code.
@@ -231,7 +222,7 @@ ${UserConfigDir}/carapace/specs/<command>.yaml
 
 ## Next Steps
 
-To convert a scraped YAML spec to a native Go completer, see the **carapace-convert** skill.
+To convert a scraped YAML spec to a native Go completer, see the **references/convert.md** skill.
 
 ## Reference Repositories
 

--- a/skills/carapace/references/setup.md
+++ b/skills/carapace/references/setup.md
@@ -1,14 +1,3 @@
----
-name: carapace-setup
-description: >
-  Use when user needs to set up, configure, or troubleshoot carapace shell completion —
-  including per-shell integration, environment variables, overlays, and extensions.
-  For choices/variants/bridges, use the carapace-choice skill instead.
-  Triggers on: "setup carapace", "configure carapace", "carapace setup", "shell completion setup",
-  "add completion to shell", "carapace env vars", "carapace overlay", "carapace extension".
-user-invocable: true
----
-
 # Carapace Setup & Configuration
 
 ## Install
@@ -39,7 +28,7 @@ The config directory is `${UserConfigDir}/carapace/`:
 
 > On **all** OSes, carapace respects `$XDG_CONFIG_HOME` for its config directory.
 
-The `CARAPACE_BRIDGES` line is optional — see the **carapace-choice** skill for bridge details.
+The `CARAPACE_BRIDGES` line is optional — see the **references/choice.md** skill for bridge details.
 
 ### Bash
 
@@ -142,7 +131,7 @@ Set all variables **before** sourcing the carapace init snippet.
 
 ### CARAPACE_BRIDGES
 
-Comma-separated implicit bridge sources. Enables completion for commands carapace lacks a native completer for, by delegating to the shell's own completion. Default order: `zsh,fish,bash,inshellisense`. See the **carapace-choice** skill for full bridge details.
+Comma-separated implicit bridge sources. Enables completion for commands carapace lacks a native completer for, by delegating to the shell's own completion. Default order: `zsh,fish,bash,inshellisense`. See the **references/choice.md** skill for full bridge details.
 
 ### CARAPACE_EXCLUDES
 

--- a/skills/carapace/references/spec.md
+++ b/skills/carapace/references/spec.md
@@ -1,13 +1,3 @@
----
-name: carapace-spec
-description: >
-  Use when user needs to create a carapace user spec (YAML completion file). Covers schema,
-  flags, subcommands, parsing modes, runnable specs, and environment variables.
-  For macro formatting and lookup, use the carapace-macro skill instead.
-  Triggers on: "create completion", "carapace spec", "user spec", "completion yaml", or any request to write a spec file.
-user-invocable: true
----
-
 # Carapace User Spec Creation Guide
 
 Create shell completion specs for [carapace](https://carapace.sh) using YAML files.
@@ -155,7 +145,7 @@ documentation:
 
 ## Macros
 
-Macros are `$`-prefixed completion actions used in completion arrays. For full details on macro types, formatting, and how to look up available macros, see the **carapace-macro** skill. To convert a spec to a native Go completer, see the **carapace-convert** skill.
+Macros are `$`-prefixed completion actions used in completion arrays. For full details on macro types, formatting, and how to look up available macros, see the **references/macro.md** skill. To convert a spec to a native Go completer, see the **references/convert.md** skill.
 
 ### Quick Reference
 
@@ -177,7 +167,7 @@ run: "$pwsh(echo one`ntwo)"
 
 ## Modifiers
 
-Change completion behavior with ` ||| ` delimiter. For full modifier reference, see the **carapace-macro** skill.
+Change completion behavior with ` ||| ` delimiter. For full modifier reference, see the **references/macro.md** skill.
 
 ```yaml
 # Generic: apply to all values
@@ -246,7 +236,7 @@ completion:
   positionalany: ["$carapace.tools.git.LsRemoteRefs({url: '${C_ARG0}'})"]
 ```
 
-> For macro formatting details, see the **carapace-macro** skill.
+> For macro formatting details, see the **references/macro.md** skill.
 
 ### Shebang (Bash Script)
 
@@ -323,7 +313,7 @@ completion:
   positionalany: ["$carapace.bridge.CarapaceBin([kubectl])"]
 ```
 
-> For macro formatting details, see the **carapace-macro** skill.
+> For macro formatting details, see the **references/macro.md** skill.
 
 - Generic bridge: `CarapaceBin`.
 - Framework bridges: `Argcomplete`, `Aws`, `Bash`, `Carapace`, `Clap`, `Click`, `Cobra`, `Complete`, `Gcloud`, `Inshellisense`, `JJ`, `Kingpin`, `Kitten`, `Urfavecli`, `UrfavecliV1`, `Yargs`.
@@ -335,4 +325,4 @@ completion:
 carapace _carapace           # reload specs
 ```
 
-> For macro lookup and formatting, see the **carapace-macro** skill.
+> For macro lookup and formatting, see the **references/macro.md** skill.


### PR DESCRIPTION
Replace 10 individual skills with a single composite skill containing
a SKILL.md entry point (routing table + quick guide) and sub-resources
as .md files. This reduces skill list noise, makes copying/sharing
simpler, and keeps cross-references local.

Assisted-by: Crush:glm-5.1
