### PR TITLE
update but completer for v0.20.3

### DIFF
--- a/completers/common/but_completer/cmd/absorb.go
+++ b/completers/common/but_completer/cmd/absorb.go
@@ -7,9 +7,10 @@ import (
 )
 
 var absorbCmd = &cobra.Command{
-	Use:   "absorb",
-	Short: "Amends changes into the appropriate commits where they belong.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "absorb",
+	Short:   "Amends changes into the appropriate commits where they belong.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "editing commits",
 }
 
 func init() {
@@ -17,7 +18,6 @@ func init() {
 
 	absorbCmd.Flags().Bool("dry-run", false, "Show the absorption plan without making any changes")
 	absorbCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	absorbCmd.Flags().BoolP("new", "n", false, "Create new commits, instead of amending existing ones. This is useful when you want to preserve existing commits and add new ones for the absorbed changes")
 	rootCmd.AddCommand(absorbCmd)
 
 	carapace.Gen(absorbCmd).PositionalCompletion(

--- a/completers/common/but_completer/cmd/alias.go
+++ b/completers/common/but_completer/cmd/alias.go
@@ -6,9 +6,10 @@ import (
 )
 
 var aliasCmd = &cobra.Command{
-	Use:   "alias",
-	Short: "Manage command aliases.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "alias",
+	Short:   "Manage command aliases.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/amend.go
+++ b/completers/common/but_completer/cmd/amend.go
@@ -6,9 +6,10 @@ import (
 )
 
 var amendCmd = &cobra.Command{
-	Use:   "amend",
-	Short: "Amend a file change into a specific commit and rebases any dependent commits.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "amend",
+	Short:   "Amend a file change into a specific commit and rebases any dependent commits.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "editing commits",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/apply.go
+++ b/completers/common/but_completer/cmd/apply.go
@@ -7,9 +7,10 @@ import (
 )
 
 var applyCmd = &cobra.Command{
-	Use:   "apply",
-	Short: "Apply a branch to the workspace.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "apply",
+	Short:   "Apply a branch to the workspace.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/branch_delete.go
+++ b/completers/common/but_completer/cmd/branch_delete.go
@@ -15,7 +15,6 @@ var branch_deleteCmd = &cobra.Command{
 func init() {
 	carapace.Gen(branch_deleteCmd).Standalone()
 
-	branch_deleteCmd.Flags().BoolP("force", "f", false, "Force deletion without confirmation")
 	branch_deleteCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	branchCmd.AddCommand(branch_deleteCmd)
 

--- a/completers/common/but_completer/cmd/branch_update.go
+++ b/completers/common/but_completer/cmd/branch_update.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/but"
+	"github.com/spf13/cobra"
+)
+
+var branch_updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update your local branch with the content of its remote counterpart.",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(branch_updateCmd).Standalone()
+
+	branch_updateCmd.Flags().Bool("dry-run", false, "Preview the resulting branch state without persisting changes")
+	branch_updateCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	branch_updateCmd.Flags().BoolP("interactive", "i", false, "Open the generated integration script in an editor")
+	branch_updateCmd.Flags().StringP("strategy", "s", "", "Strategy to use for the integration. If no strategy is specified, we default to pull-rebase")
+	branch_updateCmd.Flags().BoolP("verbose", "v", false, "Show additional dry-run details like the current divergence")
+	branchCmd.AddCommand(branch_updateCmd)
+
+	carapace.Gen(branch_updateCmd).FlagCompletion(carapace.ActionMap{
+		"strategy": carapace.ActionValuesDescribed(
+			"pull-rebase", "Rebuilds the branch picking first the commits on the remote, and then the commits on the local branch",
+			"smart-squash", "Tries to fold matching remote work into related local commits. This is done through matching Change IDs, and falling back to pull-rebase ordering otherwise",
+			"merge", "Keeps your local history and merges the remote tip into it",
+			"pick-remote", "Rebuilds the branch picking only the commits on the remote",
+		),
+	})
+
+	carapace.Gen(branch_updateCmd).PositionalCompletion(
+		but.ActionLocalBranches(),
+	)
+}

--- a/completers/common/but_completer/cmd/clean.go
+++ b/completers/common/but_completer/cmd/clean.go
@@ -6,9 +6,10 @@ import (
 )
 
 var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Remove empty branches from the workspace.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "clean",
+	Short:   "Remove empty branches from the workspace.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/commit.go
+++ b/completers/common/but_completer/cmd/commit.go
@@ -18,6 +18,7 @@ func init() {
 	carapace.Gen(commitCmd).Standalone()
 
 	commitCmd.Flags().StringP("ai", "i", "", "Generate commit message using AI with optional user summary. Use --ai by itself or --ai=\"your instructions\" (equals sign required for value)")
+	commitCmd.Flags().BoolP("all", "a", false, "No-op compatibility flag for git commit -a")
 	commitCmd.Flags().StringSliceP("changes", "p", nil, "Uncommitted file or hunk CLI IDs to include in the commit. Can be specified multiple times or as comma-separated values. If not specified, all uncommitted changes (or changes staged to the target branch) are committed")
 	commitCmd.Flags().BoolP("create", "c", false, "Whether to create a new branch for this commit. If the branch name given matches an existing branch, that branch will be used instead. If no branch name is given, a new branch with a generated name will be created")
 	commitCmd.Flags().Bool("diff", false, "Always show diff inside the editor")

--- a/completers/common/but_completer/cmd/config.go
+++ b/completers/common/but_completer/cmd/config.go
@@ -6,9 +6,10 @@ import (
 )
 
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "View and manage GitButler configuration.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "config",
+	Short:   "View and manage GitButler configuration.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/diff.go
+++ b/completers/common/but_completer/cmd/diff.go
@@ -8,9 +8,10 @@ import (
 )
 
 var diffCmd = &cobra.Command{
-	Use:   "diff",
-	Short: "Displays the diff of changes in the repo.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "diff",
+	Short:   "Displays the diff of changes in the repo.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "inspection",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/discard.go
+++ b/completers/common/but_completer/cmd/discard.go
@@ -8,9 +8,10 @@ import (
 )
 
 var discardCmd = &cobra.Command{
-	Use:   "discard",
-	Short: "Discard uncommitted changes from the worktree.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "discard",
+	Short:   "Discard uncommitted changes from the worktree.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/gui.go
+++ b/completers/common/but_completer/cmd/gui.go
@@ -10,11 +10,17 @@ var guiCmd = &cobra.Command{
 	Short:   "Open the GitButler GUI for the current project.",
 	Aliases: []string{"."},
 	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {
 	carapace.Gen(guiCmd).Standalone()
 
 	guiCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	guiCmd.Flags().BoolP("new-window", "n", false, "Open the project in a new application window")
 	rootCmd.AddCommand(guiCmd)
+
+	carapace.Gen(guiCmd).PositionalCompletion(
+		carapace.ActionFiles(),
+	)
 }

--- a/completers/common/but_completer/cmd/mark.go
+++ b/completers/common/but_completer/cmd/mark.go
@@ -10,7 +10,7 @@ var markCmd = &cobra.Command{
 	Use:     "mark",
 	Short:   "Mark a commit or branch for auto-stage or auto-commit.",
 	Run:     func(cmd *cobra.Command, args []string) {},
-	GroupID: "branching and committing",
+	GroupID: "rules",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/merge.go
+++ b/completers/common/but_completer/cmd/merge.go
@@ -7,9 +7,10 @@ import (
 )
 
 var mergeCmd = &cobra.Command{
-	Use:   "merge",
-	Short: "Merge a branch into your local target branch.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "merge",
+	Short:   "Merge a branch into your local target branch.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/move.go
+++ b/completers/common/but_completer/cmd/move.go
@@ -7,9 +7,10 @@ import (
 )
 
 var moveCmd = &cobra.Command{
-	Use:   "move",
-	Short: "Move a commit or branch to a different location.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "move",
+	Short:   "Move a commit or branch to a different location.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "editing commits",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/oplog_restore.go
+++ b/completers/common/but_completer/cmd/oplog_restore.go
@@ -15,7 +15,6 @@ var oplog_restoreCmd = &cobra.Command{
 func init() {
 	carapace.Gen(oplog_restoreCmd).Standalone()
 
-	oplog_restoreCmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 	oplog_restoreCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	oplogCmd.AddCommand(oplog_restoreCmd)
 

--- a/completers/common/but_completer/cmd/pick.go
+++ b/completers/common/but_completer/cmd/pick.go
@@ -7,9 +7,10 @@ import (
 )
 
 var pickCmd = &cobra.Command{
-	Use:   "pick",
-	Short: "Cherry-pick a commit from an unapplied branch into an applied virtual branch.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "pick",
+	Short:   "Cherry-pick a commit from an unapplied branch into an applied virtual branch.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/pr.go
+++ b/completers/common/but_completer/cmd/pr.go
@@ -10,6 +10,7 @@ var prCmd = &cobra.Command{
 	Short:   "Commands for creating and managing reviews on a forge, e.g. GitHub PRs or GitLab MRs",
 	Aliases: []string{"review", "mr"},
 	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "server interactions",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/pull.go
+++ b/completers/common/but_completer/cmd/pull.go
@@ -6,9 +6,10 @@ import (
 )
 
 var pullCmd = &cobra.Command{
-	Use:   "pull",
-	Short: "Updates all applied branches to be up to date with the target branch.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "pull",
+	Short:   "Updates all applied branches to be up to date with the target branch.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "server interactions",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/redo.go
+++ b/completers/common/but_completer/cmd/redo.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var redoCmd = &cobra.Command{
+	Use:     "redo",
+	Short:   "Redo the last undo.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "operation history",
+}
+
+func init() {
+	carapace.Gen(redoCmd).Standalone()
+
+	redoCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
+	rootCmd.AddCommand(redoCmd)
+}

--- a/completers/common/but_completer/cmd/resolve.go
+++ b/completers/common/but_completer/cmd/resolve.go
@@ -6,9 +6,10 @@ import (
 )
 
 var resolveCmd = &cobra.Command{
-	Use:   "resolve",
-	Short: "Resolve conflicts in a commit.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "resolve",
+	Short:   "Resolve conflicts in a commit.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/reword.go
+++ b/completers/common/but_completer/cmd/reword.go
@@ -7,16 +7,17 @@ import (
 )
 
 var rewordCmd = &cobra.Command{
-	Use:   "reword",
-	Short: "Edit the commit message of the specified commit.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "reword",
+	Short:   "Edit the commit message of the specified commit.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "editing commits",
 }
 
 func init() {
 	carapace.Gen(rewordCmd).Standalone()
 
 	rewordCmd.Flags().Bool("diff", false, "Always show diff inside the editor")
-	rewordCmd.Flags().BoolP("format", "f", false, "Format the existing commit message to 72-char line wrapping without opening an editor")
+	rewordCmd.Flags().BoolP("fix-formatting", "f", false, "Format the existing commit message to 72-char line wrapping without opening an editor")
 	rewordCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	rewordCmd.Flags().StringP("message", "m", "", "The new commit message or branch name. If not provided, opens an editor")
 	rewordCmd.Flags().Bool("no-diff", false, "Never show the diff inside the editor")

--- a/completers/common/but_completer/cmd/root.go
+++ b/completers/common/but_completer/cmd/root.go
@@ -30,22 +30,21 @@ func init() {
 	rootCmd.AddGroup(
 		&cobra.Group{ID: "inspection"},
 		&cobra.Group{ID: "branching and committing"},
-		&cobra.Group{ID: "server interactions"},
 		&cobra.Group{ID: "editing commits"},
 		&cobra.Group{ID: "operation history"},
-		&cobra.Group{ID: "alias"},
+		&cobra.Group{ID: "server interactions"},
+		&cobra.Group{ID: "rules"},
+		&cobra.Group{ID: "other commands"},
 	)
 
 	rootCmd.Flags().StringP("current-dir", "C", "", "Run as if but was started in PATH instead of the current working directory")
-	rootCmd.Flags().StringP("format", "f", "", "Explicitly control how output should be formatted")
+	rootCmd.PersistentFlags().String("format", "", "Explicitly control how output should be formatted")
 	rootCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
-	rootCmd.PersistentFlags().BoolP("json", "j", false, "Whether to use JSON output format")
-	rootCmd.PersistentFlags().Bool("status-after", false, "After a mutation command completes, also output workspace status")
 	rootCmd.Flags().BoolP("version", "V", false, "Print version")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
 		"current-dir": carapace.ActionDirectories(),
-		"format":      carapace.ActionValues("human", "shell", "json", "none"),
+		"format":      carapace.ActionValues("human", "agent", "shell", "json", "none"),
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
@@ -78,7 +77,7 @@ func init() {
 				aliasCmd := &cobra.Command{
 					Use:                key,
 					Short:              strings.TrimSpace(value),
-					GroupID:            "alias",
+					GroupID:            "other commands",
 					DisableFlagParsing: true,
 					Run:                func(cmd *cobra.Command, args []string) {},
 				}

--- a/completers/common/but_completer/cmd/setup.go
+++ b/completers/common/but_completer/cmd/setup.go
@@ -6,9 +6,10 @@ import (
 )
 
 var setupCmd = &cobra.Command{
-	Use:   "setup",
-	Short: "Sets up a GitButler project from a git repository in the current directory.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "setup",
+	Short:   "Sets up a GitButler project from a git repository in the current directory.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/show.go
+++ b/completers/common/but_completer/cmd/show.go
@@ -7,9 +7,10 @@ import (
 )
 
 var showCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Shows detailed information about a commit or branch.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "show",
+	Short:   "Shows detailed information about a commit or branch.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "inspection",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/skill.go
+++ b/completers/common/but_completer/cmd/skill.go
@@ -6,9 +6,10 @@ import (
 )
 
 var skillCmd = &cobra.Command{
-	Use:   "skill",
-	Short: "Manage AI agent skills for GitButler.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "skill",
+	Short:   "Manage AI agent skills for GitButler.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/squash.go
+++ b/completers/common/but_completer/cmd/squash.go
@@ -7,9 +7,10 @@ import (
 )
 
 var squashCmd = &cobra.Command{
-	Use:   "squash",
-	Short: "Squash commits together.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "squash",
+	Short:   "Squash commits together.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "editing commits",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/stage.go
+++ b/completers/common/but_completer/cmd/stage.go
@@ -8,9 +8,10 @@ import (
 )
 
 var stageCmd = &cobra.Command{
-	Use:   "stage",
-	Short: "Stages a file or hunk to a specific branch.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "stage",
+	Short:   "Stages a file or hunk to a specific branch.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/teardown.go
+++ b/completers/common/but_completer/cmd/teardown.go
@@ -2,18 +2,25 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/but"
 	"github.com/spf13/cobra"
 )
 
 var teardownCmd = &cobra.Command{
-	Use:   "teardown",
-	Short: "Exit GitButler mode and return to normal Git workflow.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "teardown",
+	Short:   "Exit GitButler mode and return to normal Git workflow.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {
 	carapace.Gen(teardownCmd).Standalone()
 
+	teardownCmd.Flags().StringP("checkout-to", "c", "", "Explicit override for which local branch to checkout to")
 	teardownCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	rootCmd.AddCommand(teardownCmd)
+
+	carapace.Gen(teardownCmd).FlagCompletion(carapace.ActionMap{
+		"checkout-to": but.ActionLocalBranches(),
+	})
 }

--- a/completers/common/but_completer/cmd/tui.go
+++ b/completers/common/but_completer/cmd/tui.go
@@ -6,9 +6,10 @@ import (
 )
 
 var tuiCmd = &cobra.Command{
-	Use:   "tui",
-	Short: "Show an interactive TUI.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "tui",
+	Short:   "Show an interactive TUI.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/unapply.go
+++ b/completers/common/but_completer/cmd/unapply.go
@@ -7,15 +7,15 @@ import (
 )
 
 var unapplyCmd = &cobra.Command{
-	Use:   "unapply",
-	Short: "Unapply a branch from the workspace.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "unapply",
+	Short:   "Unapply a branch from the workspace.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "branching and committing",
 }
 
 func init() {
 	carapace.Gen(unapplyCmd).Standalone()
 
-	unapplyCmd.Flags().BoolP("force", "f", false, "Force unapply without confirmation")
 	unapplyCmd.Flags().BoolP("help", "h", false, "Print help (see more with '--help')")
 	rootCmd.AddCommand(unapplyCmd)
 

--- a/completers/common/but_completer/cmd/uncommit.go
+++ b/completers/common/but_completer/cmd/uncommit.go
@@ -7,9 +7,10 @@ import (
 )
 
 var uncommitCmd = &cobra.Command{
-	Use:   "uncommit",
-	Short: "Uncommit changes from a commit or file-in-commit to the unstaged area.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "uncommit",
+	Short:   "Uncommit changes from a commit or file-in-commit to the unstaged area.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "editing commits",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/unmark.go
+++ b/completers/common/but_completer/cmd/unmark.go
@@ -9,7 +9,7 @@ var unmarkCmd = &cobra.Command{
 	Use:     "unmark",
 	Short:   "Removes any marks from the workspace",
 	Run:     func(cmd *cobra.Command, args []string) {},
-	GroupID: "branching and committing",
+	GroupID: "rules",
 }
 
 func init() {

--- a/completers/common/but_completer/cmd/update.go
+++ b/completers/common/but_completer/cmd/update.go
@@ -6,9 +6,10 @@ import (
 )
 
 var updateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Manage GitButler CLI and app updates.",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "update",
+	Short:   "Manage GitButler CLI and app updates.",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	GroupID: "other commands",
 }
 
 func init() {

--- a/pkg/actions/tools/but/alias.go
+++ b/pkg/actions/tools/but/alias.go
@@ -29,7 +29,7 @@ type butAliases struct {
 }
 
 func Aliases() (*butAliases, error) {
-	output, err := exec.Command("but", "alias", "list", "--json").Output() // TODO support context?
+	output, err := exec.Command("but", "--format", "json", "alias", "list").Output() // TODO support context?
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/actions/tools/but/branch.go
+++ b/pkg/actions/tools/but/branch.go
@@ -30,7 +30,7 @@ type branchList struct {
 //	branch (branch description)
 //	another (another description)
 func ActionLocalBranches() carapace.Action {
-	return carapace.ActionExecCommand("but", "branch", "list", "--local", "--json")(func(output []byte) carapace.Action {
+	return carapace.ActionExecCommand("but", "--format", "json", "branch", "list", "--local")(func(output []byte) carapace.Action {
 		var list branchList
 		if err := json.Unmarshal(output, &list); err != nil {
 			return carapace.ActionMessage(err.Error())

--- a/pkg/actions/tools/but/oplog.go
+++ b/pkg/actions/tools/but/oplog.go
@@ -75,7 +75,7 @@ func (e entry) style() string {
 //	b59e6ab3fa3d (2025-11-02 18:15:22 CreateCommit)
 //	ba997064b522 (2025-11-02 18:40:58 CreateCommit)
 func ActionOplogEntries() carapace.Action {
-	return carapace.ActionExecCommand("but", "--json", "oplog")(func(output []byte) carapace.Action {
+	return carapace.ActionExecCommand("but", "--format", "json", "oplog")(func(output []byte) carapace.Action {
 		var entries []entry
 		if err := json.Unmarshal(output, &entries); err != nil {
 			return carapace.ActionMessage(err.Error())

--- a/pkg/actions/tools/but/status.go
+++ b/pkg/actions/tools/but/status.go
@@ -64,7 +64,7 @@ type butStatus struct {
 
 func actionStatus(includeCommitted bool, f func(status butStatus) carapace.Action) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		args := []string{"status", "--json"}
+		args := []string{"--format", "json", "status"}
 		if includeCommitted {
 			args = append(args, "-f")
 		}


### PR DESCRIPTION
Add `branch update` and `redo` subcommands, add missing `--new-window`
flag on gui (with $files positional), `--checkout-to` flag on teardown
(with branch completion).

Assisted-by: Crush:glm-5.1
