### PR TITLE
fix: windows compilation

### DIFF
--- a/cmd/carapace/main.go
+++ b/cmd/carapace/main.go
@@ -10,10 +10,9 @@ import (
 var commit, date string
 var version = "develop"
 
-//go:generate go build -o ../carapace-generate/carapace-generate ../carapace-generate
-//go:generate ../carapace-generate/carapace-generate generate-all ../../completers
-//go:generate ../carapace-generate/carapace-generate macros --code github.com/carapace-sh/carapace-bin/pkg/actions github.com/carapace-sh/carapace-bridge/pkg/actions github.com/carapace-sh/carapace-jjlex/pkg/actions --output ../../pkg/actions/actions_generated.go
-//go:generate ../carapace-generate/carapace-generate conditions ../../pkg/conditions --output ../../pkg/conditions/conditions_generated.go
+//go:generate go run ../carapace-generate generate-all ../../completers
+//go:generate go run ../carapace-generate macros --code github.com/carapace-sh/carapace-bin/pkg/actions github.com/carapace-sh/carapace-bridge/pkg/actions github.com/carapace-sh/carapace-jjlex/pkg/actions --output ../../pkg/actions/actions_generated.go
+//go:generate go run ../carapace-generate conditions ../../pkg/conditions --output ../../pkg/conditions/conditions_generated.go
 func main() {
 	if strings.Contains(version, "SNAPSHOT") {
 		version += fmt.Sprintf(" (%v) [%v]", date, commit)


### PR DESCRIPTION
With the latest release Windows compilation broke when building on a Windows machine rather than cross-compiling like CI does here (mostly because of the `.exe` extension). This should fix it.
