### PR TITLE
kubeadm: updates from v1.36.2

### DIFF
--- a/completers/common/kubeadm_completer/cmd/config_validate.go
+++ b/completers/common/kubeadm_completer/cmd/config_validate.go
@@ -14,6 +14,7 @@ var config_validateCmd = &cobra.Command{
 func init() {
 	carapace.Gen(config_validateCmd).Standalone()
 
+	config_validateCmd.Flags().Bool("allow-deprecated-api", false, "Allow validation of deprecated APIs.")
 	config_validateCmd.Flags().Bool("allow-experimental-api", false, "Allow validation of experimental, unreleased APIs.")
 	config_validateCmd.Flags().String("config", "", "Path to a kubeadm configuration file.")
 	configCmd.AddCommand(config_validateCmd)

--- a/man/cmd/kubeadm/kubeadm.alpha.yaml
+++ b/man/cmd/kubeadm/kubeadm.alpha.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: alpha
 description: Kubeadm experimental sub-commands
+documentation:
+    command: Preview experimental features made available for gathering community feedback. Currently there are no experimental commands under this group.

--- a/man/cmd/kubeadm/kubeadm.certs.certificate-key.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.certificate-key.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: certificate-key
 description: Generate certificate keys
+documentation:
+    command: Generate a secure random certificate key that can be used with kubeadm init and kubeadm join to enable automatic copying of certificates when joining additional control-plane nodes.

--- a/man/cmd/kubeadm/kubeadm.certs.check-expiration.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.check-expiration.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: check-expiration
 description: Check certificates expiration for a Kubernetes cluster
+documentation:
+    command: Check expiration for the certificates in the local PKI managed by kubeadm. Displays remaining validity for all certificates in the cluster.
 flags:
     --allow-missing-template-keys: If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     --cert-dir=: The path where to save the certificates

--- a/man/cmd/kubeadm/kubeadm.certs.generate-csr.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.generate-csr.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: generate-csr
 description: Generate keys and certificate signing requests
+documentation:
+    command: Generate keys and certificate signing requests (CSRs) for all control-plane certificates and kubeconfig files. Designed for use in External CA Mode — generates CSRs which can be submitted to an external certificate authority for signing.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.admin.conf.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.admin.conf.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: admin.conf
 description: Renew the certificate embedded in the kubeconfig file for the admin to use and for kubeadm itself
+documentation:
+    command: Renew the certificate embedded in the kubeconfig file for the admin to use and for kubeadm itself.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Renew all available certificates
+documentation:
+    command: Renew all available certificates in the cluster. Renewals run unconditionally regardless of expiration date. After renewal, control-plane components must be restarted and renewed certificates re-distributed.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.apiserver-etcd-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.apiserver-etcd-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver-etcd-client
 description: Renew the certificate the apiserver uses to access etcd
+documentation:
+    command: Renew the certificate the API server uses to access etcd.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.apiserver-kubelet-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.apiserver-kubelet-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver-kubelet-client
 description: Renew the certificate for the API server to connect to kubelet
+documentation:
+    command: Renew the certificate for the API server to connect to kubelet.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.apiserver.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.apiserver.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver
 description: Renew the certificate for serving the Kubernetes API
+documentation:
+    command: Renew the certificate for serving the Kubernetes API server.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.controller-manager.conf.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.controller-manager.conf.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: controller-manager.conf
 description: Renew the certificate embedded in the kubeconfig file for the controller manager to use
+documentation:
+    command: Renew the certificate embedded in the kubeconfig file for the controller manager.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.etcd-healthcheck-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.etcd-healthcheck-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-healthcheck-client
 description: Renew the certificate for liveness probes to healthcheck etcd
+documentation:
+    command: Renew the certificate for liveness probes to healthcheck etcd.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.etcd-peer.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.etcd-peer.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-peer
 description: Renew the certificate for etcd nodes to communicate with each other
+documentation:
+    command: Renew the certificate for etcd nodes to communicate with each other.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.etcd-server.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.etcd-server.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-server
 description: Renew the certificate for serving etcd
+documentation:
+    command: Renew the certificate for serving etcd.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.front-proxy-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.front-proxy-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: front-proxy-client
 description: Renew the certificate for the front proxy client
+documentation:
+    command: Renew the certificate for the front proxy client.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.scheduler.conf.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.scheduler.conf.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: scheduler.conf
 description: Renew the certificate embedded in the kubeconfig file for the scheduler manager to use
+documentation:
+    command: Renew the certificate embedded in the kubeconfig file for the scheduler.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.super-admin.conf.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.super-admin.conf.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: super-admin.conf
 description: Renew the certificate embedded in the kubeconfig file for the super-admin
+documentation:
+    command: Renew the certificate embedded in the kubeconfig file for the super-admin.
 flags:
     --cert-dir=: The path where to save the certificates
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.certs.renew.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.renew.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: renew
 description: Renew certificates for a Kubernetes cluster
+documentation:
+    command: Renew certificates for a Kubernetes cluster. Can renew all available certificates or selectively renew individual certificates. Renewals run unconditionally regardless of expiration date. Extra attributes such as SANs are based on the existing files. After renewal, control-plane components must be restarted and renewed certificates re-distributed.

--- a/man/cmd/kubeadm/kubeadm.certs.yaml
+++ b/man/cmd/kubeadm/kubeadm.certs.yaml
@@ -3,3 +3,5 @@ name: certs
 aliases:
     - certificates
 description: Commands related to handling Kubernetes certificates
+documentation:
+    command: Manage Kubernetes certificates. Provides utilities for renewing certificates, generating certificate keys, checking expiration, and generating certificate signing requests for external CA mode.

--- a/man/cmd/kubeadm/kubeadm.completion.yaml
+++ b/man/cmd/kubeadm/kubeadm.completion.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: completion SHELL
 description: Output shell completion code for the specified shell (bash or zsh)
+documentation:
+    command: Output shell completion code for the specified shell (bash or zsh). The shell code must be evaluated to provide interactive completion of kubeadm commands. This can be done by sourcing it from the `.bash_profile`. Requires the bash-completion framework on bash. For zsh, completions are only supported in versions of zsh >= 5.2.

--- a/man/cmd/kubeadm/kubeadm.config.images.list.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.images.list.yaml
@@ -7,6 +7,10 @@ flags:
     -o, --output=: 'Output format. One of: text|json|yaml|kyaml|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.'
 persistentflags:
     --config=: Path to a kubeadm configuration file.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --image-repository=: Choose a container registry to pull control plane images from
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.

--- a/man/cmd/kubeadm/kubeadm.config.images.list.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.images.list.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: list
 description: Print a list of images kubeadm will use. The configuration file is used in case any images or image repositories are customized
+documentation:
+    command: Print a list of images kubeadm will use. The configuration file is used if any images or image repositories are customized.
 flags:
     --allow-missing-template-keys: If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     --show-managed-fields: If true, keep the managedFields when printing objects in JSON or YAML format.

--- a/man/cmd/kubeadm/kubeadm.config.images.pull.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.images.pull.yaml
@@ -4,6 +4,10 @@ description: Pull images used by kubeadm
 persistentflags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --image-repository=: Choose a container registry to pull control plane images from
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.

--- a/man/cmd/kubeadm/kubeadm.config.images.pull.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.images.pull.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: pull
 description: Pull images used by kubeadm
+documentation:
+    command: Pull the images used by kubeadm for the control plane. Useful to pre-pull images before running kubeadm init.
 persistentflags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.config.images.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.images.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: images
 description: Interact with container images used by kubeadm
+documentation:
+    command: Manage the container images used by kubeadm. Provides commands to list and pull the images required for the control plane.

--- a/man/cmd/kubeadm/kubeadm.config.migrate.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.migrate.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: migrate
 description: Read an older version of the kubeadm configuration API types from a file, and output the similar config object for the newer version
+documentation:
+    command: Convert old configuration files using a deprecated API version to a newer, supported API version (kubeadm.k8s.io/v1beta4). Performs the conversion locally in the CLI without touching anything in the cluster.
 flags:
     --allow-experimental-api: Allow migration to experimental, unreleased APIs.
     --new-config=: Path to the resulting equivalent kubeadm config file using the new API version. Optional, if not specified output will be sent to STDOUT.

--- a/man/cmd/kubeadm/kubeadm.config.print.init-defaults.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.print.init-defaults.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: init-defaults
 description: Print default init configuration, that can be used for 'kubeadm init'
+documentation:
+    command: Print default init configuration for kubeadm init. Output can be used as a starting point for a custom configuration file.
 flags:
     --component-configs=*: 'A comma-separated list for component config API objects to print the default values for. Available values: [KubeProxyConfiguration KubeletConfiguration]. If this flag is not set, no component configs will be printed.'

--- a/man/cmd/kubeadm/kubeadm.config.print.join-defaults.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.print.join-defaults.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: join-defaults
 description: Print default join configuration, that can be used for 'kubeadm join'
+documentation:
+    command: Print default join configuration for kubeadm join. Output can be used as a starting point for a custom configuration file.

--- a/man/cmd/kubeadm/kubeadm.config.print.reset-defaults.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.print.reset-defaults.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: reset-defaults
 description: Print default reset configuration, that can be used for 'kubeadm reset'
+documentation:
+    command: Print default reset configuration for kubeadm reset. Output can be used as a starting point for a custom configuration file.

--- a/man/cmd/kubeadm/kubeadm.config.print.upgrade-defaults.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.print.upgrade-defaults.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: upgrade-defaults
 description: Print default upgrade configuration, that can be used for 'kubeadm upgrade'
+documentation:
+    command: Print default upgrade configuration for kubeadm upgrade. Output can be used as a starting point for a custom configuration file.

--- a/man/cmd/kubeadm/kubeadm.config.print.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.print.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: print
 description: Print configuration
+documentation:
+    command: Print default kubeadm configurations for init, join, reset, or upgrade operations.

--- a/man/cmd/kubeadm/kubeadm.config.validate.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.validate.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: validate
 description: Read a file containing the kubeadm configuration API and report any validation problems
+documentation:
+    command: Validate a kubeadm configuration API file and report any warnings and errors. Exit status is zero if no errors, non-zero otherwise.
 flags:
     --allow-deprecated-api: Allow validation of deprecated APIs.
     --allow-experimental-api: Allow validation of experimental, unreleased APIs.

--- a/man/cmd/kubeadm/kubeadm.config.validate.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.validate.yaml
@@ -2,5 +2,6 @@
 name: validate
 description: Read a file containing the kubeadm configuration API and report any validation problems
 flags:
+    --allow-deprecated-api: Allow validation of deprecated APIs.
     --allow-experimental-api: Allow validation of experimental, unreleased APIs.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.config.yaml
+++ b/man/cmd/kubeadm/kubeadm.config.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: config
 description: Manage configuration for a kubeadm cluster persisted in a ConfigMap in the cluster
+documentation:
+    command: Manage the kubeadm configuration that is uploaded to the cluster during kubeadm init (stored in a ConfigMap called kubeadm-config in the kube-system namespace) and read during kubeadm join, kubeadm reset, and kubeadm upgrade.
 persistentflags:
     --kubeconfig=: The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.

--- a/man/cmd/kubeadm/kubeadm.help.yaml
+++ b/man/cmd/kubeadm/kubeadm.help.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: help [command]
 description: Help about any command
+documentation:
+    command: Display help information about kubeadm and its subcommands.

--- a/man/cmd/kubeadm/kubeadm.init.phase.addon.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.addon.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Install all the addons
+documentation:
+    command: Install all addon components (CoreDNS and kube-proxy) via the API server. CoreDNS will not be scheduled until a CNI plugin is installed.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.addon.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.addon.all.yaml
@@ -7,7 +7,11 @@ flags:
     --config=: Path to a kubeadm configuration file.
     --control-plane-endpoint=: Specify a stable IP address or DNS name for the control plane.
     --dry-run: Don't apply any changes; just output what would be done.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --image-repository=: Choose a container registry to pull control plane images from
     --kubeconfig=: The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.

--- a/man/cmd/kubeadm/kubeadm.init.phase.addon.coredns.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.addon.coredns.yaml
@@ -4,7 +4,11 @@ description: Install the CoreDNS addon to a Kubernetes cluster
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Don't apply any changes; just output what would be done.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --image-repository=: Choose a container registry to pull control plane images from
     --kubeconfig=: The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.

--- a/man/cmd/kubeadm/kubeadm.init.phase.addon.coredns.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.addon.coredns.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: coredns
 description: Install the CoreDNS addon to a Kubernetes cluster
+documentation:
+    command: Install the CoreDNS addon to a Kubernetes cluster via the API server. CoreDNS provides DNS-based service discovery. Will not be scheduled until a CNI plugin is installed.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Don't apply any changes; just output what would be done.

--- a/man/cmd/kubeadm/kubeadm.init.phase.addon.kube-proxy.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.addon.kube-proxy.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kube-proxy
 description: Install the kube-proxy addon to a Kubernetes cluster
+documentation:
+    command: Install the kube-proxy addon to a Kubernetes cluster via the API server. Kube-proxy maintains network rules on nodes for service routing.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.addon.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.addon.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: addon
 description: Install required addons for passing conformance tests
+documentation:
+    command: 'Install required addons for passing conformance tests. Deploys CoreDNS and kube-proxy via the API server. Note: although the DNS server is deployed, it will not be scheduled until CNI is installed.'

--- a/man/cmd/kubeadm/kubeadm.init.phase.bootstrap-token.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.bootstrap-token.yaml
@@ -3,6 +3,8 @@ name: bootstrap-token
 aliases:
     - bootstraptoken
 description: Generates bootstrap tokens used to join a node to a cluster
+documentation:
+    command: Generate bootstrap tokens used for establishing bidirectional trust between a node joining the cluster and a control-plane node. Writes the cluster-info ConfigMap, sets up RBAC access rules, and configures auto-approval for new CSR requests.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Don't apply any changes; just output what would be done.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Generate all certificates
+documentation:
+    command: Generate all certificates for the cluster, including CA, API server, etcd, front-proxy, and service account keys. If existing files are present they will not be overwritten.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-cert-extra-sans=*: Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.apiserver-etcd-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.apiserver-etcd-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver-etcd-client
 description: Generate the certificate the apiserver uses to access etcd
+documentation:
+    command: Generate the certificate the API server uses to access etcd.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.apiserver-kubelet-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.apiserver-kubelet-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver-kubelet-client
 description: Generate the certificate for the API server to connect to kubelet
+documentation:
+    command: Generate the certificate for the API server to connect to kubelet.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.apiserver.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.apiserver.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver
 description: Generate the certificate for serving the Kubernetes API
+documentation:
+    command: Generate the certificate for serving the Kubernetes API. Includes SANs for the advertise address, control-plane endpoint, service CIDR, and service DNS domain.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-cert-extra-sans=*: Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.ca.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.ca.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: ca
 description: Generate the self-signed Kubernetes CA to provision identities for other Kubernetes components
+documentation:
+    command: Generate the self-signed Kubernetes CA to provision identities for other Kubernetes components.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-ca.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-ca.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-ca
 description: Generate the self-signed CA to provision identities for etcd
+documentation:
+    command: Generate the self-signed CA to provision identities for etcd.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-healthcheck-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-healthcheck-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-healthcheck-client
 description: Generate the certificate for liveness probes to healthcheck etcd
+documentation:
+    command: Generate the certificate for liveness probes to healthcheck etcd.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-peer.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-peer.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-peer
 description: Generate the certificate for etcd nodes to communicate with each other
+documentation:
+    command: Generate the certificate for etcd nodes to communicate with each other. Default SANs include localhost, 127.0.0.1, and ::1.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-server.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.etcd-server.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-server
 description: Generate the certificate for serving etcd
+documentation:
+    command: Generate the certificate for serving etcd. Default SANs include localhost, 127.0.0.1, and ::1.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.front-proxy-ca.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.front-proxy-ca.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: front-proxy-ca
 description: Generate the self-signed CA to provision identities for front proxy
+documentation:
+    command: Generate the self-signed CA to provision identities for the front proxy.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.front-proxy-client.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.front-proxy-client.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: front-proxy-client
 description: Generate the certificate for the front proxy client
+documentation:
+    command: Generate the certificate for the front proxy client.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.sa.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.sa.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: sa
 description: Generate a private key for signing service account tokens along with its public key
+documentation:
+    command: Generate a private key for signing service account tokens along with its public key.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.certs.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.certs.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: certs
 description: Certificate generation
+documentation:
+    command: Generate all required certificates for the cluster. If existing cert/key files are present in the cert directory, kubeadm skips generation for those and uses the existing files. Users can provide their own CA by placing it in /etc/kubernetes/pki before running.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Generate all static Pod manifest files
+documentation:
+    command: 'Generate all static Pod manifests for the control plane: API server, controller manager, and scheduler.'
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.all.yaml
@@ -10,7 +10,11 @@ flags:
     --control-plane-endpoint=: Specify a stable IP address or DNS name for the control plane.
     --controller-manager-extra-args=&: A set of extra flags to pass to the Controller Manager or override default ones in form of <flagname>=<value>
     --dry-run: Don't apply any changes; just output what would be done.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --image-repository=: Choose a container registry to pull control plane images from
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.
     --patches=: Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd", "kubeletconfiguration", "corednsdeployment". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.apiserver.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.apiserver.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apiserver
 description: Generates the kube-apiserver static Pod manifest
+documentation:
+    command: Generate the kube-apiserver static Pod manifest. Configures the API server with appropriate flags, volumes, and certificates.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.apiserver.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.apiserver.yaml
@@ -9,7 +9,11 @@ flags:
     --config=: Path to a kubeadm configuration file.
     --control-plane-endpoint=: Specify a stable IP address or DNS name for the control plane.
     --dry-run: Don't apply any changes; just output what would be done.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --image-repository=: Choose a container registry to pull control plane images from
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.
     --patches=: Path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd", "kubeletconfiguration", "corednsdeployment". "patchtype" can be one of "strategic", "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.controller-manager.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.controller-manager.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: controller-manager
 description: Generates the kube-controller-manager static Pod manifest
+documentation:
+    command: Generate the kube-controller-manager static Pod manifest. Configures the controller manager with appropriate flags and certificates.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.scheduler.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.scheduler.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: scheduler
 description: Generates the kube-scheduler static Pod manifest
+documentation:
+    command: Generate the kube-scheduler static Pod manifest. Configures the scheduler with appropriate flags and certificates.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.control-plane.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: control-plane
 description: Generate all static Pod manifest files necessary to establish the control plane
+documentation:
+    command: Generate all static Pod manifest files necessary to establish the control plane. Manifests are written to /etc/kubernetes/manifests and the kubelet watches this directory for Pods to create on startup.

--- a/man/cmd/kubeadm/kubeadm.init.phase.etcd.local.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.etcd.local.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: local
 description: Generate the static Pod manifest file for a local, single-node local etcd instance
+documentation:
+    command: Generate the static Pod manifest for a local, single-node etcd instance. Configures etcd with appropriate data directory, peer, and client certificates.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.etcd.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.etcd.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd
 description: Generate static Pod manifest file for local etcd
+documentation:
+    command: Generate the static Pod manifest for a local etcd instance. Only used when external etcd is not provided.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.admin.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.admin.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: admin
 description: Generate a kubeconfig file for the admin to use and for kubeadm itself
+documentation:
+    command: Generate a kubeconfig file for the admin to use and for kubeadm itself. Written to /etc/kubernetes/admin.conf.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Generate all kubeconfig files
+documentation:
+    command: 'Generate all kubeconfig files: admin, super-admin, kubelet, controller-manager, and scheduler.'
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.controller-manager.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.controller-manager.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: controller-manager
 description: Generate a kubeconfig file for the controller manager to use
+documentation:
+    command: Generate a kubeconfig file for the controller manager. Written to /etc/kubernetes/controller-manager.conf.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.kubelet.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.kubelet.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet
 description: Generate a kubeconfig file for the kubelet to use *only* for cluster bootstrapping purposes
+documentation:
+    command: Generate a kubeconfig file for the kubelet to use only for cluster bootstrapping purposes. After the control plane is up, kubelet credentials should be requested from the CSR API.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.scheduler.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.scheduler.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: scheduler
 description: Generate a kubeconfig file for the scheduler to use
+documentation:
+    command: Generate a kubeconfig file for the scheduler. Written to /etc/kubernetes/scheduler.conf.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.super-admin.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.super-admin.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: super-admin
 description: Generate a kubeconfig file for the super-admin
+documentation:
+    command: Generate a kubeconfig file for the super-admin that bypasses RBAC. Written to /etc/kubernetes/super-admin.conf.
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubeconfig.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubeconfig
 description: Generate all kubeconfig files necessary to establish the control plane and the admin kubeconfig file
+documentation:
+    command: Generate all kubeconfig files necessary to establish the control plane and the admin kubeconfig. Files are written to /etc/kubernetes/.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubelet-finalize.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubelet-finalize.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Run all kubelet-finalize phases
+documentation:
+    command: Run all kubelet finalization steps after TLS bootstrap.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubelet-finalize.enable-client-cert-rotation.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubelet-finalize.enable-client-cert-rotation.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: enable-client-cert-rotation
 description: Enable kubelet client certificate rotation
+documentation:
+    command: Enable kubelet client certificate rotation. After TLS bootstrap, the kubelet will automatically request new client certificates before the current one expires.
 flags:
     --cert-dir=: The path where to save and store the certificates.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubelet-finalize.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubelet-finalize.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet-finalize
 description: Updates settings relevant to the kubelet after TLS bootstrap
+documentation:
+    command: Update settings relevant to the kubelet after TLS bootstrap. Currently only supports enabling client certificate rotation.

--- a/man/cmd/kubeadm/kubeadm.init.phase.kubelet-start.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.kubelet-start.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet-start
 description: Write kubelet settings and (re)start the kubelet
+documentation:
+    command: Write a KubeletConfiguration file and an environment file with node-specific kubelet settings, then (re)start the kubelet.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.init.phase.mark-control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.mark-control-plane.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: mark-control-plane
 description: Mark a node as a control-plane
+documentation:
+    command: Mark a node as a control-plane by applying the node-role.kubernetes.io/control-plane label and the node-role.kubernetes.io/control-plane:NoSchedule taint. Ensures no additional workloads are scheduled on the control-plane node.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Don't apply any changes; just output what would be done.

--- a/man/cmd/kubeadm/kubeadm.init.phase.preflight.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.preflight.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: preflight
 description: Run pre-flight checks
+documentation:
+    command: Run pre-flight checks to validate the system state before making changes. Some checks only trigger warnings; others are errors and will cause kubeadm to exit until the problem is corrected or --ignore-preflight-errors is specified.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.init.phase.show-join-command.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.show-join-command.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: show-join-command
 description: Show the join command for control-plane and worker node
+documentation:
+    command: Show the kubeadm join command for control-plane and worker nodes. Displays the commands that can be used to add additional nodes to the cluster.

--- a/man/cmd/kubeadm/kubeadm.init.phase.upload-certs.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.upload-certs.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: upload-certs
 description: Upload certificates to kubeadm-certs
+documentation:
+    command: Upload control-plane certificates to the kubeadm-certs Secret in the cluster. Certificates are encrypted with a 32-byte AES key. By default the certs and encryption key expire after two hours. Used to distribute certs to additional control-plane nodes joining the cluster.
 flags:
     --certificate-key=: Key used to encrypt the control-plane certificates in the kubeadm-certs Secret. The certificate key is a hex encoded string that is an AES key of size 32 bytes.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.init.phase.upload-config.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.upload-config.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Upload all configuration to a config map
+documentation:
+    command: Upload both kubeadm ClusterConfiguration and kubelet configuration to ConfigMaps in the cluster.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.init.phase.upload-config.kubeadm.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.upload-config.kubeadm.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubeadm
 description: Upload the kubeadm ClusterConfiguration to a ConfigMap
+documentation:
+    command: Upload the kubeadm ClusterConfiguration to a ConfigMap called kubeadm-config in the kube-system namespace. Enables correct configuration of system components and seamless upgrades.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.init.phase.upload-config.kubelet.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.upload-config.kubelet.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet
 description: Upload the kubelet component config to a ConfigMap
+documentation:
+    command: Upload the kubelet configuration extracted from the kubeadm InitConfiguration to a kubelet-config ConfigMap in the cluster.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.init.phase.upload-config.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.upload-config.yaml
@@ -3,3 +3,5 @@ name: upload-config
 aliases:
     - uploadconfig
 description: Upload the kubeadm and kubelet configuration to a ConfigMap
+documentation:
+    command: Upload the kubeadm and kubelet configuration to ConfigMaps in the cluster, enabling correct configuration of system components and a seamless user experience when upgrading.

--- a/man/cmd/kubeadm/kubeadm.init.phase.wait-control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.wait-control-plane.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: wait-control-plane
 description: Wait for the control plane to start
+documentation:
+    command: Wait for the control plane to start. Kubeadm waits until the control plane components are up and running before continuing the init sequence.

--- a/man/cmd/kubeadm/kubeadm.init.phase.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.phase.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: phase
 description: Use this command to invoke single phase of the "init" workflow
+documentation:
+    command: Invoke individual phases of the kubeadm init workflow. Each phase can be run separately, allowing selective execution or re-execution of specific init steps.

--- a/man/cmd/kubeadm/kubeadm.init.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: init
 description: Run this command in order to set up the Kubernetes control plane
+documentation:
+    command: 'Initialize a Kubernetes control-plane node. Executes a sequence of phases: preflight checks, certificate generation, kubeconfig file creation, etcd static pod setup, control-plane static pod manifests, kubelet start, upload-config, mark-control-plane, bootstrap-token, addon installation (CoreDNS and kube-proxy), and kubelet finalization. Supports --skip-phases to skip specific phases, --config for configuration file-based init, --upload-certs to temporarily upload control-plane certificates, and --dry-run.'
 flags:
     --apiserver-advertise-address=: The IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: Port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.init.yaml
+++ b/man/cmd/kubeadm/kubeadm.init.yaml
@@ -11,7 +11,11 @@ flags:
     --control-plane-endpoint=: Specify a stable IP address or DNS name for the control plane.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.
     --dry-run: Don't apply any changes; just output what would be done.
-    --feature-gates=: 'A set of key=value pairs that describe feature gates for various features. Options are:'
+    --feature-gates=: |-
+        A set of key=value pairs that describe feature gates for various features. Options are:
+        NodeLocalCRISocket=true|false (default=true)
+        PublicKeysECDSA=true|false (DEPRECATED - default=false)
+        RootlessControlPlane=true|false (ALPHA - default=false)
     --ignore-preflight-errors=*: 'A list of checks whose errors will be shown as warnings. Example: ''IsPrivilegedUser,Swap''. Value ''all'' ignores errors from all checks.'
     --image-repository=: Choose a container registry to pull control plane images from
     --kubernetes-version=: Choose a specific Kubernetes version for the control plane.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-join.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-join.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Join a machine as a control plane instance
+documentation:
+    command: 'Run all control-plane join steps: mark the node as control-plane and wait for the control plane to start.'
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-join.mark-control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-join.mark-control-plane.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: mark-control-plane
 description: Mark a node as a control-plane
+documentation:
+    command: Mark a joined node as a control-plane by applying the node-role.kubernetes.io/control-plane label and the node-role.kubernetes.io/control-plane:NoSchedule taint.
 flags:
     --config=: Path to a kubeadm configuration file.
     --control-plane: Create a new control plane instance on this node

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-join.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-join.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: control-plane-join
 description: Join a machine as a control plane instance
+documentation:
+    command: Join a control-plane node to the cluster. Includes marking the node as control-plane and waiting for the control plane to start.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all [api-server-endpoint]
 description: Prepare the machine for serving a control plane
+documentation:
+    command: 'Run all control-plane preparation steps: download certificates, generate certificates and kubeconfig files, and create the control-plane manifest.'
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: If the node should host a new control plane instance, the port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.certs.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.certs.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: certs [api-server-endpoint]
 description: Generate the certificates for the new control plane components
+documentation:
+    command: Generate the certificates for a new control-plane node joining the cluster. Uses certificates downloaded from the kubeadm-certs Secret.
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.control-plane.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: control-plane
 description: Generate the manifests for the new control plane components
+documentation:
+    command: Generate the static Pod manifest for the control-plane on the joining node.
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: If the node should host a new control plane instance, the port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.download-certs.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.download-certs.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: download-certs [api-server-endpoint]
 description: Download certificates shared among control-plane nodes from the kubeadm-certs Secret
+documentation:
+    command: Download control-plane certificates from the kubeadm-certs Secret in the cluster. Requires --certificate-key to decrypt the certificates.
 flags:
     --certificate-key=: Use this key to decrypt the certificate secrets uploaded by init. The certificate key is a hex encoded string that is an AES key of size 32 bytes.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.kubeconfig.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.kubeconfig.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubeconfig [api-server-endpoint]
 description: Generate the kubeconfig for the new control plane components
+documentation:
+    command: Generate kubeconfig files for the new control-plane node joining the cluster.
 flags:
     --certificate-key=: Use this key to decrypt the certificate secrets uploaded by init. The certificate key is a hex encoded string that is an AES key of size 32 bytes.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.control-plane-prepare.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: control-plane-prepare
 description: Prepare the machine for serving a control plane
+documentation:
+    command: Prepare the machine to join as a control-plane node. Downloads shared certificates, generates certificates and kubeconfig files, and creates static pod manifests for the new control plane.

--- a/man/cmd/kubeadm/kubeadm.join.phase.etcd-join.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.etcd-join.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: etcd-join
 description: Join etcd for control plane nodes
+documentation:
+    command: Add a new local etcd member to the existing etcd cluster. Used when joining an additional control-plane node with stacked etcd.
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.join.phase.kubelet-start.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.kubelet-start.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet-start [api-server-endpoint]
 description: Write kubelet settings, certificates and (re)start the kubelet
+documentation:
+    command: Write kubelet settings, certificates, and (re)start the kubelet on the joining node.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.join.phase.kubelet-wait-bootstrap.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.kubelet-wait-bootstrap.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet-wait-bootstrap
 description: Wait for the kubelet to bootstrap itself
+documentation:
+    command: Wait for the kubelet to bootstrap itself on the joining node. The kubelet performs TLS bootstrap and requests a signed certificate from the control plane.
 flags:
     --config=: Path to a kubeadm configuration file.
     --cri-socket=: Path to the CRI socket to connect. If empty kubeadm will try to auto-detect this value; use this option only if you have more than one CRI installed or if you have non-standard CRI socket.

--- a/man/cmd/kubeadm/kubeadm.join.phase.preflight.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.preflight.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: preflight [api-server-endpoint]
 description: Run join pre-flight checks
+documentation:
+    command: Run join pre-flight checks to validate the system state. Some checks only trigger warnings; others are errors and will cause kubeadm to exit.
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: If the node should host a new control plane instance, the port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.join.phase.wait-control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.wait-control-plane.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: wait-control-plane
 description: Wait for the control plane to start
+documentation:
+    command: Wait for the control plane to start on the joining control-plane node. Monitors the kube-apiserver readiness endpoint.

--- a/man/cmd/kubeadm/kubeadm.join.phase.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.phase.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: phase
 description: Use this command to invoke single phase of the "join" workflow
+documentation:
+    command: Invoke individual phases of the kubeadm join workflow. Each phase can be run separately, allowing selective execution or re-execution of specific join steps.

--- a/man/cmd/kubeadm/kubeadm.join.yaml
+++ b/man/cmd/kubeadm/kubeadm.join.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: join [api-server-endpoint]
 description: Run this on any machine you wish to join an existing cluster
+documentation:
+    command: Initialize a Kubernetes worker or control-plane node and join it to an existing cluster. Establishes bidirectional trust through token-based discovery (node trusts the control plane) and TLS bootstrap (control plane trusts the node). Supports --control-plane to join as an additional control-plane node, --certificate-key to download shared certificates, --skip-phases, and --config.
 flags:
     --apiserver-advertise-address=: If the node should host a new control plane instance, the IP address the API Server will advertise it's listening on. If not set the default network interface will be used.
     --apiserver-bind-port=: If the node should host a new control plane instance, the port for the API Server to bind to.

--- a/man/cmd/kubeadm/kubeadm.kubeconfig.user.yaml
+++ b/man/cmd/kubeadm/kubeadm.kubeconfig.user.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: user
 description: Output a kubeconfig file for an additional user
+documentation:
+    command: Output a kubeconfig file for an additional user. Accepts --client-name for the CN of the client certificate, --org for the O, --token as an alternative authentication mechanism, and --validity-period for the certificate validity duration (default 8760h0m0s = 1 year).
 flags:
     --client-name=!: The name of user. It will be used as the CN if client certificates are created
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.kubeconfig.yaml
+++ b/man/cmd/kubeadm/kubeadm.kubeconfig.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubeconfig
 description: Kubeconfig file utilities
+documentation:
+    command: Manage kubeconfig files for the cluster. Provides utilities for generating kubeconfig files for additional users.

--- a/man/cmd/kubeadm/kubeadm.reset.phase.cleanup-node.yaml
+++ b/man/cmd/kubeadm/kubeadm.reset.phase.cleanup-node.yaml
@@ -3,6 +3,8 @@ name: cleanup-node
 aliases:
     - cleanupnode
 description: Run cleanup node.
+documentation:
+    command: Clean up the node local file system from files created by kubeadm init or kubeadm join. Removes certificates, kubeconfig files, and static pod manifests.
 flags:
     --cert-dir=: The path to the directory where the certificates are stored. If specified, clean this directory.
     --cleanup-tmp-dir: Cleanup the "/etc/kubernetes/tmp" directory

--- a/man/cmd/kubeadm/kubeadm.reset.phase.preflight.yaml
+++ b/man/cmd/kubeadm/kubeadm.reset.phase.preflight.yaml
@@ -3,6 +3,8 @@ name: preflight
 aliases:
     - pre-flight
 description: Run reset pre-flight checks
+documentation:
+    command: Run reset pre-flight checks to validate the system state before performing the reset.
 flags:
     --dry-run: Don't apply any changes; just output what would be done.
     --ignore-preflight-errors=*: 'A list of checks whose errors will be shown as warnings. Example: ''IsPrivilegedUser,Swap''. Value ''all'' ignores errors from all checks.'

--- a/man/cmd/kubeadm/kubeadm.reset.phase.remove-etcd-member.yaml
+++ b/man/cmd/kubeadm/kubeadm.reset.phase.remove-etcd-member.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: remove-etcd-member
 description: Remove a local etcd member.
+documentation:
+    command: Remove a local etcd member from the etcd cluster. Only applicable for control-plane nodes using stacked etcd.
 flags:
     --dry-run: Don't apply any changes; just output what would be done.
     --kubeconfig=: The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.

--- a/man/cmd/kubeadm/kubeadm.reset.phase.yaml
+++ b/man/cmd/kubeadm/kubeadm.reset.phase.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: phase
 description: Use this command to invoke single phase of the "reset" workflow
+documentation:
+    command: Invoke individual phases of the kubeadm reset workflow. Each phase can be run separately.

--- a/man/cmd/kubeadm/kubeadm.reset.yaml
+++ b/man/cmd/kubeadm/kubeadm.reset.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: reset
 description: Performs a best effort revert of changes made to this host by 'kubeadm init' or 'kubeadm join'
+documentation:
+    command: Revert changes made to this host by kubeadm init or kubeadm join. Cleans up the local file system. For control-plane nodes, also removes the local stacked etcd member. Does not delete etcd data with external etcd, clean CNI config in /etc/cni/net.d, clean iptables/nftables/IPVS rules, or remove /home/rsteube/.kube.
 flags:
     --cert-dir=: The path to the directory where the certificates are stored. If specified, clean this directory.
     --cleanup-tmp-dir: Cleanup the "/etc/kubernetes/tmp" directory

--- a/man/cmd/kubeadm/kubeadm.token.create.yaml
+++ b/man/cmd/kubeadm/kubeadm.token.create.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: create [token]
 description: Create bootstrap tokens on the server
+documentation:
+    command: Create a bootstrap token on the server. Token format is [a-z0-9]{6}.[a-z0-9]{16}. If no token is given, kubeadm generates a random one. Supports --ttl (default 24h), --print-join-command to output the full kubeadm join command, and --usages to specify token use cases.
 flags:
     --certificate-key=: When used together with '--print-join-command', print the full 'kubeadm join' flag needed to join the cluster as a control-plane. To create a new certificate key you must use 'kubeadm init phase upload-certs --upload-certs'.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.token.delete.yaml
+++ b/man/cmd/kubeadm/kubeadm.token.delete.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: delete [token-value] ...
 description: Delete bootstrap tokens on the server
+documentation:
+    command: Delete bootstrap tokens from the server. Accepts the full token string or just the token ID.

--- a/man/cmd/kubeadm/kubeadm.token.generate.yaml
+++ b/man/cmd/kubeadm/kubeadm.token.generate.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: generate
 description: Generate and print a bootstrap token, but do not create it on the server
+documentation:
+    command: Generate and print a random bootstrap token but do not create it on the server. For convenience only — users can provide their own token in the correct format.

--- a/man/cmd/kubeadm/kubeadm.token.list.yaml
+++ b/man/cmd/kubeadm/kubeadm.token.list.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: list
 description: List bootstrap tokens on the server
+documentation:
+    command: List all bootstrap tokens on the server. Supports various output formats (text, json, yaml, etc.).
 flags:
     --allow-missing-template-keys: If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.
     --show-managed-fields: If true, keep the managedFields when printing objects in JSON or YAML format.

--- a/man/cmd/kubeadm/kubeadm.token.yaml
+++ b/man/cmd/kubeadm/kubeadm.token.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: token
 description: Manage bootstrap tokens
+documentation:
+    command: Manage bootstrap tokens used for establishing bidirectional trust between a joining node and the control-plane node. Kubeadm init creates an initial token with a 24-hour TTL. Token format is [a-z0-9]{6}.[a-z0-9]{16}.
 persistentflags:
     --dry-run: Whether to enable dry-run mode or not
     --kubeconfig=: The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Upgrade all the addons
+documentation:
+    command: Upgrade all addon components (CoreDNS and kube-proxy) during the upgrade apply process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.coredns.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.coredns.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: coredns
 description: Upgrade the CoreDNS addon
+documentation:
+    command: Upgrade the CoreDNS addon during the upgrade apply process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.kube-proxy.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.kube-proxy.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kube-proxy
 description: Upgrade the kube-proxy addon
+documentation:
+    command: Upgrade the kube-proxy addon during the upgrade apply process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.addon.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: addon
 description: Upgrade the default kubeadm addons
+documentation:
+    command: Upgrade addon components (CoreDNS and kube-proxy) during the upgrade apply process.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.bootstrap-token.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.bootstrap-token.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: bootstrap-token
 description: Configures bootstrap token and cluster-info RBAC rules
+documentation:
+    command: Configure bootstrap tokens during the upgrade apply process. Ensures tokens are properly set up for joining new nodes after the upgrade.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.control-plane.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: control-plane
 description: Upgrade the control plane
+documentation:
+    command: Upgrade the control-plane static pod manifests to the new Kubernetes version during the upgrade apply process.
 flags:
     --certificate-renewal: Perform the renewal of certificates used by component changed during upgrades.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.kubelet-config.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.kubelet-config.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet-config
 description: Upgrade the kubelet configuration for this node
+documentation:
+    command: Update the kubelet configuration to the new version during the upgrade apply process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.post-upgrade.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.post-upgrade.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: post-upgrade
 description: Run post upgrade tasks
+documentation:
+    command: Run post-upgrade tasks after the control-plane has been upgraded.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.preflight.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.preflight.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: preflight
 description: Run preflight checks before upgrade
+documentation:
+    command: Run upgrade pre-flight checks to validate that the cluster can be upgraded. Checks version skew policies and verifies the cluster is in a healthy state.
 flags:
     --allow-experimental-upgrades: Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.
     --allow-release-candidate-upgrades: Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Upload all the configurations to ConfigMaps
+documentation:
+    command: Upload both kubeadm ClusterConfiguration and kubelet configuration to ConfigMaps after the control-plane upgrade.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.kubeadm.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.kubeadm.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubeadm
 description: Upload the kubeadm ClusterConfiguration to a ConfigMap
+documentation:
+    command: Upload the updated kubeadm ClusterConfiguration to the kubeadm-config ConfigMap after the control-plane upgrade.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.kubelet.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.kubelet.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet
 description: Upload the kubelet configuration to a ConfigMap
+documentation:
+    command: Upload the updated kubelet configuration to the kubelet-config ConfigMap after the control-plane upgrade.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output what actions would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.upload-config.yaml
@@ -3,3 +3,5 @@ name: upload-config
 aliases:
     - uploadconfig
 description: Upload the kubeadm and kubelet configurations to ConfigMaps
+documentation:
+    command: Upload the updated kubeadm and kubelet configuration to ConfigMaps after the control-plane upgrade.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.phase.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: phase
 description: Use this command to invoke single phase of the "apply" workflow
+documentation:
+    command: Invoke individual phases of the kubeadm upgrade apply workflow. Each phase can be run separately.

--- a/man/cmd/kubeadm/kubeadm.upgrade.apply.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.apply.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: apply [version]
 description: Upgrade your Kubernetes cluster to the specified version
+documentation:
+    command: 'Upgrade the Kubernetes control-plane node to the specified version. Runs phases: preflight, control-plane, upload-config, kubelet-config, bootstrap-token, addon, and post-upgrade. Supports --force for non-interactive mode, --certificate-renewal (default true), --etcd-upgrade (default true), and --yes to skip confirmation.'
 flags:
     --allow-experimental-upgrades: Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.
     --allow-release-candidate-upgrades: Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.

--- a/man/cmd/kubeadm/kubeadm.upgrade.diff.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.diff.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: diff [version]
 description: 'Show what differences would be applied to existing static pod manifests. See also: kubeadm upgrade apply --dry-run'
+documentation:
+    command: Show differences that would be applied to existing static pod manifests during an upgrade. Useful for reviewing changes before running the actual upgrade.
 flags:
     --config=: Path to a kubeadm configuration file.
     --kubeconfig=: The kubeconfig file to use when talking to the cluster. If the flag is not set, a set of standard locations can be searched for an existing kubeconfig file.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.all.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.all.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: all
 description: Upgrade all the addons
+documentation:
+    command: Upgrade all addon components (CoreDNS and kube-proxy) on the node during the upgrade node process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output the actions that would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.coredns.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.coredns.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: coredns
 description: Upgrade the CoreDNS addon
+documentation:
+    command: Upgrade the CoreDNS addon on the node during the upgrade node process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output the actions that would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.kube-proxy.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.kube-proxy.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kube-proxy
 description: Upgrade the kube-proxy addon
+documentation:
+    command: Upgrade the kube-proxy addon on the node during the upgrade node process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output the actions that would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.addon.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: addon
 description: Upgrade the default kubeadm addons
+documentation:
+    command: Upgrade addon components on the node during the upgrade node process.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.control-plane.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.control-plane.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: control-plane
 description: Upgrade the control plane instance deployed on this node, if any
+documentation:
+    command: Upgrade the control-plane static pod manifests on this node during the upgrade node process. Only applicable for additional control-plane nodes.
 flags:
     --certificate-renewal: Perform the renewal of certificates used by component changed during upgrades.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.kubelet-config.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.kubelet-config.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubelet-config
 description: Upgrade the kubelet configuration for this node
+documentation:
+    command: Update the kubelet configuration on this node during the upgrade node process.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output the actions that would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.post-upgrade.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.post-upgrade.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: post-upgrade
 description: Run post upgrade tasks
+documentation:
+    command: Run post-upgrade tasks on the node after the upgrade.
 flags:
     --config=: Path to a kubeadm configuration file.
     --dry-run: Do not change any state, just output the actions that would be performed.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.preflight.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.preflight.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: preflight
 description: Run upgrade node pre-flight checks
+documentation:
+    command: Run upgrade pre-flight checks on the node to validate that it can be upgraded.
 flags:
     --config=: Path to a kubeadm configuration file.
     --ignore-preflight-errors=*: 'A list of checks whose errors will be shown as warnings. Example: ''IsPrivilegedUser,Swap''. Value ''all'' ignores errors from all checks.'

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.phase.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.phase.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: phase
 description: Use this command to invoke single phase of the "node" workflow
+documentation:
+    command: Invoke individual phases of the kubeadm upgrade node workflow. Each phase can be run separately.

--- a/man/cmd/kubeadm/kubeadm.upgrade.node.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.node.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: node
 description: Upgrade commands for a node in the cluster
+documentation:
+    command: 'Upgrade a node (worker or additional control-plane) in the cluster. Runs phases: preflight, control-plane (if present), kubelet-config, addon, and post-upgrade. Automatically renews certificates by default (opt-out with --certificate-renewal=false).'
 flags:
     --certificate-renewal: Perform the renewal of certificates used by component changed during upgrades.
     --config=: Path to a kubeadm configuration file.

--- a/man/cmd/kubeadm/kubeadm.upgrade.plan.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.plan.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: plan [version] [flags]
 description: Check which versions are available to upgrade to and validate whether your current cluster is upgradeable.
+documentation:
+    command: Check which versions are available to upgrade to and validate whether the current cluster is upgradeable. Can only run on control-plane nodes with admin.conf.
 flags:
     --allow-experimental-upgrades: Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.
     --allow-missing-template-keys: If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.

--- a/man/cmd/kubeadm/kubeadm.upgrade.yaml
+++ b/man/cmd/kubeadm/kubeadm.upgrade.yaml
@@ -1,3 +1,5 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: upgrade
 description: Upgrade your cluster smoothly to a newer version with this command
+documentation:
+    command: Upgrade a Kubernetes cluster to a new version. Provides commands to plan an upgrade, apply it, and upgrade individual nodes. Since v1.15.0, kubeadm upgrade apply and kubeadm upgrade node also automatically renew kubeadm-managed certificates (opt-out with --certificate-renewal=false).

--- a/man/cmd/kubeadm/kubeadm.version.yaml
+++ b/man/cmd/kubeadm/kubeadm.version.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: version
 description: Print the version of kubeadm
+documentation:
+    command: Print the version of kubeadm. Supports --output flag with options yaml, json, and short.
 flags:
     -o, --output=: Output format; available options are 'yaml', 'json' and 'short'

--- a/man/cmd/kubeadm/kubeadm.yaml
+++ b/man/cmd/kubeadm/kubeadm.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: kubeadm
 description: 'kubeadm: easily bootstrap a secure Kubernetes cluster'
+documentation:
+    command: Bootstrap a secure Kubernetes cluster using best-practice fast paths. Provides `kubeadm init` to initialize a control-plane node and `kubeadm join` to join worker or additional control-plane nodes to the cluster. By design, kubeadm only handles bootstrapping — not machine provisioning or addon installation. Higher-level tooling is expected to build on top of kubeadm for conformant cluster deployments.
 persistentflags:
     --rootfs=: The path to the 'real' host root filesystem. This will cause kubeadm to chroot into the provided path.
     --vmodule=: comma-separated list of pattern=N settings for file-filtered logging

--- a/pkg/actions/tools/kubeadm/feature.go
+++ b/pkg/actions/tools/kubeadm/feature.go
@@ -7,18 +7,17 @@ import (
 
 // ActionFeatureGates completes feature gates
 //
-//	ControlPlaneKubeletLocalMode=true
-//	NodeLocalCRISocket=false
+//	NodeLocalCRISocket=true
+//	PublicKeysECDSA=false
+//	RootlessControlPlane=false
 func ActionFeatureGates() carapace.Action {
 	return carapace.ActionMultiPartsN("=", 2, func(c carapace.Context) carapace.Action {
 		switch len(c.Parts) {
 		case 0:
-			return carapace.ActionValues(
-				"ControlPlaneKubeletLocalMode",
-				"NodeLocalCRISocket",
-				"PublicKeysECDSA",
-				"RootlessControlPlane",
-				"WaitForAllControlPlaneComponents",
+			return carapace.ActionValuesDescribed(
+				"NodeLocalCRISocket", "default=true",
+				"PublicKeysECDSA", "DEPRECATED - default=false",
+				"RootlessControlPlane", "ALPHA - default=false",
 			).Suffix("=")
 		default:
 			return carapace.ActionValues("true", "false").StyleF(style.ForKeyword)


### PR DESCRIPTION
- Add --allow-deprecated-api flag to config validate
- Update ActionFeatureGates to current v1.36.2 feature gates
- Update man docs with expanded feature-gates descriptions

Assisted-by: Crush:glm-5.1
