### PR TITLE
add zsh builtin completers

### DIFF
--- a/cmd/carapace-generate/cmd/generate_all.go
+++ b/cmd/carapace-generate/cmd/generate_all.go
@@ -82,14 +82,14 @@ var generateAllCmd = &cobra.Command{
 
 func filterByGoos(all completer.CompleterMap, goos string) completer.CompleterMap {
 	groups := map[string][]string{
-		"android":   {"common", "unix", "linux", "android", "bash"},
-		"darwin":    {"common", "unix", "bsd", "darwin", "bash"},
-		"freebsd":   {"common", "unix", "bsd", "freebsd", "bash"},
-		"linux":     {"common", "unix", "linux", "bash"},
-		"netbsd":    {"common", "unix", "bsd", "netbsd", "bash"},
-		"openbsd":   {"common", "unix", "bsd", "openbsd", "bash"},
+		"android":   {"common", "unix", "linux", "android", "bash", "zsh"},
+		"darwin":    {"common", "unix", "bsd", "darwin", "bash", "zsh"},
+		"freebsd":   {"common", "unix", "bsd", "freebsd", "bash", "zsh"},
+		"linux":     {"common", "unix", "linux", "bash", "zsh"},
+		"netbsd":    {"common", "unix", "bsd", "netbsd", "bash", "zsh"},
+		"openbsd":   {"common", "unix", "bsd", "openbsd", "bash", "zsh"},
 		"windows":   {"common", "windows"},
-		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd", "bash"},
+		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd", "bash", "zsh"},
 	}
 
 	filtered := make(completer.CompleterMap)

--- a/cmd/carapace-generate/pkg/completer/completers.go
+++ b/cmd/carapace-generate/pkg/completer/completers.go
@@ -20,15 +20,15 @@ func ReadCompleters(dir, goos string) (completer.CompleterMap, error) {
 	// TODO shell specific completers
 	// TODO distro specific completers (arch,ubuntu,...)
 	groups := map[string][]string{
-		"android": {"common", "unix", "linux", "android", "bash"},
-		"darwin":  {"common", "unix", "bsd", "darwin", "bash"},
-		"freebsd": {"common", "unix", "bsd", "freebsd", "bash"},
-		"linux":   {"common", "unix", "linux", "bash"},
-		"netbsd":  {"common", "unix", "bsd", "netbsd", "bash"},
-		"openbsd": {"common", "unix", "bsd", "openbsd", "bash"},
+		"android": {"common", "unix", "linux", "android", "bash", "zsh"},
+		"darwin":  {"common", "unix", "bsd", "darwin", "bash", "zsh"},
+		"freebsd": {"common", "unix", "bsd", "freebsd", "bash", "zsh"},
+		"linux":   {"common", "unix", "linux", "bash", "zsh"},
+		"netbsd":  {"common", "unix", "bsd", "netbsd", "bash", "zsh"},
+		"openbsd": {"common", "unix", "bsd", "openbsd", "bash", "zsh"},
 		"windows": {"common", "windows"},
 
-		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd", "bash"},
+		"force_all": {"common", "unix", "linux", "bsd", "darwin", "android", "windows", "freebsd", "netbsd", "openbsd", "bash", "zsh"},
 	}
 
 	completers, err := readCompleters(dir)

--- a/cmd/carapace/cmd/snippet/bash.go
+++ b/cmd/carapace/cmd/snippet/bash.go
@@ -15,7 +15,7 @@ const bashCompleter = `_carapace_completer() {
   declare -x CARAPACE_SHELL_ALIASES="$(alias -p | sed 's/alias //;s/=.*//')"
   declare -x CARAPACE_SHELL_BUILTINS="$(compgen -b)"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(compgen -A function)"
-  declare -x CARAPACE_SHELL_JOBS="$(jobs -p 2>/dev/null | while read -r pid; do echo "%$((++n))"; done)"
+  declare -x CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | sed -n '/Running\|Stopped/s/^\[\([0-9]*\)\].*/%\1/p')"
   declare -x CARAPACE_SHELL_VARIABLES="$(compgen -v)"
 
   local command="${COMP_WORDS[0]}" nospace data compline="${COMP_LINE:0:${COMP_POINT}}"

--- a/cmd/carapace/cmd/snippet/fish.go
+++ b/cmd/carapace/cmd/snippet/fish.go
@@ -13,7 +13,7 @@ function _carapace_completer
   set --local --export CARAPACE_SHELL_ALIASES (alias | string replace -r 'alias ' '' | string replace -r '=.*' '')
   set --local --export CARAPACE_SHELL_BUILTINS (builtin --names)
   set --local --export CARAPACE_SHELL_FUNCTIONS (functions --all)
-  set --local --export CARAPACE_SHELL_JOBS (jobs -p 2>/dev/null | while read -r pid; echo "%%"(math $n + 1); set n (math $n + 1); end)
+  set --local --export CARAPACE_SHELL_JOBS (jobs 2>/dev/null | string match -r '^\d+\s+\d+\s+(running|stopped|suspended|continued)' | string replace -r '^(\d+).*' '%%$1')
   set --local --export CARAPACE_SHELL_VARIABLES (set --names)
   set --local data
   IFS='' set data (echo (commandline -cp)'' | sed "s/ \$/ ''/" | xargs carapace $argv[1] fish 2>/dev/null)

--- a/cmd/carapace/cmd/snippet/zsh.go
+++ b/cmd/carapace/cmd/snippet/zsh.go
@@ -23,7 +23,7 @@ function _carapace_completer {
   declare -x CARAPACE_SHELL_ALIASES="$(alias | sed 's/alias //;s/=.*//')"
   declare -x CARAPACE_SHELL_BUILTINS="$(print -roC1 -- ${(k)builtins})"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(print -l ${(ok)functions})"
-  declare -x CARAPACE_SHELL_JOBS="$(jobs -p 2>/dev/null | while read -r pid; do echo "%%$((++n))"; done)"
+  declare -x CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | sed -n '/running\|suspended\|stopped/s/^\[\([0-9]*\)\].*/%%\1/p')"
   declare -x CARAPACE_SHELL_VARIABLES="$(print -l ${(ok)parameters})"
 
   # shellcheck disable=SC2086,SC2154,SC2155

--- a/completers/zsh/alias_completer/cmd/root.go
+++ b/completers/zsh/alias_completer/cmd/root.go
@@ -20,6 +20,7 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	// TODO missing flags and support for `+flag` notation
 	rootCmd.Flags().BoolS("g", "g", false, "define a global alias")
 	rootCmd.Flags().BoolS("s", "s", false, "define a suffix alias")
 

--- a/completers/zsh/alias_completer/cmd/root.go
+++ b/completers/zsh/alias_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "alias",
+	Short: "Define or display aliases",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-alias",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("g", "g", false, "define a global alias")
+	rootCmd.Flags().BoolS("s", "s", false, "define a suffix alias")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		shell.ActionAliases(),
+	)
+}

--- a/completers/zsh/alias_completer/main.go
+++ b/completers/zsh/alias_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/alias_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/bg_completer/cmd/root.go
+++ b/completers/zsh/bg_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bg",
+	Short: "Put jobs in the background",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-bg",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/zsh/bg_completer/cmd/root.go
+++ b/completers/zsh/bg_completer/cmd/root.go
@@ -21,6 +21,6 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionJobSpecs(),
+		shell.ActionJobSpecs().FilterArgs(),
 	)
 }

--- a/completers/zsh/bg_completer/main.go
+++ b/completers/zsh/bg_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/bg_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/break_completer/cmd/root.go
+++ b/completers/zsh/break_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/number"
 	"github.com/spf13/cobra"
 )
 
@@ -19,11 +20,8 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("i", "i", false, "exit from loops running in interactive mode")
-
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValues(
-			"1", "2", "3", "4", "5", "6", "7", "8", "9",
-		).Usage("loop count to exit"),
+		number.ActionRange(number.RangeOpts{Start: 1, End: 9}).
+			Usage("loop count to exit"),
 	)
 }

--- a/completers/zsh/break_completer/cmd/root.go
+++ b/completers/zsh/break_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "break",
+	Short: "Exit from loop constructs",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-break",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("i", "i", false, "exit from loops running in interactive mode")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"1", "2", "3", "4", "5", "6", "7", "8", "9",
+		).Usage("loop count to exit"),
+	)
+}

--- a/completers/zsh/break_completer/main.go
+++ b/completers/zsh/break_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/break_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/builtin_completer/cmd/root.go
+++ b/completers/zsh/builtin_completer/cmd/root.go
@@ -8,10 +8,11 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "builtin",
-	Short: "Execute shell builtins",
-	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-builtin",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:                "builtin",
+	Short:              "Execute shell builtins",
+	Long:               "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-builtin",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
 }
 
 func Execute() error {

--- a/completers/zsh/builtin_completer/cmd/root.go
+++ b/completers/zsh/builtin_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "builtin",
+	Short: "Execute shell builtins",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-builtin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		shell.ActionBuiltins(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/zsh/builtin_completer/main.go
+++ b/completers/zsh/builtin_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/builtin_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/cd_completer/cmd/root.go
+++ b/completers/zsh/cd_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "cd",
+	Short: "Change the current working directory",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-cd",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("L", "L", false, "force symbolic links to be followed")
+	rootCmd.Flags().BoolS("P", "P", false, "use the physical directory structure without following symbolic links")
+	rootCmd.Flags().BoolS("e", "e", false, "if the -P option is supplied, exit with a non-zero status if the current working directory cannot be determined successfully")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/zsh/cd_completer/main.go
+++ b/completers/zsh/cd_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/cd_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/chdir_completer/cmd/root.go
+++ b/completers/zsh/chdir_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "chdir",
+	Short: "Change the current working directory",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-chdir",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("L", "L", false, "force symbolic links to be followed")
+	rootCmd.Flags().BoolS("P", "P", false, "use the physical directory structure without following symbolic links")
+	rootCmd.Flags().BoolS("s", "s", false, "restrict to named directories")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/zsh/chdir_completer/main.go
+++ b/completers/zsh/chdir_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/chdir_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/command_completer/cmd/root.go
+++ b/completers/zsh/command_completer/cmd/root.go
@@ -19,6 +19,7 @@ func Execute() error {
 
 func init() {
 	carapace.Gen(rootCmd).Standalone()
+	rootCmd.Flags().SetInterspersed(false)
 
 	rootCmd.Flags().BoolS("p", "p", false, "use a default PATH that is guaranteed to find all the standard utilities")
 

--- a/completers/zsh/command_completer/cmd/root.go
+++ b/completers/zsh/command_completer/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "command",
+	Short: "Execute a command with absolutely no special treatment",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-command",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("p", "p", false, "use a default PATH that is guaranteed to find all the standard utilities")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionExecutables(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/zsh/command_completer/main.go
+++ b/completers/zsh/command_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/command_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/continue_completer/cmd/root.go
+++ b/completers/zsh/continue_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "continue",
+	Short: "Resume the next iteration of a loop",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-continue",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("i", "i", false, "resume from loops running in interactive mode")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues("1", "2", "3", "4", "5", "6", "7", "8", "9").Usage("loop count to continue"),
+	)
+}

--- a/completers/zsh/continue_completer/cmd/root.go
+++ b/completers/zsh/continue_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/number"
 	"github.com/spf13/cobra"
 )
 
@@ -19,9 +20,8 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("i", "i", false, "resume from loops running in interactive mode")
-
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValues("1", "2", "3", "4", "5", "6", "7", "8", "9").Usage("loop count to continue"),
+		number.ActionRange(number.RangeOpts{Start: 1, End: 9}).
+			Usage("loop count to continue"),
 	)
 }

--- a/completers/zsh/continue_completer/main.go
+++ b/completers/zsh/continue_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/continue_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/dirs_completer/cmd/root.go
+++ b/completers/zsh/dirs_completer/cmd/root.go
@@ -23,8 +23,4 @@ func init() {
 	rootCmd.Flags().BoolS("l", "l", false, "produce a longer listing")
 	rootCmd.Flags().BoolS("p", "p", false, "print one entry per line")
 	rootCmd.Flags().BoolS("v", "v", false, "print one entry per line with position index")
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/dirs_completer/cmd/root.go
+++ b/completers/zsh/dirs_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "dirs",
+	Short: "Display the directory stack",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-dirs",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("c", "c", false, "clear the directory stack")
+	rootCmd.Flags().BoolS("l", "l", false, "produce a longer listing")
+	rootCmd.Flags().BoolS("p", "p", false, "print one entry per line")
+	rootCmd.Flags().BoolS("v", "v", false, "print one entry per line with position index")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/dirs_completer/main.go
+++ b/completers/zsh/dirs_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/dirs_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/disown_completer/cmd/root.go
+++ b/completers/zsh/disown_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "disown",
+	Short: "Remove jobs from the job table",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-disown",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "remove all jobs")
+	rootCmd.Flags().BoolS("r", "r", false, "remove all running jobs")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/zsh/disown_completer/cmd/root.go
+++ b/completers/zsh/disown_completer/cmd/root.go
@@ -20,10 +20,7 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("a", "a", false, "remove all jobs")
-	rootCmd.Flags().BoolS("r", "r", false, "remove all running jobs")
-
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionJobSpecs(),
+		shell.ActionJobSpecs().FilterArgs(),
 	)
 }

--- a/completers/zsh/disown_completer/main.go
+++ b/completers/zsh/disown_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/disown_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/echo_completer/cmd/root.go
+++ b/completers/zsh/echo_completer/cmd/root.go
@@ -22,8 +22,4 @@ func init() {
 	rootCmd.Flags().BoolS("E", "E", false, "disable interpretation of backslash escapes")
 	rootCmd.Flags().BoolS("e", "e", false, "enable interpretation of backslash escapes")
 	rootCmd.Flags().BoolS("n", "n", false, "do not output a trailing newline")
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/echo_completer/cmd/root.go
+++ b/completers/zsh/echo_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "echo",
+	Short: "Display a line of text",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-echo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("E", "E", false, "disable interpretation of backslash escapes")
+	rootCmd.Flags().BoolS("e", "e", false, "enable interpretation of backslash escapes")
+	rootCmd.Flags().BoolS("n", "n", false, "do not output a trailing newline")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/echo_completer/main.go
+++ b/completers/zsh/echo_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/echo_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/eval_completer/cmd/root.go
+++ b/completers/zsh/eval_completer/cmd/root.go
@@ -7,10 +7,11 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "eval",
-	Short: "Evaluate arguments as shell commands",
-	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-eval",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:                "eval",
+	Short:              "Evaluate arguments as shell commands",
+	Long:               "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-eval",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
 }
 
 func Execute() error {

--- a/completers/zsh/eval_completer/cmd/root.go
+++ b/completers/zsh/eval_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "eval",
+	Short: "Evaluate arguments as shell commands",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-eval",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/zsh/eval_completer/main.go
+++ b/completers/zsh/eval_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/eval_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/exec_completer/cmd/root.go
+++ b/completers/zsh/exec_completer/cmd/root.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "exec",
+	Short: "Replace the current shell with a command",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-exec",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "set the argv[0] string")
+	rootCmd.Flags().BoolS("c", "c", false, "clear the environment")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionExecutables(),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/zsh/exec_completer/cmd/root.go
+++ b/completers/zsh/exec_completer/cmd/root.go
@@ -19,6 +19,7 @@ func Execute() error {
 
 func init() {
 	carapace.Gen(rootCmd).Standalone()
+	rootCmd.Flags().SetInterspersed(false)
 
 	rootCmd.Flags().BoolS("a", "a", false, "set the argv[0] string")
 	rootCmd.Flags().BoolS("c", "c", false, "clear the environment")

--- a/completers/zsh/exec_completer/main.go
+++ b/completers/zsh/exec_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/exec_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/exit_completer/cmd/root.go
+++ b/completers/zsh/exit_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "exit",
+	Short: "Exit the shell",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-exit",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+		).Usage("exit status"),
+	)
+}

--- a/completers/zsh/exit_completer/cmd/root.go
+++ b/completers/zsh/exit_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/number"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +21,7 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValues(
-			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-		).Usage("exit status"),
+		number.ActionRange(number.RangeOpts{Start: 0, End: 9}).
+			Usage("exit status"),
 	)
 }

--- a/completers/zsh/exit_completer/main.go
+++ b/completers/zsh/exit_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/exit_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/export_completer/cmd/root.go
+++ b/completers/zsh/export_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Set export attribute for shell variables",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-export",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("f", "f", false, "refer to shell functions")
+	rootCmd.Flags().BoolS("n", "n", false, "remove the export property from each name")
+	rootCmd.Flags().BoolS("p", "p", false, "display a list of all exported variables or functions")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return shell.ActionVariables()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/zsh/export_completer/cmd/root.go
+++ b/completers/zsh/export_completer/cmd/root.go
@@ -20,8 +20,6 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("f", "f", false, "refer to shell functions")
-	rootCmd.Flags().BoolS("n", "n", false, "remove the export property from each name")
 	rootCmd.Flags().BoolS("p", "p", false, "display a list of all exported variables or functions")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(

--- a/completers/zsh/export_completer/main.go
+++ b/completers/zsh/export_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/export_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/fc_completer/cmd/root.go
+++ b/completers/zsh/fc_completer/cmd/root.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fc",
+	Short: "Fix command - edit and re-execute commands from history",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-fc",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("A", "A", false, "append current history to history file")
+	rootCmd.Flags().BoolS("D", "D", false, "don't run, just print")
+	rootCmd.Flags().BoolS("W", "W", false, "append current history to history file")
+	rootCmd.Flags().BoolS("e", "e", false, "specify editor to use")
+	rootCmd.Flags().BoolS("l", "l", false, "list commands instead of editing")
+	rootCmd.Flags().BoolS("n", "n", false, "omit command numbers from display")
+	rootCmd.Flags().BoolS("r", "r", false, "reverse the order of commands")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues().Usage("first event number or string"),
+	)
+}

--- a/completers/zsh/fc_completer/cmd/root.go
+++ b/completers/zsh/fc_completer/cmd/root.go
@@ -22,10 +22,14 @@ func init() {
 	rootCmd.Flags().BoolS("A", "A", false, "append current history to history file")
 	rootCmd.Flags().BoolS("D", "D", false, "don't run, just print")
 	rootCmd.Flags().BoolS("W", "W", false, "append current history to history file")
-	rootCmd.Flags().BoolS("e", "e", false, "specify editor to use")
+	rootCmd.Flags().StringS("e", "e", "", "specify editor to use")
 	rootCmd.Flags().BoolS("l", "l", false, "list commands instead of editing")
 	rootCmd.Flags().BoolS("n", "n", false, "omit command numbers from display")
 	rootCmd.Flags().BoolS("r", "r", false, "reverse the order of commands")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"e": carapace.ActionExecutables(),
+	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
 		carapace.ActionValues().Usage("first event number or string"),

--- a/completers/zsh/fc_completer/main.go
+++ b/completers/zsh/fc_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/fc_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/fg_completer/cmd/root.go
+++ b/completers/zsh/fg_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "fg",
+	Short: "Bring jobs to the foreground",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-fg",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/zsh/fg_completer/cmd/root.go
+++ b/completers/zsh/fg_completer/cmd/root.go
@@ -21,6 +21,6 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionJobSpecs(),
+		shell.ActionJobSpecs().FilterArgs(),
 	)
 }

--- a/completers/zsh/fg_completer/main.go
+++ b/completers/zsh/fg_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/fg_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/getopts_completer/cmd/root.go
+++ b/completers/zsh/getopts_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "getopts",
+	Short: "Parse command options",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-getopts",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues().Usage("option string"),
+	)
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues().Usage("name of shell variable to receive option"),
+	)
+}

--- a/completers/zsh/getopts_completer/main.go
+++ b/completers/zsh/getopts_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/getopts_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/hash_completer/cmd/root.go
+++ b/completers/zsh/hash_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "hash",
+	Short: "View or modify the command hash table",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-hash",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("d", "d", false, "forget all remembered commands")
+	rootCmd.Flags().BoolS("r", "r", false, "remove all commands from hash table")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return carapace.ActionExecutables()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/zsh/hash_completer/main.go
+++ b/completers/zsh/hash_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/hash_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/history_completer/cmd/root.go
+++ b/completers/zsh/history_completer/cmd/root.go
@@ -19,12 +19,10 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
-	rootCmd.Flags().BoolS("c", "c", false, "clear the history list")
 	rootCmd.Flags().BoolS("d", "d", false, "delete the specified history entry")
 	rootCmd.Flags().BoolS("n", "n", false, "don't include event numbers")
 	rootCmd.Flags().BoolS("p", "p", false, "perform history expansion")
 	rootCmd.Flags().BoolS("r", "r", false, "read the history file")
-	rootCmd.Flags().BoolS("w", "w", false, "write the history file")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
 		carapace.ActionValues(),

--- a/completers/zsh/history_completer/cmd/root.go
+++ b/completers/zsh/history_completer/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Display or manipulate the command history",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-history",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("c", "c", false, "clear the history list")
+	rootCmd.Flags().BoolS("d", "d", false, "delete the specified history entry")
+	rootCmd.Flags().BoolS("n", "n", false, "don't include event numbers")
+	rootCmd.Flags().BoolS("p", "p", false, "perform history expansion")
+	rootCmd.Flags().BoolS("r", "r", false, "read the history file")
+	rootCmd.Flags().BoolS("w", "w", false, "write the history file")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/history_completer/main.go
+++ b/completers/zsh/history_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/history_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/jobs_completer/cmd/root.go
+++ b/completers/zsh/jobs_completer/cmd/root.go
@@ -24,6 +24,6 @@ func init() {
 	rootCmd.Flags().BoolS("p", "p", false, "list only process IDs")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionJobSpecs(),
+		shell.ActionJobSpecs().FilterArgs(),
 	)
 }

--- a/completers/zsh/jobs_completer/cmd/root.go
+++ b/completers/zsh/jobs_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "jobs",
+	Short: "Display the status of jobs",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-jobs",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("l", "l", false, "list process IDs")
+	rootCmd.Flags().BoolS("p", "p", false, "list only process IDs")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/zsh/jobs_completer/main.go
+++ b/completers/zsh/jobs_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/jobs_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/kill_completer/cmd/root.go
+++ b/completers/zsh/kill_completer/cmd/root.go
@@ -2,14 +2,16 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/ps"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "kill",
-	Short: "Send a signal to a process",
-	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-kill",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:                "kill",
+	Short:              "Send a signal to a process",
+	Long:               "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-kill",
+	Run:                func(cmd *cobra.Command, args []string) {},
+	DisableFlagParsing: true,
 }
 
 func Execute() error {
@@ -20,28 +22,10 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValuesDescribed(
-			"-TERM", "terminate signal (default)",
-			"-HUP", "hangup signal",
-			"-INT", "interrupt signal",
-			"-KILL", "kill signal (cannot be caught)",
-			"-STOP", "stop process",
-			"-CONT", "continue stopped process",
-		),
+		ps.ActionKillSignals().Prefix("-"),
 	)
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValuesDescribed(
-			"HUP", "hangup signal",
-			"INT", "interrupt signal",
-			"KILL", "kill signal (cannot be caught)",
-			"QUIT", "quit signal",
-			"TERM", "terminate signal",
-			"STOP", "stop process",
-			"CONT", "continue stopped process",
-			"USR1", "user-defined signal 1",
-			"USR2", "user-defined signal 2",
-			"PIPE", "broken pipe signal",
-		),
+		ps.ActionProcessIds().FilterArgs().Shift(1),
 	)
 }

--- a/completers/zsh/kill_completer/cmd/root.go
+++ b/completers/zsh/kill_completer/cmd/root.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "kill",
+	Short: "Send a signal to a process",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-kill",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValuesDescribed(
+			"-TERM", "terminate signal (default)",
+			"-HUP", "hangup signal",
+			"-INT", "interrupt signal",
+			"-KILL", "kill signal (cannot be caught)",
+			"-STOP", "stop process",
+			"-CONT", "continue stopped process",
+		),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValuesDescribed(
+			"HUP", "hangup signal",
+			"INT", "interrupt signal",
+			"KILL", "kill signal (cannot be caught)",
+			"QUIT", "quit signal",
+			"TERM", "terminate signal",
+			"STOP", "stop process",
+			"CONT", "continue stopped process",
+			"USR1", "user-defined signal 1",
+			"USR2", "user-defined signal 2",
+			"PIPE", "broken pipe signal",
+		),
+	)
+}

--- a/completers/zsh/kill_completer/main.go
+++ b/completers/zsh/kill_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/kill_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/let_completer/cmd/root.go
+++ b/completers/zsh/let_completer/cmd/root.go
@@ -18,8 +18,4 @@ func Execute() error {
 
 func init() {
 	carapace.Gen(rootCmd).Standalone()
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/let_completer/cmd/root.go
+++ b/completers/zsh/let_completer/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "let",
+	Short: "Evaluate arithmetic expressions",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-let",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/let_completer/main.go
+++ b/completers/zsh/let_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/let_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/local_completer/cmd/root.go
+++ b/completers/zsh/local_completer/cmd/root.go
@@ -29,8 +29,4 @@ func init() {
 	rootCmd.Flags().BoolS("t", "t", false, "mark as tagged")
 	rootCmd.Flags().BoolS("u", "u", false, "uppercase conversion")
 	rootCmd.Flags().BoolS("x", "x", false, "export")
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/local_completer/cmd/root.go
+++ b/completers/zsh/local_completer/cmd/root.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "local",
+	Short: "Define local variables",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-local",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("E", "E", false, "use scientific notation")
+	rootCmd.Flags().BoolS("L", "L", false, "left justify")
+	rootCmd.Flags().BoolS("R", "R", false, "right justify")
+	rootCmd.Flags().BoolS("Z", "Z", false, "zero fill")
+	rootCmd.Flags().BoolS("h", "h", false, "use hash notation")
+	rootCmd.Flags().BoolS("i", "i", false, "use integer arithmetic")
+	rootCmd.Flags().BoolS("r", "r", false, "make readonly")
+	rootCmd.Flags().BoolS("t", "t", false, "mark as tagged")
+	rootCmd.Flags().BoolS("u", "u", false, "uppercase conversion")
+	rootCmd.Flags().BoolS("x", "x", false, "export")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/local_completer/main.go
+++ b/completers/zsh/local_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/local_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/logout_completer/cmd/root.go
+++ b/completers/zsh/logout_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Exit the shell",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-logout",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+		).Usage("exit status"),
+	)
+}

--- a/completers/zsh/logout_completer/cmd/root.go
+++ b/completers/zsh/logout_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/number"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +21,7 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValues(
-			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-		).Usage("exit status"),
+		number.ActionRange(number.RangeOpts{Start: 0, End: 9}).
+			Usage("exit status"),
 	)
 }

--- a/completers/zsh/logout_completer/main.go
+++ b/completers/zsh/logout_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/logout_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/popd_completer/cmd/root.go
+++ b/completers/zsh/popd_completer/cmd/root.go
@@ -22,7 +22,5 @@ func init() {
 	rootCmd.Flags().BoolS("n", "n", false, "suppress the normal change of directory")
 	rootCmd.Flags().BoolS("q", "q", false, "quiet mode")
 
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues("+N", "-N").Usage("specify entry to remove"),
-	)
+	// TODO  positional completion
 }

--- a/completers/zsh/popd_completer/cmd/root.go
+++ b/completers/zsh/popd_completer/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "popd",
+	Short: "Pop the directory stack",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-popd",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("n", "n", false, "suppress the normal change of directory")
+	rootCmd.Flags().BoolS("q", "q", false, "quiet mode")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues("+N", "-N").Usage("specify entry to remove"),
+	)
+}

--- a/completers/zsh/popd_completer/main.go
+++ b/completers/zsh/popd_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/popd_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/print_completer/cmd/root.go
+++ b/completers/zsh/print_completer/cmd/root.go
@@ -23,8 +23,4 @@ func init() {
 	rootCmd.Flags().BoolS("R", "R", false, "like -e")
 	rootCmd.Flags().BoolS("n", "n", false, "do not output a trailing newline")
 	rootCmd.Flags().BoolS("z", "z", false, "push arguments onto editing buffer stack")
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/print_completer/cmd/root.go
+++ b/completers/zsh/print_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "print",
+	Short: "Display a line of text",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-print",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("D", "D", false, "interpret escape sequences")
+	rootCmd.Flags().BoolS("R", "R", false, "like -e")
+	rootCmd.Flags().BoolS("n", "n", false, "do not output a trailing newline")
+	rootCmd.Flags().BoolS("z", "z", false, "push arguments onto editing buffer stack")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/print_completer/main.go
+++ b/completers/zsh/print_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/print_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/printf_completer/cmd/root.go
+++ b/completers/zsh/printf_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "printf",
+	Short: "Display formatted output",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-printf",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("v", "v", false, "assign output to variable")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues().Usage("format string"),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/printf_completer/cmd/root.go
+++ b/completers/zsh/printf_completer/cmd/root.go
@@ -24,8 +24,4 @@ func init() {
 	carapace.Gen(rootCmd).PositionalCompletion(
 		carapace.ActionValues().Usage("format string"),
 	)
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/printf_completer/main.go
+++ b/completers/zsh/printf_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/printf_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/pushd_completer/cmd/root.go
+++ b/completers/zsh/pushd_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "pushd",
+	Short: "Push directory onto the directory stack",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-pushd",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("L", "L", false, "force symbolic links to be followed")
+	rootCmd.Flags().BoolS("P", "P", false, "use the physical directory structure")
+	rootCmd.Flags().BoolS("n", "n", false, "suppress the normal change of directory")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/zsh/pushd_completer/main.go
+++ b/completers/zsh/pushd_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/pushd_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/pwd_completer/cmd/root.go
+++ b/completers/zsh/pwd_completer/cmd/root.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "pwd",
+	Short: "Print the current working directory",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-pwd",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("L", "L", false, "print logical path")
+	rootCmd.Flags().BoolS("P", "P", false, "print physical path")
+}

--- a/completers/zsh/pwd_completer/main.go
+++ b/completers/zsh/pwd_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/pwd_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/read_completer/cmd/root.go
+++ b/completers/zsh/read_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "read",
+	Short: "Read a line from the standard input",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-read",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("0", "0", false, "delimiter is NUL")
+	rootCmd.Flags().BoolS("A", "A", false, "array")
+	rootCmd.Flags().BoolS("r", "r", false, "raw mode")
+	rootCmd.Flags().BoolS("s", "s", false, "no output")
+	rootCmd.Flags().BoolS("t", "t", false, "timeout")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues().Usage("variable name"),
+	)
+}

--- a/completers/zsh/read_completer/main.go
+++ b/completers/zsh/read_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/read_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/readonly_completer/cmd/root.go
+++ b/completers/zsh/readonly_completer/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "readonly",
+	Short: "Mark variables as readonly",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-readonly",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("f", "f", false, "refer to shell functions")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionVariables(),
+	)
+}

--- a/completers/zsh/readonly_completer/main.go
+++ b/completers/zsh/readonly_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/readonly_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/return_completer/cmd/root.go
+++ b/completers/zsh/return_completer/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "return",
+	Short: "Cause a shell function to return",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-return",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+		).Usage("exit status"),
+	)
+}

--- a/completers/zsh/return_completer/cmd/root.go
+++ b/completers/zsh/return_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/number"
 	"github.com/spf13/cobra"
 )
 
@@ -20,8 +21,7 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValues(
-			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-		).Usage("exit status"),
+		number.ActionRange(number.RangeOpts{Start: 0, End: 9}).
+			Usage("exit status"),
 	)
 }

--- a/completers/zsh/return_completer/main.go
+++ b/completers/zsh/return_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/return_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/set_completer/cmd/root.go
+++ b/completers/zsh/set_completer/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set or unset values of shell options and positional parameters",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-set",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("A", "A", false, "array assignment")
+	rootCmd.Flags().BoolS("e", "e", false, "exit immediately on error")
+	rootCmd.Flags().BoolS("f", "f", false, "disable file name generation")
+	rootCmd.Flags().BoolS("h", "h", false, "remember command locations")
+	rootCmd.Flags().BoolS("k", "k", false, "assign arguments as environment variables")
+	rootCmd.Flags().BoolS("m", "m", false, "enable job control")
+	rootCmd.Flags().BoolS("n", "n", false, "read but do not execute")
+	rootCmd.Flags().BoolS("t", "t", false, "exit after one command")
+	rootCmd.Flags().BoolS("u", "u", false, "treat unset variables as error")
+	rootCmd.Flags().BoolS("v", "v", false, "print shell input lines")
+	rootCmd.Flags().BoolS("x", "x", false, "print commands and arguments")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"A": carapace.ActionValues("name", "array"),
+	})
+}

--- a/completers/zsh/set_completer/main.go
+++ b/completers/zsh/set_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/set_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/setopt_completer/cmd/root.go
+++ b/completers/zsh/setopt_completer/cmd/root.go
@@ -53,6 +53,6 @@ func init() {
 			"silent", "singlecommands", "singlelinezle", "smartcomplete", "sunkeyboardhack",
 			"transposechars", "trapsasync", "unset", "verbose", "vi", "warncreateglobal",
 			"warnnestedvar", "xtrace", "zle",
-		),
+		).FilterArgs(),
 	)
 }

--- a/completers/zsh/setopt_completer/cmd/root.go
+++ b/completers/zsh/setopt_completer/cmd/root.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "setopt",
+	Short: "Set shell options",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-setopt",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("e", "e", false, "exit on error")
+	rootCmd.Flags().BoolS("k", "k", false, "all arguments as keyword")
+	rootCmd.Flags().BoolS("m", "m", false, "job control")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(
+			"allexport", "alwayslastprompt", "alwaystoend", "autocd", "autocontinue",
+			"autolist", "automenu", "autoparamkeys", "autoparamslash", "autopushd",
+			"autoresume", "badpattern", "banghist", "beep", "bgnice", "braceccl",
+			"cdablevars", "cdsilent", "chaselinks", "checkjobs", "checkrunningjobs",
+			"clobber", "completeinword", "correct", "correctall", "dirsspell",
+			"dotglob", "dvorak", "emacs", "errexit", "errreturn", "exec",
+			"extendedglob", "extendedhistory", "flowcontrol", "forcefloat", "glob",
+			"globassign", "globcomplete", "globdots", "globstarshort", "globsubst",
+			"hashcmds", "hashdirs", "hashexecutablesonly", "hashlistall", "histallowclobber",
+			"histbeep", "histexpiredupsfirst", "histfcntllock", "histfindnodups",
+			"histignorealldups", "histignoredups", "histignorespace", "histlexwords",
+			"histnofunctions", "histnostore", "histreduceblanks", "histsavenodups",
+			"histsubstpattern", "history", "historyappend", "historysubsel",
+			"hookstyle", "hostcomplete", "huponexit", "ignorebraces", "ignoreclosebraces",
+			"incappendhistory", "incappendhistorytime", "interactivecomments", "interactiveimmediate",
+			"interactivestart", "keeplogs", "listambiguous", "listbeep", "listpacked",
+			"listrowsfirst", "localloops", "localoptions", "localpatterns", "login",
+			"longlistjobs", "magicequalsubst", "mailwarning", "markdirs", "menucomplete",
+			"monitor", "multios", "noclobber", "nocomments", "nodie", "noerrreturn",
+			"noflowcontrol", "noglobalexport", "nohup", "notify", "nullglob",
+			"numericglobsort", "octalzeroes", "overstrike", "pathdirs", "pipefail",
+			"posixbuiltins", "posixident", "printeightbit", "prn", "promptbang",
+			"promptcr", "promptpercent", "promptsp", "promptsubst", "quietzle",
+			"rcquotes", "receivesignals", "restricted", "rmstarwait", "schedule",
+			"shallowersetopt", "shglob", "shortloops", "showcomplete", "showtype",
+			"silent", "singlecommands", "singlelinezle", "smartcomplete", "sunkeyboardhack",
+			"transposechars", "trapsasync", "unset", "verbose", "vi", "warncreateglobal",
+			"warnnestedvar", "xtrace", "zle",
+		),
+	)
+}

--- a/completers/zsh/setopt_completer/main.go
+++ b/completers/zsh/setopt_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/setopt_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/shift_completer/cmd/root.go
+++ b/completers/zsh/shift_completer/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "shift",
+	Short: "Shift positional parameters",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-shift",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues("1", "2", "3", "4", "5", "6", "7", "8", "9").Usage("number of positions to shift"),
+	)
+}

--- a/completers/zsh/shift_completer/cmd/root.go
+++ b/completers/zsh/shift_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/number"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionValues("1", "2", "3", "4", "5", "6", "7", "8", "9").Usage("number of positions to shift"),
+		number.ActionRange(number.RangeOpts{Start: 1, End: 9}).
+			Usage("number of positions to shift"),
 	)
 }

--- a/completers/zsh/shift_completer/main.go
+++ b/completers/zsh/shift_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/shift_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/source_completer/cmd/root.go
+++ b/completers/zsh/source_completer/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "source",
+	Short: "Read and execute commands from a file",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-source",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionFiles("*.zsh", "*.sh"),
+	)
+}

--- a/completers/zsh/source_completer/main.go
+++ b/completers/zsh/source_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/source_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/test_completer/cmd/root.go
+++ b/completers/zsh/test_completer/cmd/root.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Evaluate a conditional expression",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-test",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/test_completer/cmd/root.go
+++ b/completers/zsh/test_completer/cmd/root.go
@@ -18,8 +18,4 @@ func Execute() error {
 
 func init() {
 	carapace.Gen(rootCmd).Standalone()
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/test_completer/main.go
+++ b/completers/zsh/test_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/test_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/times_completer/cmd/root.go
+++ b/completers/zsh/times_completer/cmd/root.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "times",
+	Short: "Print the CPU times used",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-times",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+}

--- a/completers/zsh/times_completer/main.go
+++ b/completers/zsh/times_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/times_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/trap_completer/cmd/root.go
+++ b/completers/zsh/trap_completer/cmd/root.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "trap",
+	Short: "Trap signals and execute commands",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-trap",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"HUP", "INT", "QUIT", "ILL", "TRAP", "IOT", "BUS", "FPE", "KILL",
+			"USR1", "SEGV", "USR2", "PIPE", "ALRM", "TERM", "STKFLT", "CHLD",
+			"CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU", "XFSZ",
+			"VTALRM", "PROF", "WINCH", "POLL", "PWR", "SYS", "ZERR", "DEBUG",
+			"EXIT", "0",
+		).Usage("signal"),
+	)
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues().Usage("command"),
+	)
+}

--- a/completers/zsh/trap_completer/cmd/root.go
+++ b/completers/zsh/trap_completer/cmd/root.go
@@ -19,6 +19,7 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	// TODO fix positional completion
 	carapace.Gen(rootCmd).PositionalCompletion(
 		carapace.ActionValues(
 			"HUP", "INT", "QUIT", "ILL", "TRAP", "IOT", "BUS", "FPE", "KILL",

--- a/completers/zsh/trap_completer/main.go
+++ b/completers/zsh/trap_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/trap_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/type_completer/cmd/root.go
+++ b/completers/zsh/type_completer/cmd/root.go
@@ -25,6 +25,6 @@ func init() {
 	rootCmd.Flags().BoolS("w", "w", false, "describe how word would be interpreted")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionExecutables(),
+		carapace.ActionExecutables().FilterArgs(),
 	)
 }

--- a/completers/zsh/type_completer/cmd/root.go
+++ b/completers/zsh/type_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "type",
+	Short: "Identify command types",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-type",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("A", "A", false, "only names with alias or builtin")
+	rootCmd.Flags().BoolS("f", "f", false, "use functions")
+	rootCmd.Flags().BoolS("m", "m", false, "use pattern matching")
+	rootCmd.Flags().BoolS("w", "w", false, "describe how word would be interpreted")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionExecutables(),
+	)
+}

--- a/completers/zsh/type_completer/main.go
+++ b/completers/zsh/type_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/type_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/typeset_completer/cmd/root.go
+++ b/completers/zsh/typeset_completer/cmd/root.go
@@ -31,8 +31,4 @@ func init() {
 	rootCmd.Flags().BoolS("t", "t", false, "mark as tagged")
 	rootCmd.Flags().BoolS("u", "u", false, "uppercase conversion")
 	rootCmd.Flags().BoolS("x", "x", false, "export")
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/typeset_completer/cmd/root.go
+++ b/completers/zsh/typeset_completer/cmd/root.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "typeset",
+	Short: "Define variables and set attributes",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-typeset",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("E", "E", false, "use scientific notation")
+	rootCmd.Flags().BoolS("L", "L", false, "left justify")
+	rootCmd.Flags().BoolS("R", "R", false, "right justify")
+	rootCmd.Flags().BoolS("Z", "Z", false, "zero fill")
+	rootCmd.Flags().BoolS("f", "f", false, "refer to functions")
+	rootCmd.Flags().BoolS("h", "h", false, "use hash notation")
+	rootCmd.Flags().BoolS("i", "i", false, "use integer arithmetic")
+	rootCmd.Flags().BoolS("l", "l", false, "lowercase conversion")
+	rootCmd.Flags().BoolS("r", "r", false, "make readonly")
+	rootCmd.Flags().BoolS("t", "t", false, "mark as tagged")
+	rootCmd.Flags().BoolS("u", "u", false, "uppercase conversion")
+	rootCmd.Flags().BoolS("x", "x", false, "export")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/typeset_completer/main.go
+++ b/completers/zsh/typeset_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/typeset_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/ulimit_completer/cmd/root.go
+++ b/completers/zsh/ulimit_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "ulimit",
+	Short: "Set or display resource limits",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-ulimit",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("H", "H", false, "hard limit")
+	rootCmd.Flags().BoolS("S", "S", false, "soft limit")
+	rootCmd.Flags().BoolS("a", "a", false, "all limits")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionValues(),
+	)
+}

--- a/completers/zsh/ulimit_completer/cmd/root.go
+++ b/completers/zsh/ulimit_completer/cmd/root.go
@@ -22,8 +22,4 @@ func init() {
 	rootCmd.Flags().BoolS("H", "H", false, "hard limit")
 	rootCmd.Flags().BoolS("S", "S", false, "soft limit")
 	rootCmd.Flags().BoolS("a", "a", false, "all limits")
-
-	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionValues(),
-	)
 }

--- a/completers/zsh/ulimit_completer/main.go
+++ b/completers/zsh/ulimit_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/ulimit_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/umask_completer/cmd/root.go
+++ b/completers/zsh/umask_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "umask",
+	Short: "Display or set file creation mode mask",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-umask",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("S", "S", false, "symbolic mode")
+
+	carapace.Gen(rootCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"0", "1", "2", "3", "4", "5", "6", "7",
+		).Usage("octal digit"),
+	)
+}

--- a/completers/zsh/umask_completer/main.go
+++ b/completers/zsh/umask_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/umask_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/unalias_completer/cmd/root.go
+++ b/completers/zsh/unalias_completer/cmd/root.go
@@ -23,6 +23,6 @@ func init() {
 	rootCmd.Flags().BoolS("a", "a", false, "remove all aliases")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionAliases(),
+		shell.ActionAliases().FilterArgs(),
 	)
 }

--- a/completers/zsh/unalias_completer/cmd/root.go
+++ b/completers/zsh/unalias_completer/cmd/root.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "unalias",
+	Short: "Remove aliases",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-unalias",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("a", "a", false, "remove all aliases")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionAliases(),
+	)
+}

--- a/completers/zsh/unalias_completer/main.go
+++ b/completers/zsh/unalias_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/unalias_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/unset_completer/cmd/root.go
+++ b/completers/zsh/unset_completer/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "unset",
+	Short: "Unset variables and functions",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-unset",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("f", "f", false, "refer to shell functions")
+	rootCmd.Flags().BoolS("v", "v", false, "refer to shell variables")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionVariables(),
+	)
+}

--- a/completers/zsh/unset_completer/cmd/root.go
+++ b/completers/zsh/unset_completer/cmd/root.go
@@ -24,6 +24,6 @@ func init() {
 	rootCmd.Flags().BoolS("v", "v", false, "refer to shell variables")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionVariables(),
+		shell.ActionVariables().FilterArgs(),
 	)
 }

--- a/completers/zsh/unset_completer/main.go
+++ b/completers/zsh/unset_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/unset_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/wait_completer/cmd/root.go
+++ b/completers/zsh/wait_completer/cmd/root.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/shell"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "wait",
+	Short: "Wait for background jobs to complete",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-wait",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		shell.ActionJobSpecs(),
+	)
+}

--- a/completers/zsh/wait_completer/cmd/root.go
+++ b/completers/zsh/wait_completer/cmd/root.go
@@ -21,6 +21,6 @@ func init() {
 	carapace.Gen(rootCmd).Standalone()
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		shell.ActionJobSpecs(),
+		shell.ActionJobSpecs().FilterArgs(),
 	)
 }

--- a/completers/zsh/wait_completer/main.go
+++ b/completers/zsh/wait_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/wait_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/zsh/whence_completer/cmd/root.go
+++ b/completers/zsh/whence_completer/cmd/root.go
@@ -25,6 +25,6 @@ func init() {
 	rootCmd.Flags().BoolS("w", "w", false, "describe how word would be interpreted")
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionExecutables(),
+		carapace.ActionExecutables().FilterArgs(),
 	)
 }

--- a/completers/zsh/whence_completer/cmd/root.go
+++ b/completers/zsh/whence_completer/cmd/root.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "whence",
+	Short: "Identify command types",
+	Long:  "https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-whence",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().BoolS("c", "c", false, "list all commands matching")
+	rootCmd.Flags().BoolS("f", "f", false, "use functions")
+	rootCmd.Flags().BoolS("v", "v", false, "verbose output")
+	rootCmd.Flags().BoolS("w", "w", false, "describe how word would be interpreted")
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		carapace.ActionExecutables(),
+	)
+}

--- a/completers/zsh/whence_completer/main.go
+++ b/completers/zsh/whence_completer/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/carapace-sh/carapace-bin/completers/zsh/whence_completer/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/completer/completers.go
+++ b/pkg/completer/completers.go
@@ -35,8 +35,22 @@ func (c Completers) Less(i, j int) bool { // TODO this needs testing (and likely
 
 	// TODO shells? more specific stuff
 	groupPriority := map[string]int{
-		"user":   -21, // user specs
-		"system": -20, // system specs
+		"user":   -41, // user specs
+		"system": -40, // system specs
+
+		// CARAPACE_SHELL: -35 (see below)
+
+		"bash":       -30,
+		"bash-ble":   -29,
+		"cmd-clink":  -28,
+		"elvish":     -27,
+		"fish":       -26,
+		"nushell":    -25,
+		"oil":        -24,
+		"powershell": -23,
+		"tcsh":       -22,
+		"xonsh":      -21,
+		"zsh":        -20,
 
 		// runtime.GOOS: -15 (see below)
 
@@ -54,6 +68,21 @@ func (c Completers) Less(i, j int) bool { // TODO this needs testing (and likely
 		"common":  -1,
 		// TODO support pseudo os 'termux'?
 		"bridge": 1, // lower priority than anything internal
+	}
+
+	switch b := os.Getenv("CARAPACE_SHELL"); b { // TODO public access of env in carapace
+	case "bash",
+		"bash-ble",
+		"cmd-clink",
+		"elvish",
+		"fish",
+		"nushell",
+		"oil",
+		"powershell",
+		"tcsh",
+		"xonsh",
+		"zsh":
+		groupPriority[b] = -35
 	}
 
 	// TODO urks - this is getting a bit out of hand. use copy map? needs to still support `force_all` build tag


### PR DESCRIPTION
Add 48 zsh shell builtin completers following the same pattern
as bash builtins. Completions are gated behind CARAPACE_BUILTINS=zsh.

Includes: alias, bg, break, builtin, cd, chdir, command, continue,
dirs, disown, echo, eval, exec, exit, export, fc, fg, getopts, hash,
history, jobs, kill, let, local, logout, popd, print, printf, pushd,
pwd, read, readonly, return, set, setopt, shift, source, test, times,
trap, type, typeset, ulimit, umask, unalias, unset, wait, whence

Assisted-by: Crush:minimax-m2.7
