### PR TITLE
add completion for git 2.54 config-based hooks (hook.<name>.command/event/enabled)

### DIFF
--- a/completers/common/git_completer/cmd/hook_run.go
+++ b/completers/common/git_completer/cmd/hook_run.go
@@ -24,6 +24,6 @@ func init() {
 	})
 
 	carapace.Gen(hook_runCmd).PositionalCompletion(
-		git.ActionHooks(),
+		git.ActionHookEvents(),
 	)
 }

--- a/pkg/actions/tools/git/config.go
+++ b/pkg/actions/tools/git/config.go
@@ -25,6 +25,7 @@ func ActionConfigs() carapace.Action {
 			replacer := strings.NewReplacer(
 				"*", "<*>",
 				"branch.<name>", "branch.<branch>",
+				"hook.<friendly-name>", "hook.<hook>",
 				"remote.<name>", "remote.<remote>",
 				"submodule.<name>", "submodule.<submodule>",
 			)
@@ -39,6 +40,8 @@ func ActionConfigs() carapace.Action {
 					switch placeholder {
 					case "<branch>":
 						return ActionLocalBranches()
+					case "<hook>":
+						return ActionHookNames()
 					case "<remote>":
 						return ActionRemotes()
 					case "<submodule>":
@@ -902,6 +905,15 @@ func ActionConfigValues(config string) carapace.Action {
 					"trustExitCode": _bool,
 					"wordRegex":     carapace.ActionValues().Usage("word regex"),
 					"xfuncname":     carapace.ActionValues().Usage("extended function name regex"),
+				}[splitted[2]]
+			}
+		case "hook":
+			switch len(splitted) {
+			case 3:
+				return carapace.ActionMap{
+					"command": bridge.ActionCarapaceBin().SplitP(),
+					"enabled": _bool,
+					"event":   ActionHookEvents(),
 				}[splitted[2]]
 			}
 		case "remote":

--- a/pkg/actions/tools/git/hook.go
+++ b/pkg/actions/tools/git/hook.go
@@ -66,9 +66,12 @@ func ActionHookEvents() carapace.Action {
 //	no-leaks
 func ActionHookNames() carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		return carapace.ActionExecCommand("git", "config", "--get-regexp", "^hook\\.", "--name-only")(func(output []byte) carapace.Action {
+		return carapace.ActionExecCommandE("git", "config", "--name-only", "--get-regexp", "^hook\\.")(func(output []byte, err error) carapace.Action {
+			if err != nil {
+				return carapace.ActionValues()
+			}
 			names := make(map[string]bool)
-			for _, line := range strings.Split(string(output), "\n") {
+			for line := range strings.SplitSeq(string(output), "\n") {
 				line = strings.TrimSpace(line)
 				if line == "" {
 					continue

--- a/pkg/actions/tools/git/hook.go
+++ b/pkg/actions/tools/git/hook.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"strings"
+
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace/pkg/traverse"
 )
@@ -56,4 +58,31 @@ func ActionHookEvents() carapace.Action {
 		"p4-pre-submit", "invoked before submit",
 		"post-index-change", "invoked when the index is written in read-cache.c do_write_locked_index",
 	).Tag("hook events").Uid("git", "hook-event")
+}
+
+// ActionHookNames completes configured hook names
+//
+//	linter
+//	no-leaks
+func ActionHookNames() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		return carapace.ActionExecCommand("git", "config", "--get-regexp", "^hook\\.", "--name-only")(func(output []byte) carapace.Action {
+			names := make(map[string]bool)
+			for _, line := range strings.Split(string(output), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				parts := strings.SplitN(line, ".", 3)
+				if len(parts) >= 2 {
+					names[parts[1]] = true
+				}
+			}
+			vals := make([]string, 0, len(names))
+			for name := range names {
+				vals = append(vals, name)
+			}
+			return carapace.ActionValues(vals...).Tag("hook names")
+		})
+	}).UidF(Uid("hook-name"))
 }


### PR DESCRIPTION
Git 2.54 introduced config-based hooks with three new config keys:
- hook.<name>.command — the command to run
- hook.<name>.event — which hook event triggers it
- hook.<name>.enabled — whether the hook is active

Add ActionHookNames to complete configured hook names from git config,
wire the hook.<friendly-name> placeholder in ActionConfigs, and add
value completion for the three new subkeys in ActionConfigValues.

Assisted-by: Crush:glm-5.1
