### PR TITLE
Add balooctl6 completer

### DIFF
--- a/completers/linux/balooctl6_completer/cmd/check.go
+++ b/completers/linux/balooctl6_completer/cmd/check.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check for any unindexed files and index them",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(checkCmd).Standalone()
+
+	rootCmd.AddCommand(checkCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/clear.go
+++ b/completers/linux/balooctl6_completer/cmd/clear.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var clearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Forget the specified files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(clearCmd).Standalone()
+
+	rootCmd.AddCommand(clearCmd)
+
+	carapace.Gen(clearCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+	carapace.Gen(clearCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/config.go
+++ b/completers/linux/balooctl6_completer/cmd/config.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Modify the Baloo configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(configCmd).Standalone()
+
+	rootCmd.AddCommand(configCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/config_add.go
+++ b/completers/linux/balooctl6_completer/cmd/config_add.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var config_addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a value to a config option",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(config_addCmd).Standalone()
+
+	configCmd.AddCommand(config_addCmd)
+
+	carapace.Gen(config_addCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"includeFolders",
+			"excludeFolders",
+			"excludeFilters",
+			"excludeMimetypes",
+		),
+	)
+	carapace.Gen(config_addCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			switch c.Args[0] {
+			case "includeFolders", "excludeFolders":
+				return carapace.ActionDirectories()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/config_list.go
+++ b/completers/linux/balooctl6_completer/cmd/config_list.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var config_listCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "Show the value of a config option",
+	Aliases: []string{"ls", "show"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(config_listCmd).Standalone()
+
+	configCmd.AddCommand(config_listCmd)
+
+	carapace.Gen(config_listCmd).PositionalAnyCompletion(
+		carapace.ActionValues(
+			"hidden",
+			"contentIndexing",
+			"includeFolders",
+			"excludeFolders",
+			"excludeFilters",
+			"excludeMimetypes",
+		),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/config_rm.go
+++ b/completers/linux/balooctl6_completer/cmd/config_rm.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var config_rmCmd = &cobra.Command{
+	Use:     "rm",
+	Short:   "Remove a value from a config option",
+	Aliases: []string{"remove"},
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(config_rmCmd).Standalone()
+
+	configCmd.AddCommand(config_rmCmd)
+
+	carapace.Gen(config_rmCmd).PositionalCompletion(
+		carapace.ActionValues(
+			"includeFolders",
+			"excludeFolders",
+			"excludeFilters",
+			"excludeMimetypes",
+		),
+	)
+	carapace.Gen(config_rmCmd).PositionalAnyCompletion(
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			switch c.Args[0] {
+			case "includeFolders", "excludeFolders":
+				return carapace.ActionDirectories()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/config_set.go
+++ b/completers/linux/balooctl6_completer/cmd/config_set.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var config_setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set the value of a boolean config option",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(config_setCmd).Standalone()
+
+	configCmd.AddCommand(config_setCmd)
+
+	carapace.Gen(config_setCmd).PositionalCompletion(
+		carapace.ActionValues("hidden", "contentIndexing"),
+		carapace.ActionValues("true", "false", "yes", "no", "y", "n", "1", "0"),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/disable.go
+++ b/completers/linux/balooctl6_completer/cmd/disable.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var disableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(disableCmd).Standalone()
+
+	rootCmd.AddCommand(disableCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/enable.go
+++ b/completers/linux/balooctl6_completer/cmd/enable.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var enableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(enableCmd).Standalone()
+
+	rootCmd.AddCommand(enableCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/failed.go
+++ b/completers/linux/balooctl6_completer/cmd/failed.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var failedCmd = &cobra.Command{
+	Use:   "failed",
+	Short: "Display files which could not be indexed",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(failedCmd).Standalone()
+
+	rootCmd.AddCommand(failedCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/index.go
+++ b/completers/linux/balooctl6_completer/cmd/index.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Index the specified files",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(indexCmd).Standalone()
+
+	rootCmd.AddCommand(indexCmd)
+
+	carapace.Gen(indexCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
+	carapace.Gen(indexCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/indexSize.go
+++ b/completers/linux/balooctl6_completer/cmd/indexSize.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var indexSizeCmd = &cobra.Command{
+	Use:   "indexSize",
+	Short: "Display the disk space used by index",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(indexSizeCmd).Standalone()
+
+	rootCmd.AddCommand(indexSizeCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/monitor.go
+++ b/completers/linux/balooctl6_completer/cmd/monitor.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var monitorCmd = &cobra.Command{
+	Use:   "monitor",
+	Short: "Monitor the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(monitorCmd).Standalone()
+
+	rootCmd.AddCommand(monitorCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/purge.go
+++ b/completers/linux/balooctl6_completer/cmd/purge.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var purgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Remove the index database",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(purgeCmd).Standalone()
+
+	rootCmd.AddCommand(purgeCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/resume.go
+++ b/completers/linux/balooctl6_completer/cmd/resume.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(resumeCmd).Standalone()
+
+	rootCmd.AddCommand(resumeCmd)
+}

--- a/completers/linux/balooctl6_completer/cmd/root.go
+++ b/completers/linux/balooctl6_completer/cmd/root.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "balooctl6",
+	Short: "Command-line interface for the Baloo file indexer",
+	Long:  "https://community.kde.org/Baloo",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.PersistentFlags().StringP("format", "f", "multiline", "Output format <multiline|json|simple>")
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Displays help on commandline options")
+	rootCmd.PersistentFlags().Bool("help-all", false, "Displays help, including generic Qt options")
+	rootCmd.PersistentFlags().String("qmljsdebugger", "", "Activates the QML/JS debugger with a specified port")
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "Displays version information")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"format": carapace.ActionValues("multiline", "json", "simple"),
+	})
+}

--- a/completers/linux/balooctl6_completer/cmd/status.go
+++ b/completers/linux/balooctl6_completer/cmd/status.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Print the status of the indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(statusCmd).Standalone()
+
+	rootCmd.AddCommand(statusCmd)
+
+	carapace.Gen(statusCmd).PositionalAnyCompletion(
+		carapace.ActionFiles(),
+	)
+}

--- a/completers/linux/balooctl6_completer/cmd/suspend.go
+++ b/completers/linux/balooctl6_completer/cmd/suspend.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend",
+	Short: "Suspend the file indexer",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(suspendCmd).Standalone()
+
+	rootCmd.AddCommand(suspendCmd)
+}

--- a/completers/linux/balooctl6_completer/main.go
+++ b/completers/linux/balooctl6_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/linux/balooctl6_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
Adds a shell completer for `balooctl6`, the CLI for KDE's Baloo file indexer (closes #3341).

- All top-level subcommands: `status`, `enable`, `disable`, `purge`, `suspend`, `resume`, `check`, `index`, `clear`, `config`, `monitor`, `indexSize`, `failed` — descriptions taken from upstream's own [`main.cpp`](https://github.com/KDE/baloo/blob/master/src/tools/balooctl/main.cpp)
- `index`/`clear` complete one or more files (required), `status` completes zero or more files (optional) — matching upstream's actual arg requirements
- Nested `config` subcommands (`list`/`ls`/`show`, `add`, `rm`/`remove`, `set`) with key-aware value completion, e.g. `config add includeFolders <TAB>` completes directories, based on reading [`configcommand.cpp`](https://github.com/KDE/baloo/blob/master/src/tools/balooctl/configcommand.cpp)
- Root persistent flags (`--format`, `--help`, `--help-all`, `--qmljsdebugger`, `--version`) matching the `--help-all` output quoted in the issue

## Test plan
- [x] `gofmt -l -s` clean
- [x] `go vet` clean
- [x] `go build -tags force_all ./...` succeeds for the whole repo
- [x] `go generate ./cmd/...` correctly registers `balooctl6` in the completer registry
- [x] `carapace-lint` (alphabetical flag/key ordering) clean
- [x] `go test ./cmd/...` — no new failures (3 pre-existing failures reproduce identically on a clean checkout without this change, confirmed unrelated)
- [x] Manually verified completion output at each command level (top-level, `config`, `config add <key>`, `config set <key>`) against the built binary, cross-checked against known-good completers (`coredumpctl`, `docker network create`) for correct behavior