### PR TITLE
add completers for bash builtins

### DIFF
--- a/cmd/carapace-generate/cmd/generate_all.go
+++ b/cmd/carapace-generate/cmd/generate_all.go
@@ -82,14 +82,14 @@ var generateAllCmd = &cobra.Command{
 
 func filterByGoos(all completer.CompleterMap, goos string) completer.CompleterMap {
 	groups := map[string][]string{
-		"android":   {"common", "unix", "linux", "android"},
-		"darwin":    {"common", "unix", "bsd", "darwin"},
-		"freebsd":   {"common", "unix", "bsd", "freebsd"},
-		"linux":     {"common", "unix", "linux"},
-		"netbsd":    {"common", "unix", "bsd", "netbsd"},
-		"openbsd":   {"common", "unix", "bsd", "openbsd"},
+		"android":   {"common", "unix", "linux", "android", "bash"},
+		"darwin":    {"common", "unix", "bsd", "darwin", "bash"},
+		"freebsd":   {"common", "unix", "bsd", "freebsd", "bash"},
+		"linux":     {"common", "unix", "linux", "bash"},
+		"netbsd":    {"common", "unix", "bsd", "netbsd", "bash"},
+		"openbsd":   {"common", "unix", "bsd", "openbsd", "bash"},
 		"windows":   {"common", "windows"},
-		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd"},
+		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd", "bash"},
 	}
 
 	filtered := make(completer.CompleterMap)

--- a/cmd/carapace-generate/pkg/completer/completers.go
+++ b/cmd/carapace-generate/pkg/completer/completers.go
@@ -20,15 +20,15 @@ func ReadCompleters(dir, goos string) (completer.CompleterMap, error) {
 	// TODO shell specific completers
 	// TODO distro specific completers (arch,ubuntu,...)
 	groups := map[string][]string{
-		"android": {"common", "unix", "linux", "android"},
-		"darwin":  {"common", "unix", "bsd", "darwin"},
-		"freebsd": {"common", "unix", "bsd", "freebsd"},
-		"linux":   {"common", "unix", "linux"},
-		"netbsd":  {"common", "unix", "bsd", "netbsd"},
-		"openbsd": {"common", "unix", "bsd", "openbsd"},
+		"android": {"common", "unix", "linux", "android", "bash"},
+		"darwin":  {"common", "unix", "bsd", "darwin", "bash"},
+		"freebsd": {"common", "unix", "bsd", "freebsd", "bash"},
+		"linux":   {"common", "unix", "linux", "bash"},
+		"netbsd":  {"common", "unix", "bsd", "netbsd", "bash"},
+		"openbsd": {"common", "unix", "bsd", "openbsd", "bash"},
 		"windows": {"common", "windows"},
 
-		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd"},
+		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd", "bash"},
 	}
 
 	completers, err := readCompleters(dir)

--- a/cmd/carapace/cmd/completers/completers.go
+++ b/cmd/carapace/cmd/completers/completers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/carapace-sh/carapace"
@@ -45,6 +46,7 @@ func Completers(filter choices.Choice, parse bool) (completer.CompleterMap, erro
 	}
 
 	RemoveExcludes(m)
+	RemoveShellBuiltins(m)
 
 	// TODO add pseudo carapace completer here instead of cmd
 	AddCarapace(m)
@@ -62,6 +64,26 @@ func AddCarapace(m completer.CompleterMap) {
 		Url:         "https://carapace.sh",
 		Execute:     func() error { return nil }, // TODO verify - there shouldn't be any need for this
 	})
+}
+
+func RemoveShellBuiltins(m completer.CompleterMap) {
+	shellGroups := map[string]bool{
+		"bash": true,
+		"fish": true,
+		"zsh":  true,
+	}
+
+	builtins := env.Builtins()
+	for name, variants := range m {
+		filtered := slices.DeleteFunc(variants, func(c completer.Completer) bool {
+			return shellGroups[c.Group] && !slices.Contains(builtins, c.Group)
+		})
+		if len(filtered) == 0 {
+			delete(m, name)
+		} else {
+			m[name] = filtered
+		}
+	}
 }
 
 func RemoveExcludes[T any](m map[string]T) {

--- a/cmd/carapace/cmd/snippet/bash.go
+++ b/cmd/carapace/cmd/snippet/bash.go
@@ -12,8 +12,11 @@ const bashCompleter = `_carapace_completer() {
   export COMP_WORDBREAKS
 
   declare -x CARAPACE_SHELL=bash
+  declare -x CARAPACE_SHELL_ALIASES="$(alias -p | sed 's/alias //;s/=.*//')"
   declare -x CARAPACE_SHELL_BUILTINS="$(compgen -b)"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(compgen -A function)"
+  declare -x CARAPACE_SHELL_JOBS="$(jobs -p 2>/dev/null | while read -r pid; do echo "%$((++n))"; done)"
+  declare -x CARAPACE_SHELL_VARIABLES="$(compgen -v)"
 
   local command="${COMP_WORDS[0]}" nospace data compline="${COMP_LINE:0:${COMP_POINT}}"
 

--- a/cmd/carapace/cmd/snippet/fish.go
+++ b/cmd/carapace/cmd/snippet/fish.go
@@ -10,8 +10,11 @@ func Fish(completers []string) string {
 
 function _carapace_completer
   set --local --export CARAPACE_SHELL fish
+  set --local --export CARAPACE_SHELL_ALIASES (alias | string replace -r 'alias ' '' | string replace -r '=.*' '')
   set --local --export CARAPACE_SHELL_BUILTINS (builtin --names)
   set --local --export CARAPACE_SHELL_FUNCTIONS (functions --all)
+  set --local --export CARAPACE_SHELL_JOBS (jobs -p 2>/dev/null | while read -r pid; echo "%%"(math $n + 1); set n (math $n + 1); end)
+  set --local --export CARAPACE_SHELL_VARIABLES (set --names)
   set --local data
   IFS='' set data (echo (commandline -cp)'' | sed "s/ \$/ ''/" | xargs carapace $argv[1] fish 2>/dev/null)
   if [ $status -eq 1 ]

--- a/cmd/carapace/cmd/snippet/zsh.go
+++ b/cmd/carapace/cmd/snippet/zsh.go
@@ -20,7 +20,7 @@ function _carapace_completer {
   declare -x CARAPACE_COMPLINE="${words}"
   declare -x CARAPACE_ZSH_HASH_DIRS="$(hash -d)"
   declare -x CARAPACE_SHELL=zsh
-  declare -x CARAPACE_SHELL_ALIASES="$(alias -p | sed 's/alias //;s/=.*//')"
+  declare -x CARAPACE_SHELL_ALIASES="$(alias | sed 's/alias //;s/=.*//')"
   declare -x CARAPACE_SHELL_BUILTINS="$(print -roC1 -- ${(k)builtins})"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(print -l ${(ok)functions})"
   declare -x CARAPACE_SHELL_JOBS="$(jobs -p 2>/dev/null | while read -r pid; do echo "%%$((++n))"; done)"

--- a/cmd/carapace/cmd/snippet/zsh.go
+++ b/cmd/carapace/cmd/snippet/zsh.go
@@ -20,8 +20,11 @@ function _carapace_completer {
   declare -x CARAPACE_COMPLINE="${words}"
   declare -x CARAPACE_ZSH_HASH_DIRS="$(hash -d)"
   declare -x CARAPACE_SHELL=zsh
+  declare -x CARAPACE_SHELL_ALIASES="$(alias -p | sed 's/alias //;s/=.*//')"
   declare -x CARAPACE_SHELL_BUILTINS="$(print -roC1 -- ${(k)builtins})"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(print -l ${(ok)functions})"
+  declare -x CARAPACE_SHELL_JOBS="$(jobs -p 2>/dev/null | while read -r pid; do echo "%%$((++n))"; done)"
+  declare -x CARAPACE_SHELL_VARIABLES="$(print -l ${(ok)parameters})"
 
   # shellcheck disable=SC2086,SC2154,SC2155
   lines="$(echo "${compline}''" | xargs carapace "${command}" zsh 2>/dev/null)"

--- a/completers/bash/alias_completer/cmd/root.go
+++ b/completers/bash/alias_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "alias",
+	Short: "Define or display aliases",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-alias",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("p", "p", false, "print all defined aliases in a reusable format")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return shell.ActionAliases()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/bash/alias_completer/main.go
+++ b/completers/bash/alias_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/alias_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/bg_completer/cmd/root.go
+++ b/completers/bash/bg_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bg",
+	Short: "Move jobs to the background",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Job-Control-Builtins.html#index-bg",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/bash/bg_completer/main.go
+++ b/completers/bash/bg_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/bg_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/bind_completer/cmd/root.go
+++ b/completers/bash/bind_completer/cmd/root.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bind",
+	Short: "Set Readline key bindings and variables",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-bind",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("P", "P", false, "list function names and bindings")
+	rootCmd.Flags().BoolS("S", "S", false, "list key sequences that invoke macros and their values")
+	rootCmd.Flags().BoolS("V", "V", false, "list variable names and values")
+	rootCmd.Flags().BoolS("X", "X", false, "list key sequences bound with -x and associated commands in a form that can be reused as input")
+	rootCmd.Flags().StringS("f", "f", "", "read key bindings from filename")
+	rootCmd.Flags().BoolS("l", "l", false, "list names of functions")
+	rootCmd.Flags().StringS("m", "m", "", "use keymap as the keymap for the duration of this command")
+	rootCmd.Flags().BoolS("p", "p", false, "list functions and bindings in a form that can be reused as input")
+	rootCmd.Flags().StringS("q", "q", "", "query about which keys invoke the named function")
+	rootCmd.Flags().StringS("r", "r", "", "remove the binding for keyseq")
+	rootCmd.Flags().BoolS("s", "s", false, "list key sequences that invoke macros and their values in a form that can be reused as input")
+	rootCmd.Flags().StringS("u", "u", "", "unbind all keys which are bound to the named function")
+	rootCmd.Flags().BoolS("v", "v", false, "list variable names and values in a form that can be reused as input")
+	rootCmd.Flags().StringS("x", "x", "", "cause shell-command to be executed when keyseq is entered")
+
+	// TODO function completion
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"f": carapace.ActionFiles(),
+		"m": carapace.ActionValuesDescribed(
+			"emacs", "emacs keymap",
+			"emacs-standard", "emacs-standard keymap",
+			"emacs-meta", "emacs-meta keymap",
+			"emacs-ctlx", "emacs-ctlx keymap",
+			"vi", "vi keymap",
+			"vi-move", "vi-move keymap",
+			"vi-command", "vi-command keymap",
+			"vi-insert", "vi-insert keymap",
+		),
+	})
+}

--- a/completers/bash/bind_completer/main.go
+++ b/completers/bash/bind_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/bind_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/builtin_completer/cmd/root.go
+++ b/completers/bash/builtin_completer/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "builtin",
+	Short:              "Execute shell builtins",
+	Long:               "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-builtin",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		shell.ActionBuiltins(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/bash/builtin_completer/main.go
+++ b/completers/bash/builtin_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/builtin_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/caller_completer/cmd/root.go
+++ b/completers/bash/caller_completer/cmd/root.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "caller",
+	Short: "Return the context of the current subroutine call",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-caller",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+}

--- a/completers/bash/caller_completer/main.go
+++ b/completers/bash/caller_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/caller_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/cd_completer/cmd/root.go
+++ b/completers/bash/cd_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "cd",
+	Short: "Change the shell working directory",
+	Long:  "https://man7.org/linux/man-pages/man1/cd.1p.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("@", "@", false, "present a file with extended attributes as a directory containing the file attributes")
+	rootCmd.Flags().BoolS("L", "L", false, "force symbolic links to be followed")
+	rootCmd.Flags().BoolS("P", "P", false, "use the physical directory structure without following symbolic links")
+	rootCmd.Flags().BoolS("e", "e", false, "if the -P option is supplied, exit with a non-zero status if the current working directory cannot be determined successfully")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/bash/cd_completer/main.go
+++ b/completers/bash/cd_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/cd_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/command_completer/cmd/root.go
+++ b/completers/bash/command_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "command",
+	Short: "Execute a simple command or display information about commands",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-command",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("V", "V", false, "print a more verbose description of each command")
+	rootCmd.Flags().BoolS("p", "p", false, "use a default value for PATH that is guaranteed to find all of the standard utilities")
+	rootCmd.Flags().BoolS("v", "v", false, "print a single word indicating the command or filename that invokes command")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionExecutables().FilterArgs(),
+	)
+}

--- a/completers/bash/command_completer/main.go
+++ b/completers/bash/command_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/command_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/compgen_completer/cmd/root.go
+++ b/completers/bash/compgen_completer/cmd/root.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "compgen",
+	Short: "Display possible completions depending on the options",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-compgen",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("A", "A", "", "action type for completion")
+	rootCmd.Flags().StringS("C", "C", "", "command to execute for completion")
+	rootCmd.Flags().StringS("F", "F", "", "function to execute for completion")
+	rootCmd.Flags().StringS("G", "G", "", "glob pattern for completion")
+	rootCmd.Flags().StringS("P", "P", "", "prefix to add to each completion")
+	rootCmd.Flags().StringS("S", "S", "", "suffix to add to each completion")
+	rootCmd.Flags().StringS("V", "V", "", "store completions in indexed array varname")
+	rootCmd.Flags().StringS("W", "W", "", "wordlist for completion")
+	rootCmd.Flags().StringS("X", "X", "", "filter pattern to exclude from completions")
+	rootCmd.Flags().BoolS("a", "a", false, "alias action")
+	rootCmd.Flags().BoolS("b", "b", false, "builtin action")
+	rootCmd.Flags().BoolS("c", "c", false, "command action")
+	rootCmd.Flags().BoolS("d", "d", false, "directory action")
+	rootCmd.Flags().BoolS("e", "e", false, "exported variable action")
+	rootCmd.Flags().BoolS("f", "f", false, "file action")
+	rootCmd.Flags().BoolS("g", "g", false, "group action")
+	rootCmd.Flags().BoolS("j", "j", false, "job action")
+	rootCmd.Flags().BoolS("k", "k", false, "keyword action")
+	rootCmd.Flags().StringS("o", "o", "", "completion option")
+	rootCmd.Flags().BoolS("s", "s", false, "service action")
+	rootCmd.Flags().BoolS("u", "u", false, "user action")
+	rootCmd.Flags().BoolS("v", "v", false, "variable action")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"A": carapace.ActionValuesDescribed(
+			"alias", "aliases",
+			"arrayvar", "array variables",
+			"binding", "readline key bindings",
+			"builtin", "shell builtins",
+			"command", "commands",
+			"directory", "directories",
+			"disabled", "disabled builtins",
+			"enabled", "enabled builtins",
+			"export", "exported variables",
+			"file", "files",
+			"function", "shell functions",
+			"group", "groups",
+			"helptopic", "help topics",
+			"hostname", "hostnames",
+			"job", "jobs",
+			"keyword", "shell reserved words",
+			"running", "running jobs",
+			"service", "service names",
+			"setopt", "shell options",
+			"shopt", "shell options",
+			"signal", "signals",
+			"stopped", "stopped jobs",
+			"user", "users",
+			"variable", "shell variables",
+		),
+		"C": carapace.ActionFiles(),
+		"F": shell.ActionFunctions(true),
+		"G": carapace.ActionFiles(),
+		"P": carapace.ActionFiles(),
+		"S": carapace.ActionFiles(),
+		"W": carapace.ActionValues(),
+		"X": carapace.ActionValues(),
+	})
+}

--- a/completers/bash/compgen_completer/main.go
+++ b/completers/bash/compgen_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/compgen_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/complete_completer/cmd/root.go
+++ b/completers/bash/complete_completer/cmd/root.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "complete",
+	Short: "Specify how arguments are to be completed by Readline",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-complete",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("A", "A", "", "action type for completion")
+	rootCmd.Flags().StringS("C", "C", "", "command to execute for completion")
+	rootCmd.Flags().BoolS("D", "D", false, "apply completions as default for commands without specific completion")
+	rootCmd.Flags().BoolS("E", "E", false, "apply completions to empty commands")
+	rootCmd.Flags().StringS("F", "F", "", "function to execute for completion")
+	rootCmd.Flags().StringS("G", "G", "", "glob pattern for completion")
+	rootCmd.Flags().BoolS("I", "I", false, "apply completions to the initial word")
+	rootCmd.Flags().StringS("P", "P", "", "prefix to add to each completion")
+	rootCmd.Flags().StringS("S", "S", "", "suffix to add to each completion")
+	rootCmd.Flags().StringS("W", "W", "", "wordlist for completion")
+	rootCmd.Flags().StringS("X", "X", "", "filter pattern to exclude from completions")
+	rootCmd.Flags().BoolS("a", "a", false, "alias action")
+	rootCmd.Flags().BoolS("b", "b", false, "builtin action")
+	rootCmd.Flags().BoolS("c", "c", false, "command action")
+	rootCmd.Flags().BoolS("d", "d", false, "directory action")
+	rootCmd.Flags().BoolS("e", "e", false, "exported variable action")
+	rootCmd.Flags().BoolS("f", "f", false, "file action")
+	rootCmd.Flags().BoolS("g", "g", false, "group action")
+	rootCmd.Flags().BoolS("j", "j", false, "job action")
+	rootCmd.Flags().BoolS("k", "k", false, "keyword action")
+	rootCmd.Flags().StringS("o", "o", "", "completion option")
+	rootCmd.Flags().BoolS("p", "p", false, "print existing completion specifications in a reusable format")
+	rootCmd.Flags().BoolS("r", "r", false, "remove a completion specification")
+	rootCmd.Flags().BoolS("s", "s", false, "service action")
+	rootCmd.Flags().BoolS("u", "u", false, "user action")
+	rootCmd.Flags().BoolS("v", "v", false, "variable action")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"A": carapace.ActionValuesDescribed(
+			"alias", "aliases",
+			"arrayvar", "array variables",
+			"binding", "readline key bindings",
+			"builtin", "shell builtins",
+			"command", "commands",
+			"directory", "directories",
+			"disabled", "disabled builtins",
+			"enabled", "enabled builtins",
+			"export", "exported variables",
+			"file", "files",
+			"function", "shell functions",
+			"group", "groups",
+			"helptopic", "help topics",
+			"hostname", "hostnames",
+			"job", "jobs",
+			"keyword", "shell reserved words",
+			"running", "running jobs",
+			"service", "service names",
+			"setopt", "shell options",
+			"shopt", "shell options",
+			"signal", "signals",
+			"stopped", "stopped jobs",
+			"user", "users",
+			"variable", "shell variables",
+		),
+		"C": carapace.ActionFiles(),
+		"F": shell.ActionFunctions(true),
+		"G": carapace.ActionFiles(),
+		"P": carapace.ActionFiles(),
+		"S": carapace.ActionFiles(),
+		"W": carapace.ActionValues(),
+		"X": carapace.ActionValues(),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionExecutables(),
+	)
+}

--- a/completers/bash/complete_completer/main.go
+++ b/completers/bash/complete_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/complete_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/compopt_completer/cmd/root.go
+++ b/completers/bash/compopt_completer/cmd/root.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "compopt",
+	Short: "Modify or display completion options",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-compopt",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("D", "D", false, "change options for the default command completion")
+	rootCmd.Flags().BoolS("E", "E", false, "change options for the empty command completion")
+	rootCmd.Flags().BoolS("I", "I", false, "change options for completion on the initial word")
+	rootCmd.Flags().StringS("o", "o", "", "set completion option")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"o": carapace.ActionValuesDescribed(
+			"bashdefault", "perform default bash completions",
+			"default", "use readline's default filename completion",
+			"dirnames", "perform directory name completion",
+			"filenames", "completions are filenames",
+			"noargs", "do not complete arguments",
+			"nobashdefault", "do not perform default bash completions",
+			"nodefault", "do not use readline's default filename completion",
+			"nodirnames", "do not perform directory name completion",
+			"nofilenames", "completions are not filenames",
+			"noquote", "do not quote completions",
+			"nosort", "do not sort completions",
+			"nospace", "do not append a space after completion",
+			"plusdirs", "also perform directory name completion",
+			"quote", "quote completions",
+			"sort", "sort completions",
+		),
+	})
+}

--- a/completers/bash/compopt_completer/main.go
+++ b/completers/bash/compopt_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/compopt_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/declare_completer/cmd/root.go
+++ b/completers/bash/declare_completer/cmd/root.go
@@ -2,23 +2,26 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "declare",
 	Short: "Declare variables and give them attributes",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-declare",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func Execute() error {
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	rootCmd.Flags().BoolS("A", "A", false, "each name is an associative array variable")
-	rootCmd.Flags().BoolS("F", "F", false, "inhibit  the display of function definitions")
+	rootCmd.Flags().BoolS("F", "F", false, "inhibit the display of function definitions")
 	rootCmd.Flags().BoolS("I", "I", false, "inherit the attributes and value of any existing variable with the same name")
 	rootCmd.Flags().BoolS("a", "a", false, "each name is an indexed array variable")
 	rootCmd.Flags().BoolS("f", "f", false, "each name refers to a shell function")
@@ -26,11 +29,25 @@ func init() {
 	rootCmd.Flags().BoolS("i", "i", false, "the variable is to be treated as an integer")
 	rootCmd.Flags().BoolS("l", "l", false, "all upper-case characters are converted to lower-case")
 	rootCmd.Flags().BoolS("n", "n", false, "give each name the nameref attribute")
-	rootCmd.Flags().BoolS("p", "p", false, "option will display the attributes and values of each name")
+	rootCmd.Flags().BoolS("p", "p", false, "display the attributes and values of each name")
 	rootCmd.Flags().BoolS("r", "r", false, "make names readonly")
 	rootCmd.Flags().BoolS("t", "t", false, "give each name the trace attribute")
 	rootCmd.Flags().BoolS("u", "u", false, "all lower-case characters are converted to upper-case")
 	rootCmd.Flags().BoolS("x", "x", false, "mark each name for export to subsequent commands via the environment")
 
-	// TODO shell.Variables
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if rootCmd.Flags().Lookup("f").Changed {
+				return shell.ActionFunctions(true)
+			}
+			return carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+				switch len(c.Parts) {
+				case 0:
+					return shell.ActionVariables()
+				default:
+					return carapace.ActionValues()
+				}
+			})
+		}),
+	)
 }

--- a/completers/bash/dirs_completer/cmd/root.go
+++ b/completers/bash/dirs_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "dirs",
+	Short: "Display directory stack",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html#index-dirs",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("c", "c", false, "clear the directory stack by deleting all of the elements")
+	rootCmd.Flags().BoolS("l", "l", false, "do not print tilde-prefixed versions of directories relative to your home directory")
+	rootCmd.Flags().BoolS("p", "p", false, "print the directory stack with one entry per line")
+	rootCmd.Flags().BoolS("v", "v", false, "print the directory stack with one entry per line prefixed with its position in the stack")
+}

--- a/completers/bash/dirs_completer/main.go
+++ b/completers/bash/dirs_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/dirs_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/disown_completer/cmd/root.go
+++ b/completers/bash/disown_completer/cmd/root.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "disown",
+	Short: "Remove jobs from current shell",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Job-Control-Builtins.html#index-disown",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "remove all jobs if jobspec is not supplied")
+	rootCmd.Flags().BoolS("h", "h", false, "mark each jobspec so that SIGHUP is not sent to the job if the shell receives a SIGHUP")
+	rootCmd.Flags().BoolS("r", "r", false, "remove only running jobs")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.Batch(
+			shell.ActionJobSpecs(),
+			ps.ActionProcessIds(),
+		).ToA().FilterArgs(),
+	)
+}

--- a/completers/bash/disown_completer/main.go
+++ b/completers/bash/disown_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/disown_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/echo_completer/cmd/root.go
+++ b/completers/bash/echo_completer/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "echo",
+	Short: "Write arguments to the standard output",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-echo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("E", "E", false, "explicitly suppress interpretation of backslash escapes")
+	rootCmd.Flags().BoolS("e", "e", false, "enable interpretation of backslash escapes")
+	rootCmd.Flags().BoolS("n", "n", false, "do not append a newline")
+}

--- a/completers/bash/echo_completer/main.go
+++ b/completers/bash/echo_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/echo_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/enable_completer/cmd/root.go
+++ b/completers/bash/enable_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable and disable shell builtins",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-enable",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "print a list of builtins showing whether or not each is enabled")
+	rootCmd.Flags().BoolS("d", "d", false, "remove a builtin loaded with -f")
+	rootCmd.Flags().StringS("f", "f", "", "load builtin name from shared object filename")
+	rootCmd.Flags().BoolS("n", "n", false, "disable each name or display a list of disabled builtins")
+	rootCmd.Flags().BoolS("p", "p", false, "print the list of builtins in a reusable format")
+	rootCmd.Flags().BoolS("s", "s", false, "print only the names of Posix special builtins")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"f": carapace.ActionFiles(),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionBuiltins().FilterArgs(),
+	)
+}

--- a/completers/bash/enable_completer/main.go
+++ b/completers/bash/enable_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/enable_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/eval_completer/cmd/root.go
+++ b/completers/bash/eval_completer/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:                "eval",
+	Short:              "Execute arguments as a shell command",
+	Long:               "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-eval",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		shell.ActionExecutables(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/bash/eval_completer/main.go
+++ b/completers/bash/eval_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/eval_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/exec_completer/cmd/root.go
+++ b/completers/bash/exec_completer/cmd/root.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "exec",
+	Short: "Replace the shell with the given command",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-exec",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+	rootCmd.Flags().SetInterspersed(false)
+
+	rootCmd.Flags().StringS("a", "a", "", "pass name as the zeroth argument to command")
+	rootCmd.Flags().BoolS("c", "c", false, "execute command with an empty environment")
+	rootCmd.Flags().BoolS("l", "l", false, "place a dash in the zeroth argument to command")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		shell.ActionExecutables(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/bash/exec_completer/main.go
+++ b/completers/bash/exec_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/exec_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/export_completer/cmd/root.go
+++ b/completers/bash/export_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Set export attribute for shell variables",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-export",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("f", "f", false, "refer to shell functions")
+	rootCmd.Flags().BoolS("n", "n", false, "remove the export property from each name")
+	rootCmd.Flags().BoolS("p", "p", false, "display a list of all exported variables or functions")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return shell.ActionVariables()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/bash/export_completer/main.go
+++ b/completers/bash/export_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/export_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/fc_completer/cmd/root.go
+++ b/completers/bash/fc_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fc",
+	Short: "Display or execute commands from the history list",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-fc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("e", "e", "", "select which editor to use")
+	rootCmd.Flags().BoolS("l", "l", false, "list lines instead of editing")
+	rootCmd.Flags().BoolS("n", "n", false, "omit line numbers when listing")
+	rootCmd.Flags().BoolS("r", "r", false, "reverse the order of the lines")
+	rootCmd.Flags().BoolS("s", "s", false, "re-execute command after substitution")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"e": carapace.ActionValuesDescribed(
+			"vi", "vi editor",
+			"emacs", "emacs editor",
+			"nano", "nano editor",
+		),
+	})
+}

--- a/completers/bash/fc_completer/main.go
+++ b/completers/bash/fc_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/fc_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/fg_completer/cmd/root.go
+++ b/completers/bash/fg_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fg",
+	Short: "Move job to the foreground",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Job-Control-Builtins.html#index-fg",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/bash/fg_completer/main.go
+++ b/completers/bash/fg_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/fg_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/getopts_completer/cmd/root.go
+++ b/completers/bash/getopts_completer/cmd/root.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "getopts",
+	Short: "Parse option arguments",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-getopts",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+}

--- a/completers/bash/getopts_completer/main.go
+++ b/completers/bash/getopts_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/getopts_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/hash_completer/cmd/root.go
+++ b/completers/bash/hash_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "hash",
+	Short: "Remember or display program locations",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-hash",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("d", "d", false, "forget the remembered location of each name")
+	rootCmd.Flags().BoolS("l", "l", false, "display in a format that may be reused as input")
+	rootCmd.Flags().StringS("p", "p", "", "use pathname as the full path of name")
+	rootCmd.Flags().BoolS("r", "r", false, "forget all remembered locations")
+	rootCmd.Flags().StringS("t", "t", "", "print the remembered location of name")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"p": carapace.ActionFiles(),
+		"t": shell.ActionExecutables(),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionExecutables().FilterArgs(),
+	)
+}

--- a/completers/bash/hash_completer/main.go
+++ b/completers/bash/hash_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/hash_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/help_completer/cmd/root.go
+++ b/completers/bash/help_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Display information about builtin commands",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-help",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("d", "d", false, "output short description for each pattern match")
+	rootCmd.Flags().BoolS("m", "m", false, "display usage in pseudo-manpage format")
+	rootCmd.Flags().BoolS("p", "p", false, "list all builtins matching pattern")
+	rootCmd.Flags().BoolS("s", "s", false, "output short description for each builtin")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionBuiltins().FilterArgs(),
+	)
+}

--- a/completers/bash/help_completer/main.go
+++ b/completers/bash/help_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/help_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/history_completer/cmd/root.go
+++ b/completers/bash/history_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Display or manipulate the history list",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-history",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "append history lines from this session to the history file")
+	rootCmd.Flags().BoolS("c", "c", false, "clear the history list by erasing the entries")
+	rootCmd.Flags().BoolS("d", "d", false, "delete the history entry at offset offset")
+	rootCmd.Flags().BoolS("n", "n", false, "read all history lines not already read from the history file")
+	rootCmd.Flags().StringS("p", "p", "", "perform history expansion on each arg and display the result")
+	rootCmd.Flags().BoolS("r", "r", false, "read the history file and append the contents to the history list")
+	rootCmd.Flags().StringS("s", "s", "", "append the args to the history list as a single entry")
+	rootCmd.Flags().BoolS("w", "w", false, "write the current history to the history file")
+}

--- a/completers/bash/history_completer/main.go
+++ b/completers/bash/history_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/history_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/jobs_completer/cmd/root.go
+++ b/completers/bash/jobs_completer/cmd/root.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "jobs",
+	Short: "Display status of jobs",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Job-Control-Builtins.html#index-jobs",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("l", "l", false, "list process IDs in addition to the normal information")
+	rootCmd.Flags().BoolS("n", "n", false, "display only jobs that have changed status since the user was last notified of their status")
+	rootCmd.Flags().BoolS("p", "p", false, "display only the process ID of the job's process group leader")
+	rootCmd.Flags().BoolS("r", "r", false, "display only running jobs")
+	rootCmd.Flags().BoolS("s", "s", false, "display only stopped jobs")
+	rootCmd.Flags().BoolS("x", "x", false, "replace job spec with process group ID in command")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs().FilterArgs(),
+	)
+}

--- a/completers/bash/jobs_completer/main.go
+++ b/completers/bash/jobs_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/jobs_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/let_completer/cmd/root.go
+++ b/completers/bash/let_completer/cmd/root.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "let",
+	Short: "Evaluate arithmetic expressions",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-let",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+}

--- a/completers/bash/let_completer/main.go
+++ b/completers/bash/let_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/let_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/local_completer/cmd/root.go
+++ b/completers/bash/local_completer/cmd/root.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "local",
+	Short: "Define local variables",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-local",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return shell.ActionVariables()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/bash/local_completer/main.go
+++ b/completers/bash/local_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/local_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/mapfile_completer/cmd/root.go
+++ b/completers/bash/mapfile_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "mapfile",
+	Short: "Read lines from standard input into an indexed array variable",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-mapfile",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("C", "C", "", "evaluate callback each time quantum lines are read")
+	rootCmd.Flags().StringS("O", "O", "", "begin assigning to array at index origin")
+	rootCmd.Flags().StringS("c", "c", "", "specify the number of lines read between each call to callback")
+	rootCmd.Flags().StringS("d", "d", "", "read lines until the first character of delim is read instead of newline")
+	rootCmd.Flags().StringS("n", "n", "", "copy at most count lines")
+	rootCmd.Flags().BoolS("s", "s", false, "treat the first line read as the number of lines to skip")
+	rootCmd.Flags().StringS("t", "t", "", "remove a trailing delim from each line read")
+	rootCmd.Flags().StringS("u", "u", "", "read lines from file descriptor fd instead of the standard input")
+}

--- a/completers/bash/mapfile_completer/main.go
+++ b/completers/bash/mapfile_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/mapfile_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/popd_completer/cmd/root.go
+++ b/completers/bash/popd_completer/cmd/root.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "popd",
+	Short: "Remove directories from directory stack",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html#index-popd",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("n", "n", false, "suppress the normal change of directory when removing directories from the stack")
+}

--- a/completers/bash/popd_completer/main.go
+++ b/completers/bash/popd_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/popd_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/printf_completer/cmd/root.go
+++ b/completers/bash/printf_completer/cmd/root.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "printf",
+	Short: "Format and print data",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-printf",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("v", "v", "", "assign the output to variable name rather than display it")
+}

--- a/completers/bash/printf_completer/main.go
+++ b/completers/bash/printf_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/printf_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/pushd_completer/cmd/root.go
+++ b/completers/bash/pushd_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "pushd",
+	Short: "Add directories to the top of the directory stack",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html#index-pushd",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("n", "n", false, "suppress the normal change of directory when adding directories to the stack")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionDirectories().FilterArgs(),
+	)
+}

--- a/completers/bash/pushd_completer/main.go
+++ b/completers/bash/pushd_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/pushd_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/read_completer/cmd/root.go
+++ b/completers/bash/read_completer/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "read",
+	Short: "Read a line from the standard input and split it into fields",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-read",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("N", "N", "", "read returns after reading exactly nchars characters")
+	rootCmd.Flags().StringS("d", "d", "", "continue until the first character of delim is read instead of newline")
+	rootCmd.Flags().BoolS("e", "e", false, "use Readline to obtain the line in an interactive shell")
+	rootCmd.Flags().StringS("i", "i", "", "text is placed in the initial edit buffer as if it had been entered")
+	rootCmd.Flags().StringS("n", "n", "", "read returns after reading nchars characters")
+	rootCmd.Flags().StringS("p", "p", "", "display prompt on standard error without a trailing newline before reading")
+	rootCmd.Flags().BoolS("r", "r", false, "do not allow backslashes to escape any characters")
+	rootCmd.Flags().BoolS("s", "s", false, "do not echo input coming from a terminal")
+	rootCmd.Flags().StringS("t", "t", "", "time out and return failure if a complete line of input is not read within timeout seconds")
+	rootCmd.Flags().StringS("u", "u", "", "read from file descriptor fd instead of standard input")
+}

--- a/completers/bash/read_completer/main.go
+++ b/completers/bash/read_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/read_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/readarray_completer/cmd/root.go
+++ b/completers/bash/readarray_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "readarray",
+	Short: "Read lines from standard input into an indexed array variable",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-readarray",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("C", "C", "", "evaluate callback each time quantum lines are read")
+	rootCmd.Flags().StringS("O", "O", "", "begin assigning to array at index origin")
+	rootCmd.Flags().StringS("c", "c", "", "specify the number of lines read between each call to callback")
+	rootCmd.Flags().StringS("d", "d", "", "read lines until the first character of delim is read instead of newline")
+	rootCmd.Flags().StringS("n", "n", "", "copy at most count lines")
+	rootCmd.Flags().BoolS("s", "s", false, "treat the first line read as the number of lines to skip")
+	rootCmd.Flags().StringS("t", "t", "", "remove a trailing delim from each line read")
+	rootCmd.Flags().StringS("u", "u", "", "read lines from file descriptor fd instead of the standard input")
+}

--- a/completers/bash/readarray_completer/main.go
+++ b/completers/bash/readarray_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/readarray_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/readonly_completer/cmd/root.go
+++ b/completers/bash/readonly_completer/cmd/root.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "readonly",
+	Short: "Mark shell variables as unchangeable",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-readonly",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("A", "A", false, "each name refers to an associative array variable")
+	rootCmd.Flags().BoolS("a", "a", false, "each name refers to an indexed array variable")
+	rootCmd.Flags().BoolS("f", "f", false, "each name refers to a shell function")
+	rootCmd.Flags().BoolS("p", "p", false, "display a list of all readonly variables or functions")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return shell.ActionVariables()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/bash/readonly_completer/main.go
+++ b/completers/bash/readonly_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/readonly_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/set_completer/cmd/root.go
+++ b/completers/bash/set_completer/cmd/root.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set or unset values of shell options and positional parameters",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-set",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("B", "B", false, "the shell will perform brace expansion")
+	rootCmd.Flags().BoolS("C", "C", false, "disallow existing regular files to be overwritten by redirection of output")
+	rootCmd.Flags().BoolS("E", "E", false, "the ERR trap is inherited by shell functions")
+	rootCmd.Flags().BoolS("H", "H", false, "enable ! style history substitution")
+	rootCmd.Flags().BoolS("P", "P", false, "do not resolve symbolic links when executing commands")
+	rootCmd.Flags().BoolS("T", "T", false, "the DEBUG and RETURN traps are inherited by shell functions")
+	rootCmd.Flags().BoolS("a", "a", false, "mark variables which are modified or created for export")
+	rootCmd.Flags().BoolS("b", "b", false, "cause the status of terminated background jobs to be reported immediately")
+	rootCmd.Flags().BoolS("e", "e", false, "exit immediately if a command exits with a non-zero status")
+	rootCmd.Flags().BoolS("f", "f", false, "disable file name generation (globbing)")
+	rootCmd.Flags().BoolS("h", "h", false, "remember the location of commands as they are looked up")
+	rootCmd.Flags().BoolS("k", "k", false, "all arguments in the form of assignment statements are placed in the environment")
+	rootCmd.Flags().BoolS("m", "m", false, "enable job control")
+	rootCmd.Flags().BoolS("n", "n", false, "read commands but do not execute them")
+	rootCmd.Flags().StringS("o", "o", "", "set the option corresponding to option-name")
+	rootCmd.Flags().BoolS("p", "p", false, "turned on whenever the real and effective user ids do not match")
+	rootCmd.Flags().BoolS("t", "t", false, "exit after reading and executing one command")
+	rootCmd.Flags().BoolS("u", "u", false, "treat unset variables as an error when substituting")
+	rootCmd.Flags().BoolS("v", "v", false, "print shell input lines as they are read")
+	rootCmd.Flags().BoolS("x", "x", false, "print commands and their arguments as they are executed")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"o": carapace.ActionValuesDescribed(
+			"allexport", "same as -a",
+			"braceexpand", "same as -B",
+			"emacs", "use an emacs-style line editing interface",
+			"errexit", "same as -e",
+			"errtrace", "same as -E",
+			"functrace", "same as -T",
+			"hashall", "same as -h",
+			"histexpand", "same as -H",
+			"history", "enable command history",
+			"ignoreeof", "shell does not exit on EOF",
+			"keyword", "same as -k",
+			"monitor", "same as -m",
+			"noclobber", "same as -C",
+			"noexec", "same as -n",
+			"noglob", "same as -f",
+			"nolog", "do not save function definitions in history",
+			"notify", "same as -b",
+			"nounset", "same as -u",
+			"onecmd", "same as -t",
+			"physical", "same as -P",
+			"pipefail", "return value of pipeline is the rightmost command to exit with non-zero status",
+			"posix", "change the behavior of bash to match the POSIX standard",
+			"privileged", "same as -p",
+			"verbose", "same as -v",
+			"vi", "use a vi-style line editing interface",
+			"xtrace", "same as -x",
+		),
+	})
+}

--- a/completers/bash/set_completer/main.go
+++ b/completers/bash/set_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/set_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/shopt_completer/cmd/root.go
+++ b/completers/bash/shopt_completer/cmd/root.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "shopt",
+	Short: "Set and unset shell options",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-shopt",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("o", "o", false, "restrict optnames to those defined for use with set -o")
+	rootCmd.Flags().BoolS("p", "p", false, "print each shell option with an indication of its status")
+	rootCmd.Flags().BoolS("q", "q", false, "suppress output")
+	rootCmd.Flags().BoolS("s", "s", false, "enable (set) each optname")
+	rootCmd.Flags().BoolS("u", "u", false, "disable (unset) each optname")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if rootCmd.Flags().Lookup("o").Changed {
+				return carapace.ActionValuesDescribed(
+					"allexport", "same as -a",
+					"braceexpand", "same as -B",
+					"emacs", "use an emacs-style line editing interface",
+					"errexit", "same as -e",
+					"errtrace", "same as -E",
+					"functrace", "same as -T",
+					"hashall", "same as -h",
+					"histexpand", "same as -H",
+					"history", "enable command history",
+					"ignoreeof", "shell does not exit on EOF",
+					"keyword", "same as -k",
+					"monitor", "same as -m",
+					"noclobber", "same as -C",
+					"noexec", "same as -n",
+					"noglob", "same as -f",
+					"nolog", "do not save function definitions in history",
+					"notify", "same as -b",
+					"nounset", "same as -u",
+					"onecmd", "same as -t",
+					"physical", "same as -P",
+					"pipefail", "return value of pipeline is the rightmost command to exit with non-zero status",
+					"posix", "change the behavior of bash to match the POSIX standard",
+					"privileged", "same as -p",
+					"verbose", "same as -v",
+					"vi", "use a vi-style line editing interface",
+					"xtrace", "same as -x",
+				).Filter(c.Args...)
+			}
+			return carapace.ActionValuesDescribed(
+				"assoc_expand_once", "expand associative array subscripts only once",
+				"autocd", "a command name is treated as a candidate for cd",
+				"cdable_vars", "a word that is not a directory is assumed to be a variable name",
+				"cdspell", "minor errors in the spelling of a directory are corrected",
+				"checkhash", "check whether a command found in the hash table exists",
+				"checkjobs", "check for running jobs before exiting an interactive shell",
+				"checkwinsize", "check window size after each command",
+				"cmdhist", "save all lines of a multi-line command in the same history entry",
+				"compat31", "compatibility mode for bash 3.1",
+				"compat32", "compatibility mode for bash 3.2",
+				"compat40", "compatibility mode for bash 4.0",
+				"compat41", "compatibility mode for bash 4.1",
+				"compat42", "compatibility mode for bash 4.2",
+				"compat43", "compatibility mode for bash 4.3",
+				"compat44", "compatibility mode for bash 4.4",
+				"complete_fullquote", "quote all readline completions",
+				"direxpand", "expand directory names during word completion",
+				"dirspell", "attempt spelling correction on directory names during word completion",
+				"dotglob", "include filenames beginning with a '.' in pathname expansion",
+				"execfail", "non-interactive shell does not exit on exec failure",
+				"expand_aliases", "expand aliases",
+				"extdebug", "enable extended debugging",
+				"extglob", "enable extended pattern matching",
+				"extquote", "allow $'...' and $\"...\" quoting",
+				"failglob", "pattern expansion that matches no files produces an error",
+				"force_fignore", "suffixes ignored by FIGNORE also affect word completion",
+				"globasciiranges", "use ASCII collation order for range expressions in pattern matching",
+				"globskipdots", "skip . and .. in pathname expansion",
+				"globstar", "** matches all files and directories including subdirectories",
+				"gnu_errfmt", "use GNU error message format",
+				"histappend", "append to history file rather than overwrite",
+				"histreedit", "allow user to re-edit a failed history substitution",
+				"histverify", "allow user to edit a history substitution result",
+				"hostcomplete", "attempt hostname completion",
+				"huponexit", "send SIGHUP to all jobs on exit",
+				"inherit_errexit", "command substitution inherits the errexit setting",
+				"interactive_comments", "allow comments in interactive shells",
+				"lastpipe", "run the last command of a pipeline in the current shell",
+				"lithist", "save multi-line commands with embedded newlines",
+				"localvar_inherit", "local variables inherit the value and attributes of a variable of the same name",
+				"localvar_unset", "local variables inherit the value and attributes of a variable of the same name",
+				"login_shell", "shell is a login shell",
+				"mailwarn", "warn if mail has been read and new mail has arrived",
+				"nocaseglob", "match filenames in a case-insensitive fashion",
+				"nocasematch", "match patterns in a case-insensitive fashion",
+				"no_empty_cmd_completion", "do not attempt to search PATH for completions on an empty line",
+				"noexpand_translation", "do not expand translated strings",
+				"nullglob", "allow patterns which match no files to expand to a null string",
+				"patsub_replacement", "perform pattern substitution on the right-hand side of variable expansion",
+				"progcomp", "enable programmable completion",
+				"progcomp_alias", "allow programmable completion to use aliases",
+				"promptvars", "prompt strings undergo variable expansion",
+				"restricted_shell", "shell is running in restricted mode",
+				"shift_verbose", "shift prints a message when the shift count exceeds the number of positional parameters",
+				"sourcepath", "source uses PATH to find files",
+				"varredir_close", "close file descriptors created by variable redirections",
+				"xpg_echo", "echo expands escape sequences by default",
+			).Filter(c.Args...)
+		}),
+	)
+}

--- a/completers/bash/shopt_completer/main.go
+++ b/completers/bash/shopt_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/shopt_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/source_completer/cmd/root.go
+++ b/completers/bash/source_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "source",
+	Short: "Execute commands from a file in the current shell",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-source",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringS("p", "p", "", "search path for filename")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"p": carapace.ActionDirectories(),
+	})
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/bash/source_completer/main.go
+++ b/completers/bash/source_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/source_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/test_completer/cmd/root.go
+++ b/completers/bash/test_completer/cmd/root.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Evaluate conditional expression",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-test",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValuesDescribed(
+			"-a", "file exists",
+			"-b", "file is block special",
+			"-c", "file is character special",
+			"-d", "file is a directory",
+			"-e", "file exists",
+			"-f", "file exists and is a regular file",
+			"-g", "file is set-group-id",
+			"-h", "file is a symbolic link",
+			"-k", "file has its sticky bit set",
+			"-L", "file is a symbolic link",
+			"-n", "string is not empty",
+			"-o", "shell option is enabled",
+			"-p", "file is a named pipe",
+			"-r", "file is readable",
+			"-s", "file exists and is not empty",
+			"-S", "file is a socket",
+			"-t", "file descriptor is opened on a terminal",
+			"-u", "file is set-user-id",
+			"-v", "shell variable is set",
+			"-w", "file is writable",
+			"-x", "file is executable",
+			"-z", "string is empty",
+			"-G", "file is effectively owned by your group",
+			"-N", "file has been modified since it was last read",
+			"-O", "file is effectively owned by you",
+			"-R", "shell variable is set and is a name reference",
+			"=", "strings are equal",
+			"!=", "strings are not equal",
+			"-eq", "integers are equal",
+			"-ne", "integers are not equal",
+			"-lt", "first integer is less than second",
+			"-le", "first integer is less than or equal to second",
+			"-gt", "first integer is greater than second",
+			"-ge", "first integer is greater than or equal to second",
+			"-nt", "first file is newer than second",
+			"-ot", "first file is older than second",
+			"-ef", "files are hard links to the same file",
+		),
+	)
+}

--- a/completers/bash/test_completer/main.go
+++ b/completers/bash/test_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/test_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/trap_completer/cmd/root.go
+++ b/completers/bash/trap_completer/cmd/root.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "trap",
+	Short: "Trap signals and other events",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-trap",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("P", "P", false, "display the trap commands associated with each signal_spec")
+	rootCmd.Flags().BoolS("l", "l", false, "print a list of signal names and their corresponding numbers")
+	rootCmd.Flags().BoolS("p", "p", false, "display the trap commands associated with each signal_spec in a reusable form")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.Batch(
+			ps.ActionKillSignals(),
+			carapace.ActionValuesDescribed(
+				"DEBUG", "executed before every simple command",
+				"ERR", "executed when a command's failure would cause the shell to exit",
+				"EXIT", "executed on exit from the shell",
+				"RETURN", "executed each time a shell function or script finishes",
+				"SIGDEBUG", "executed before every simple command",
+				"SIGERR", "executed when a command's failure would cause the shell to exit",
+				"SIGEXIT", "executed on exit from the shell",
+				"SIGRETURN", "executed each time a shell function or script finishes",
+			),
+		).ToA().FilterArgs(),
+	)
+}

--- a/completers/bash/trap_completer/main.go
+++ b/completers/bash/trap_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/trap_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/type_completer/cmd/root.go
+++ b/completers/bash/type_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "type",
+	Short: "Display information about command type",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-type",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("P", "P", false, "force a PATH search for each name")
+	rootCmd.Flags().BoolS("a", "a", false, "display all locations containing an executable named name")
+	rootCmd.Flags().BoolS("f", "f", false, "suppress shell function lookup")
+	rootCmd.Flags().BoolS("p", "p", false, "return the name of the disk file that would be executed")
+	rootCmd.Flags().BoolS("t", "t", false, "output a single word which is one of alias, keyword, function, builtin, file, or empty")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			// TODO shell.ActionExecutables currently bridges CarapaceBin for further args (good or bad?)
+			return shell.ActionExecutables().Shift(len(c.Args)).FilterArgs()
+		}),
+	)
+}

--- a/completers/bash/type_completer/main.go
+++ b/completers/bash/type_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/type_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/typeset_completer/cmd/root.go
+++ b/completers/bash/typeset_completer/cmd/root.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "typeset",
+	Short: "Set variable values and attributes",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-typeset",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("A", "A", false, "each name is an associative array variable")
+	rootCmd.Flags().BoolS("F", "F", false, "inhibit the display of function definitions")
+	rootCmd.Flags().BoolS("I", "I", false, "inherit the attributes and value of any existing variable with the same name")
+	rootCmd.Flags().BoolS("a", "a", false, "each name is an indexed array variable")
+	rootCmd.Flags().BoolS("f", "f", false, "each name refers to a shell function")
+	rootCmd.Flags().BoolS("g", "g", false, "forces variables to be created or modified at the global scope")
+	rootCmd.Flags().BoolS("i", "i", false, "the variable is to be treated as an integer")
+	rootCmd.Flags().BoolS("l", "l", false, "all upper-case characters are converted to lower-case")
+	rootCmd.Flags().BoolS("n", "n", false, "give each name the nameref attribute")
+	rootCmd.Flags().BoolS("p", "p", false, "display the attributes and values of each name")
+	rootCmd.Flags().BoolS("r", "r", false, "make names readonly")
+	rootCmd.Flags().BoolS("t", "t", false, "give each name the trace attribute")
+	rootCmd.Flags().BoolS("u", "u", false, "all lower-case characters are converted to upper-case")
+	rootCmd.Flags().BoolS("x", "x", false, "mark each name for export to subsequent commands via the environment")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return shell.ActionVariables()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/bash/typeset_completer/main.go
+++ b/completers/bash/typeset_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/typeset_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/ulimit_completer/cmd/root.go
+++ b/completers/bash/ulimit_completer/cmd/root.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "ulimit",
+	Short: "Modify shell resource limits",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-ulimit",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("H", "H", false, "use the hard resource limit")
+	rootCmd.Flags().BoolS("P", "P", false, "the maximum number of pseudoterminals")
+	rootCmd.Flags().BoolS("R", "R", false, "the maximum time a real-time process can run before blocking")
+	rootCmd.Flags().BoolS("S", "S", false, "use the soft resource limit")
+	rootCmd.Flags().BoolS("T", "T", false, "the maximum number of threads")
+	rootCmd.Flags().BoolS("a", "a", false, "all current limits are reported")
+	rootCmd.Flags().BoolS("b", "b", false, "the socket buffer size")
+	rootCmd.Flags().BoolS("c", "c", false, "the maximum size of core files created")
+	rootCmd.Flags().BoolS("d", "d", false, "the maximum size of a process's data segment")
+	rootCmd.Flags().BoolS("e", "e", false, "the maximum scheduling priority")
+	rootCmd.Flags().BoolS("f", "f", false, "the maximum size of files written by the shell")
+	rootCmd.Flags().BoolS("i", "i", false, "the maximum number of pending signals")
+	rootCmd.Flags().BoolS("k", "k", false, "the maximum number of kqueues allocated for this process")
+	rootCmd.Flags().BoolS("l", "l", false, "the maximum size a process may lock into memory")
+	rootCmd.Flags().BoolS("m", "m", false, "the maximum resident set size")
+	rootCmd.Flags().BoolS("n", "n", false, "the maximum number of open file descriptors")
+	rootCmd.Flags().BoolS("p", "p", false, "the pipe buffer size")
+	rootCmd.Flags().BoolS("q", "q", false, "the maximum number of bytes in POSIX message queues")
+	rootCmd.Flags().BoolS("r", "r", false, "the maximum real-time scheduling priority")
+	rootCmd.Flags().BoolS("s", "s", false, "the maximum stack size")
+	rootCmd.Flags().BoolS("t", "t", false, "the maximum amount of cpu time in seconds")
+	rootCmd.Flags().BoolS("u", "u", false, "the maximum number of user processes")
+	rootCmd.Flags().BoolS("v", "v", false, "the size of virtual memory")
+	rootCmd.Flags().BoolS("x", "x", false, "the maximum number of file locks")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValuesDescribed(
+			"hard", "current hard limit",
+			"soft", "current soft limit",
+			"unlimited", "no limit",
+		),
+	)
+}

--- a/completers/bash/ulimit_completer/main.go
+++ b/completers/bash/ulimit_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/ulimit_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/umask_completer/cmd/root.go
+++ b/completers/bash/umask_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/fs"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "umask",
+	Short: "Display or set file mode mask",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-umask",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("S", "S", false, "makes the output symbolic; otherwise an octal number is output")
+	rootCmd.Flags().BoolS("p", "p", false, "output in a form that may be reused as input")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		fs.ActionFileModes(),
+	)
+}

--- a/completers/bash/umask_completer/main.go
+++ b/completers/bash/umask_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/umask_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/unalias_completer/cmd/root.go
+++ b/completers/bash/unalias_completer/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "unalias",
+	Short: "Remove each name from the list of defined aliases",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-unalias",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "remove all alias definitions")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionAliases().FilterArgs(),
+	)
+}

--- a/completers/bash/unalias_completer/main.go
+++ b/completers/bash/unalias_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/unalias_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/unset_completer/cmd/root.go
+++ b/completers/bash/unset_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "unset",
+	Short: "Unset values and attributes of shell variables and functions",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-unset",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("f", "f", false, "treat each name as a shell function")
+	rootCmd.Flags().BoolS("n", "n", false, "treat each name as a name reference and unset the variable itself")
+	rootCmd.Flags().BoolS("v", "v", false, "treat each name as a shell variable")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			if rootCmd.Flags().Lookup("f").Changed {
+				return shell.ActionFunctions(true)
+			}
+			return shell.ActionVariables()
+		}).FilterArgs(),
+	)
+}

--- a/completers/bash/unset_completer/main.go
+++ b/completers/bash/unset_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/unset_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/bash/wait_completer/cmd/root.go
+++ b/completers/bash/wait_completer/cmd/root.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "wait",
+	Short: "Wait for job completion and return exit status",
+	Long:  "https://www.gnu.org/software/bash/manual/html_node/Job-Control-Builtins.html#index-wait",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("f", "f", false, "wait for the specified ID to terminate instead of waiting for it to change status")
+	rootCmd.Flags().BoolS("n", "n", false, "wait for a single job from the list of IDs to complete")
+	rootCmd.Flags().StringS("p", "p", "", "assign the process or job identifier of the job to variable var")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.Batch(
+			shell.ActionJobSpecs(),
+			ps.ActionProcessIds(),
+		).ToA().FilterArgs(),
+	)
+}

--- a/completers/bash/wait_completer/main.go
+++ b/completers/bash/wait_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/bash/wait_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/shell/shell.go
+++ b/pkg/actions/shell/shell.go
@@ -50,6 +50,36 @@ func ActionFunctions(hidden bool) carapace.Action {
 	}).Tag("shell functions")
 }
 
+// ActionJobSpecs completes shell job specifications
+//
+//	%1
+//	%2
+func ActionJobSpecs() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionValues(strings.Fields(os.Getenv("CARAPACE_SHELL_JOBS"))...)
+	}).Tag("job specs")
+}
+
+// ActionAliases completes shell aliases
+//
+//	ll
+//	la
+func ActionAliases() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionValues(strings.Fields(os.Getenv("CARAPACE_SHELL_ALIASES"))...)
+	}).Tag("shell aliases")
+}
+
+// ActionVariables completes shell variable names
+//
+//	PATH
+//	HOME
+func ActionVariables() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionValues(strings.Fields(os.Getenv("CARAPACE_SHELL_VARIABLES"))...)
+	}).Tag("shell variables")
+}
+
 // ActionExecutables completes builtins, functions, and commands
 //
 //	ls

--- a/pkg/actions/tools/carapace/completer.go
+++ b/pkg/actions/tools/carapace/completer.go
@@ -110,15 +110,18 @@ func ActionGroups(nameVariant string) carapace.Action {
 
 		descriptions := map[string]string{
 			"android": "termux completers",
+			"bash":    "bash completers",
 			"bridge":  "bridged completers",
 			"bsd":     "bsd-like completers",
 			"common":  "common completers",
 			"darwin":  "macos completers",
+			"fish":    "fish completers",
 			"linux":   "linux completers",
 			"unix":    "unix-like completers",
 			"user":    "user specs",
 			"system":  "system specs",
 			"windows": "windows completers",
+			"zsh":     "zsh completers",
 		}
 
 		for _, variants := range m {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -6,8 +6,16 @@ import (
 )
 
 const (
+	CARAPACE_BUILTINS = "CARAPACE_BUILTINS" // enabled shell builtin groups
 	CARAPACE_EXCLUDES = "CARAPACE_EXCLUDES" // excluded completers
 )
+
+func Builtins() []string {
+	if v, ok := os.LookupEnv(CARAPACE_BUILTINS); ok {
+		return strings.Split(v, ",")
+	}
+	return []string{}
+}
 
 func Excludes() []string {
 	// TODO: excludes should allow excluding variants/groups (`/zsh`, `@bsd`)


### PR DESCRIPTION
Add 44 new completers for bash builtins (alias, bg, bind, builtin,
caller, cd, command, compgen, complete, compopt, dirs, disown, echo,
enable, eval, exec, export, fc, fg, getopts, hash, help, history,
jobs, let, local, mapfile, popd, printf, pushd, read, readarray,
readonly, set, shopt, source, test, trap, type, typeset, ulimit,
umask, unalias, unset, wait) and enhance the existing declare
completer with variable/function completion.

Add shell action helpers (ActionAliases, ActionVariables,
ActionJobSpecs) and expose CARAPACE_SHELL_ALIASES,
CARAPACE_SHELL_JOBS, and CARAPACE_SHELL_VARIABLES environment
variables in bash/zsh/fish snippets. Register the bash completer
group in the code generator for all Unix-like platforms.

Assisted-by: Crush:glm-5.1
