### PR TITLE
fix: use int64 for block device sizes to fix 32-bit build

### DIFF
--- a/pkg/actions/fs/blockdevice-diskutil.go
+++ b/pkg/actions/fs/blockdevice-diskutil.go
@@ -13,13 +13,13 @@ type blockdevicesDiskutil struct {
 	AllDisksAndPartitions []struct {
 		DeviceIdentifier string `plist:"DeviceIdentifier"`
 		Content          string `plist:"Content"`
-		Size             int    `plist:"Size"`
+		Size             int64  `plist:"Size"`
 		APFSVolumes      []struct {
 			DeviceIdentifier string `plist:"DeviceIdentifier"`
 			DiskUUID         string `plist:"DiskUUID"`
 			VolumeName       string `plist:"VolumeName"`
 			VolumeUUID       string `plist:"VolumeUUID"`
-			Size             int    `plist:"Size"`
+			Size             int64  `plist:"Size"`
 		} `plist:"APFSVolumes"`
 		Partitions []struct {
 			DeviceIdentifier string `plist:"DeviceIdentifier"`
@@ -27,17 +27,17 @@ type blockdevicesDiskutil struct {
 			DiskUUID         string `plist:"DiskUUID"`
 			VolumeName       string `plist:"VolumeName"`
 			VolumeUUID       string `plist:"VolumeUUID"`
-			Size             int    `plist:"Size"`
+			Size             int64  `plist:"Size"`
 		} `plist:"Partitions"`
 	} `plist:"AllDisksAndPartitions"`
 }
 
-func formatBlockSize(bytes int) string {
+func formatBlockSize(bytes int64) string {
 	const (
-		kiB = 1024
-		miB = kiB * 1024
-		giB = miB * 1024
-		tiB = giB * 1024
+		kiB int64 = 1024
+		miB       = kiB * 1024
+		giB       = miB * 1024
+		tiB       = giB * 1024
 	)
 	switch {
 	case bytes >= tiB:

--- a/pkg/actions/fs/blockdevice-diskutil_test.go
+++ b/pkg/actions/fs/blockdevice-diskutil_test.go
@@ -38,7 +38,7 @@ func TestBlockDevicesDiskutil(t *testing.T) {
 
 func TestFormatBlockSize(t *testing.T) {
 	tests := []struct {
-		bytes    int
+		bytes    int64
 		expected string
 	}{
 		{500, "500B"},


### PR DESCRIPTION
Disk sizes can exceed the max int32 on 32-bit targets (linux_386),
causing a compile-time overflow. Widen the Size fields and
formatBlockSize to int64 so the release builds for linux_386_sse2.

Assisted-by: Crush:glm-5.2
