### PR TITLE
git: ActionHeads - fix error suppression for translations

### DIFF
--- a/pkg/actions/tools/git/head.go
+++ b/pkg/actions/tools/git/head.go
@@ -43,7 +43,7 @@ func ActionHeads() carapace.Action {
 					vals = append(vals, ref, strings.TrimSpace(line))
 				}
 				return carapace.ActionValuesDescribed(vals...).Style(styles.Git.Head)
-			}).Suppress("unknown revision"))
+			}).Suppress(ref)) // suppresses "unknown revision" which gets translated (ref should be included in all translations)
 		}
 		return batch.ToA().Tag("heads").UidF(Uid("ref"))
 	})


### PR DESCRIPTION
fix #3569