### PR TITLE
feat: add CARAPACE_SHELL environment variables to all shell snippets

### DIFF
--- a/cmd/carapace/cmd/snippet/cmd.go
+++ b/cmd/carapace/cmd/snippet/cmd.go
@@ -11,6 +11,7 @@ local function carapace_completion(command)
     return function(word, word_index, line_state, match_builder)
         match_builder:setnosort()
         match_builder:setvolatile()
+        os.setenv('CARAPACE_SHELL', 'cmd-clink')
         os.setenv('CARAPACE_COMPLINE', line_state:getline():sub(1, line_state:getcursor()))
 
         local file, pclose = io.popenyield(string.format('carapace %%s cmd-clink ""', command))

--- a/cmd/carapace/cmd/snippet/elvish.go
+++ b/cmd/carapace/cmd/snippet/elvish.go
@@ -16,6 +16,9 @@ func Elvish(completers []string) string {
 
 put %v | each {|c|
     set edit:completion:arg-completer[$c] = {|@arg|
+        set E:CARAPACE_SHELL = 'elvish'
+        set E:CARAPACE_SHELL_BUILTINS = (keys $builtin: | to-lines)
+
         carapace $c elvish (all $arg) | from-json | each {|completion|
     		put $completion[Messages] | all (one) | each {|m|
     			edit:notify (styled "error: " red)$m

--- a/cmd/carapace/cmd/snippet/nushell.go
+++ b/cmd/carapace/cmd/snippet/nushell.go
@@ -15,8 +15,10 @@ func Nushell(completers []string) string {
 let carapace_completer = {|spans|
   load-env {
   	CARAPACE_SHELL: 'nushell'
+  	CARAPACE_SHELL_ALIASES: (scope aliases | get name | uniq | str join "\n")
   	CARAPACE_SHELL_BUILTINS: (help commands | where category != "" | get name | each { split row " " | first } | uniq  | str join "\n")
   	CARAPACE_SHELL_FUNCTIONS: (help commands | where category == "" | get name | each { split row " " | first } | uniq  | str join "\n")
+  	CARAPACE_SHELL_VARIABLES: (scope variables | get name | uniq | str join "\n")
   }
 
   # if the current command is an alias, get it's expansion

--- a/cmd/carapace/cmd/snippet/nushell.go
+++ b/cmd/carapace/cmd/snippet/nushell.go
@@ -14,6 +14,7 @@ func Nushell(completers []string) string {
 
 let carapace_completer = {|spans|
   load-env {
+  	CARAPACE_SHELL: 'nushell'
   	CARAPACE_SHELL_BUILTINS: (help commands | where category != "" | get name | each { split row " " | first } | uniq  | str join "\n")
   	CARAPACE_SHELL_FUNCTIONS: (help commands | where category == "" | get name | each { split row " " | first } | uniq  | str join "\n")
   }

--- a/cmd/carapace/cmd/snippet/oil.go
+++ b/cmd/carapace/cmd/snippet/oil.go
@@ -9,20 +9,27 @@ func Oil(completers []string) string {
 	for i, completer := range completers {
 		completers[i] = fmt.Sprintf("%q", completer)
 	}
-	return fmt.Sprintf(`%v%v
+	shellVars := `
+  export CARAPACE_SHELL=oil
+  export CARAPACE_SHELL_ALIASES="$(alias | sed 's/alias //' | sed 's/=.*//')"
+  export CARAPACE_SHELL_BUILTINS="$(compgen -b)"
+  export CARAPACE_SHELL_FUNCTIONS="$(compgen -A function)"
+  export CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | while read -r line; do [[ $line =~ \[([0-9]+)\] ]] && echo "%${BASH_REMATCH[1]}"; done)"
+  export CARAPACE_SHELL_VARIABLES="$(compgen -v)"`
 
-_carapace_completer() {
-  local command="${COMP_WORDS[0]}"
+	completerFunc := strings.Replace(`_carapace_completer() {
+%v  local command="${COMP_WORDS[0]}"
   local compline="${COMP_LINE:0:${COMP_POINT}}"
   local IFS=$'\n'
   mapfile -t COMPREPLY < <(echo "$compline" | sed -e "s/ \$/ ''/" -e 's/"/\"/g' | xargs carapace "${command}" oil)
   [[ "${COMPREPLY[@]}" == "" ]] && COMPREPLY=() # fix for mapfile creating a non-empty array from empty command output
-  [[ ${COMPREPLY[0]} == *[/=@:.,$'\001'] ]] && compopt -o nospace
+  [[ ${COMPREPLY[0]} == *[/=@:.,$'\\x01'] ]] && compopt -o nospace
   # TODO use mapfile
   # shellcheck disable=SC2206
-  [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=(${COMPREPLY[@]%%$'\001'})
+  [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=(${COMPREPLY[@]%%$'\x01'})
 }
 
-complete -F _carapace_completer %v
-`, pathSnippet("oil"), envSnippet("oil"), strings.Join(completers, " "))
+complete -F _carapace_completer %v`, "%v", shellVars, 1)
+
+	return fmt.Sprintf("%v%v\n\n%v %v", pathSnippet("oil"), envSnippet("oil"), completerFunc, strings.Join(completers, " "))
 }

--- a/cmd/carapace/cmd/snippet/oil.go
+++ b/cmd/carapace/cmd/snippet/oil.go
@@ -9,27 +9,27 @@ func Oil(completers []string) string {
 	for i, completer := range completers {
 		completers[i] = fmt.Sprintf("%q", completer)
 	}
-	shellVars := `
+	return fmt.Sprintf(`%v%v
+
+_carapace_completer() {
   export CARAPACE_SHELL=oil
   export CARAPACE_SHELL_ALIASES="$(alias | sed 's/alias //' | sed 's/=.*//')"
   export CARAPACE_SHELL_BUILTINS="$(compgen -b)"
   export CARAPACE_SHELL_FUNCTIONS="$(compgen -A function)"
-  export CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | while read -r line; do [[ $line =~ \[([0-9]+)\] ]] && echo "%${BASH_REMATCH[1]}"; done)"
-  export CARAPACE_SHELL_VARIABLES="$(compgen -v)"`
+  export CARAPACE_SHELL_JOBS="$(jobs 2>/dev/null | while read -r line; do [[ $line =~ \[([0-9]+)\] ]] && echo "%%${BASH_REMATCH[1]}"; done)"
+  export CARAPACE_SHELL_VARIABLES="$(compgen -v)"
 
-	completerFunc := strings.Replace(`_carapace_completer() {
-%v  local command="${COMP_WORDS[0]}"
+  local command="${COMP_WORDS[0]}"
   local compline="${COMP_LINE:0:${COMP_POINT}}"
   local IFS=$'\n'
   mapfile -t COMPREPLY < <(echo "$compline" | sed -e "s/ \$/ ''/" -e 's/"/\"/g' | xargs carapace "${command}" oil)
   [[ "${COMPREPLY[@]}" == "" ]] && COMPREPLY=() # fix for mapfile creating a non-empty array from empty command output
-  [[ ${COMPREPLY[0]} == *[/=@:.,$'\\x01'] ]] && compopt -o nospace
+  [[ ${COMPREPLY[0]} == *[/=@:.,$'\001'] ]] && compopt -o nospace
   # TODO use mapfile
   # shellcheck disable=SC2206
-  [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=(${COMPREPLY[@]%%$'\x01'})
+  [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=(${COMPREPLY[@]%%$'\001'})
 }
 
-complete -F _carapace_completer %v`, "%v", shellVars, 1)
-
-	return fmt.Sprintf("%v%v\n\n%v %v", pathSnippet("oil"), envSnippet("oil"), completerFunc, strings.Join(completers, " "))
+complete -F _carapace_completer %v
+`, pathSnippet("oil"), envSnippet("oil"), strings.Join(completers, " "))
 }

--- a/cmd/carapace/cmd/snippet/powershell.go
+++ b/cmd/carapace/cmd/snippet/powershell.go
@@ -16,6 +16,7 @@ $_carapace_completer = {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingInvokeExpression", "", Scope="Function", Target="*")]
     param($wordToComplete, $commandAst, $cursorPosition)
     $env:CARAPACE_SHELL = "powershell"
+    $env:CARAPACE_SHELL_ALIASES = (Get-Alias | ForEach-Object { $_.Name } | Out-String).TrimEnd()
     $env:CARAPACE_SHELL_BUILTINS = (Get-Command -CommandType Builtin | ForEach-Object { $_.Name } | Out-String).TrimEnd()
     $env:CARAPACE_SHELL_FUNCTIONS = (Get-Command -CommandType Function | ForEach-Object { $_.Name } | Out-String).TrimEnd()
     $env:CARAPACE_SHELL_VARIABLES = (Get-Variable | ForEach-Object { $_.Name } | Out-String).TrimEnd()

--- a/cmd/carapace/cmd/snippet/powershell.go
+++ b/cmd/carapace/cmd/snippet/powershell.go
@@ -15,6 +15,11 @@ using namespace System.Management.Automation.Language
 $_carapace_completer = {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingInvokeExpression", "", Scope="Function", Target="*")]
     param($wordToComplete, $commandAst, $cursorPosition)
+    $env:CARAPACE_SHELL = "powershell"
+    $env:CARAPACE_SHELL_BUILTINS = (Get-Command -CommandType Builtin | ForEach-Object { $_.Name } | Out-String).TrimEnd()
+    $env:CARAPACE_SHELL_FUNCTIONS = (Get-Command -CommandType Function | ForEach-Object { $_.Name } | Out-String).TrimEnd()
+    $env:CARAPACE_SHELL_VARIABLES = (Get-Variable | ForEach-Object { $_.Name } | Out-String).TrimEnd()
+
     $commandElements = $commandAst.CommandElements
 
     # double quoted value works but seems single quoted needs some fixing (e.g. "example 'acti" -> "example acti")

--- a/cmd/carapace/cmd/snippet/tcsh.go
+++ b/cmd/carapace/cmd/snippet/tcsh.go
@@ -6,10 +6,9 @@ import (
 )
 
 func Tcsh(completers []string) string {
-	// TODO hardcoded for now
 	snippet := make([]string, len(completers))
 	for index, c := range completers {
-		snippet[index] = fmt.Sprintf("complete \"%v\" 'p@*@`echo \"$COMMAND_LINE'\"''\"'\" | xargs carapace %v tcsh `@@' ;", c, c)
+		snippet[index] = fmt.Sprintf("complete \"%v\" 'p@*@`echo \\\"${COMMAND_LINE}\\\"''\\\"'\\\" | xargs env CARAPACE_SHELL=tcsh CARAPACE_SHELL_BUILTINS=\\\"$(compgen -b | tr '\\\\n' ' ')\\\" CARAPACE_SHELL_FUNCTIONS=\\\"$(compgen -A function | tr '\\\\n' ' ')\\\" CARAPACE_SHELL_VARIABLES=\\\"$(compgen -v | tr '\\\\n' ' ')\\\" carapace %v tcsh `@@' ;", c, c)
 	}
 	return strings.Join(snippet, "\n")
 }

--- a/cmd/carapace/cmd/snippet/tcsh.go
+++ b/cmd/carapace/cmd/snippet/tcsh.go
@@ -6,9 +6,10 @@ import (
 )
 
 func Tcsh(completers []string) string {
+	// TODO hardcoded for now
 	snippet := make([]string, len(completers))
 	for index, c := range completers {
-		snippet[index] = fmt.Sprintf("complete \"%v\" 'p@*@`echo \\\"${COMMAND_LINE}\\\"''\\\"'\\\" | xargs env CARAPACE_SHELL=tcsh CARAPACE_SHELL_BUILTINS=\\\"$(compgen -b | tr '\\\\n' ' ')\\\" CARAPACE_SHELL_FUNCTIONS=\\\"$(compgen -A function | tr '\\\\n' ' ')\\\" CARAPACE_SHELL_VARIABLES=\\\"$(compgen -v | tr '\\\\n' ' ')\\\" carapace %v tcsh `@@' ;", c, c)
+		snippet[index] = fmt.Sprintf("complete \"%v\" 'p@*@`echo \"$COMMAND_LINE'\"''\"'\" | xargs env CARAPACE_SHELL=tcsh carapace %v tcsh `@@' ;", c, c)
 	}
 	return strings.Join(snippet, "\n")
 }

--- a/cmd/carapace/cmd/snippet/xonsh.go
+++ b/cmd/carapace/cmd/snippet/xonsh.go
@@ -20,6 +20,12 @@ def _carapace_completer(context):
     from json import loads
     from xonsh.completers.tools import sub_proc_get_output, RichCompletion
 
+    os.environ['CARAPACE_SHELL'] = 'xonsh'
+    os.environ['CARAPACE_SHELL_ALIASES'] = '\n'.join(__xonsh__.aliases.keys())
+    os.environ['CARAPACE_SHELL_BUILTINS'] = '\n'.join(__xonsh__.builtins.keys())
+    os.environ['CARAPACE_SHELL_FUNCTIONS'] = '\n'.join(__xonsh__.ctx.functions.keys())
+    os.environ['CARAPACE_SHELL_VARIABLES'] = '\n'.join(__xonsh__.env.keys())
+
     if context.command not in [%v]:
         return
 

--- a/pkg/actions/os/env.go
+++ b/pkg/actions/os/env.go
@@ -27,8 +27,11 @@ func ActionEnvironmentVariables() carapace.Action {
 		return carapace.ActionValuesDescribed(vals...).Filter(
 			"CARAPACE_COMPLINE",
 			"CARAPACE_SHELL",
+			"CARAPACE_SHELL_ALIASES",
 			"CARAPACE_SHELL_BUILTINS",
 			"CARAPACE_SHELL_FUNCTIONS",
+			"CARAPACE_SHELL_JOBS",
+			"CARAPACE_SHELL_VARIABLES",
 		)
 	}).Tag("environment variables")
 }


### PR DESCRIPTION
Adds CARAPACE_SHELL and related variables (BUILTINS, FUNCTIONS, ALIASES,
JOBS, VARIABLES) to shell snippets that were missing them. This ensures
completion functions can identify the shell and access shell-specific
context for better completion results.

Added to: elvish, oil, powershell, tcsh, xonsh, nushell, cmd-clink

Assisted-by: Crush:minimax-m2.7
