### PR TITLE
fix: replace sed forks with native shell in completion snippets

### DIFF
--- a/cmd/carapace/cmd/snippet/bash.go
+++ b/cmd/carapace/cmd/snippet/bash.go
@@ -12,10 +12,10 @@ const bashCompleter = `_carapace_completer() {
   export COMP_WORDBREAKS
 
   declare -x CARAPACE_SHELL=bash
-  declare -x CARAPACE_SHELL_ALIASES="$(alias -p | sed 's/alias //;s/=.*//')"
+  declare -x CARAPACE_SHELL_ALIASES="$(compgen -a)"
   declare -x CARAPACE_SHELL_BUILTINS="$(compgen -b)"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(compgen -A function)"
-  declare -x CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | sed -n '/Running\|Stopped/s/^\[\([0-9]*\)\].*/%\1/p')"
+  declare -x CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | while read -r line; do [[ $line =~ \[([0-9]+)\] ]] && echo "%${BASH_REMATCH[1]}"; done)"
   declare -x CARAPACE_SHELL_VARIABLES="$(compgen -v)"
 
   local command="${COMP_WORDS[0]}" nospace data compline="${COMP_LINE:0:${COMP_POINT}}"

--- a/cmd/carapace/cmd/snippet/zsh.go
+++ b/cmd/carapace/cmd/snippet/zsh.go
@@ -20,10 +20,10 @@ function _carapace_completer {
   declare -x CARAPACE_COMPLINE="${words}"
   declare -x CARAPACE_ZSH_HASH_DIRS="$(hash -d)"
   declare -x CARAPACE_SHELL=zsh
-  declare -x CARAPACE_SHELL_ALIASES="$(alias | sed 's/alias //;s/=.*//')"
+  declare -x CARAPACE_SHELL_ALIASES="${(k)aliases}"
   declare -x CARAPACE_SHELL_BUILTINS="$(print -roC1 -- ${(k)builtins})"
   declare -x CARAPACE_SHELL_FUNCTIONS="$(print -l ${(ok)functions})"
-  declare -x CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | sed -n '/running\|suspended\|stopped/s/^\[\([0-9]*\)\].*/%%\1/p')"
+  declare -x CARAPACE_SHELL_JOBS="$(print -l ${${(k)jobtexts}/#/%%%%})"
   declare -x CARAPACE_SHELL_VARIABLES="$(print -l ${(ok)parameters})"
 
   # shellcheck disable=SC2086,SC2154,SC2155
@@ -41,6 +41,7 @@ function _carapace_completer {
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
   [ -z "$message" ] || _message -r "${message}"
+  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
 
   local block tag displays values displaysArr valuesArr
   while IFS=$'\002' read -r -d $'\002' block; do
@@ -51,8 +52,6 @@ function _carapace_completer {
 
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
-
-  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
 }
 
 compdef _carapace_completer %v

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/carapace-sh/carapace-bin
 go 1.26.2
 
 require (
-	github.com/carapace-sh/carapace v1.12.0
+	github.com/carapace-sh/carapace v1.12.1
 	github.com/carapace-sh/carapace-bridge v1.6.0
 	github.com/carapace-sh/carapace-jjlex v0.1.6
 	github.com/carapace-sh/carapace-selfupdate v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/carapace-sh/carapace v1.12.0 h1:Re5zlpn8A8hlF+SLye3oitNTVB7FagBxMJIoEv5Gllw=
-github.com/carapace-sh/carapace v1.12.0/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
+github.com/carapace-sh/carapace v1.12.1 h1:jssqLGr64kMZLC17p1epKkdO1XNvcdbnGEjMntqe7Mo=
+github.com/carapace-sh/carapace v1.12.1/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
 github.com/carapace-sh/carapace-bridge v1.6.0 h1:pZkyCDyZn2ji6eEnskbNdAo6eRaPAmpHHyOuqnqM0gc=
 github.com/carapace-sh/carapace-bridge v1.6.0/go.mod h1:aJxUH5ayDNXBp3DEZSEsbou9Y25uIMzh1fAfdcY55aw=
 github.com/carapace-sh/carapace-jjlex v0.1.6 h1:VJiUVW4fm0ZkHsXOGLLhnRw3cMnBmQLMXMD8WNruTtE=


### PR DESCRIPTION
Eliminates two external process forks per tab press in both bash and zsh
completion snippets: sed piped from alias/jobs was replaced with native
shell builtins (compgen, parameter expansion). This reduces latency for
every completion invocation.

bash: alias -p | sed → compgen -a, jobs | sed → bash regex
zsh: alias | sed → ${(k)aliases}, jobs | sed → ${(k)jobtexts}
