### PR TITLE
Add man documentation for git config keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/carapace-sh/carapace-bin
 go 1.26.2
 
 require (
-	github.com/carapace-sh/carapace v1.13.0
+	github.com/carapace-sh/carapace v1.13.1
 	github.com/carapace-sh/carapace-bridge v1.6.1
 	github.com/carapace-sh/carapace-jjlex v0.1.8
 	github.com/carapace-sh/carapace-selfupdate v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/carapace-sh/carapace v1.13.0 h1:n7+47a9QbWP04TSFgnECZVd915BCOAFvaVyn9u6s8oI=
-github.com/carapace-sh/carapace v1.13.0/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
+github.com/carapace-sh/carapace v1.13.1 h1:37ZezQHuY4BgYfOtznw/ZJYGLnnj+5D7jS/ocyrqZBc=
+github.com/carapace-sh/carapace v1.13.1/go.mod h1:5MUSHyLN9GGb5/NY/j9VI68/TcZV4ApRCAHGg4WeU0s=
 github.com/carapace-sh/carapace-bridge v1.6.1 h1:fREPrzvS9hjknZ5MSK3gr1UXWJWqe8r5W5IOJv6GHS4=
 github.com/carapace-sh/carapace-bridge v1.6.1/go.mod h1:HaR3xwZfZN++Ry+Z3XFhuc+lcvh4wrktAdxE40LtFSQ=
 github.com/carapace-sh/carapace-jjlex v0.1.8 h1:+Pip1sOri76w4cBGVcMv+tLWzK24696rATlW9i5M7Z4=

--- a/man/git/config/config.yaml
+++ b/man/git/config/config.yaml
@@ -1,0 +1,3530 @@
+advice.*: |
+  These variables control various optional help messages designed to aid new users. When left
+  unconfigured, Git will give the message alongside instructions on how to squelch it. You can tell
+  Git that you have understood the issue and no longer need a specific help message by setting the
+  corresponding variable to `false`.
+
+alias.*.command: |
+  Command aliases for the `git(1)` command wrapper. Aliases can be defined using two syntaxes:
+
+am.keepcr: |
+  If true, `git-am(1)` will call `git-mailsplit(1)` for patches in mbox format with parameter
+  `--keep-cr`. In this case `git-mailsplit(1)` will not remove `\r` from lines ending with `\r\n`.
+  Can be overridden by giving `--no-keep-cr` from the command line.
+
+am.messageId: |
+  Add a `Message-ID` trailer based on the email header to the commit when using `git-am(1)` (see
+  `git-interpret-trailers(1)`). See also the `--message-id` and `--no-message-id` options.
+
+am.threeWay: |
+  By default, `git-am(1)` will fail if the patch does not apply cleanly. When set to true, this
+  setting tells `git-am(1)` to fall back on 3-way merge if the patch records the identity of blobs
+  it is supposed to apply to and we have those blobs available locally (equivalent to giving the
+  `--3way` option from the command line). Defaults to `false`.
+
+apply.ignoreWhitespace: |
+  When set to `change`, tells `git apply` to ignore changes in whitespace, in the same way as the
+  `--ignore-space-change` option. When set to one of: `no`, `none`, `never`, `false`, it tells `git
+  apply` to respect all whitespace differences.
+
+apply.whitespace: |
+  Tells `git apply` how to handle whitespace, in the same way as the `--whitespace` option.
+
+attr.tree: |
+  A reference to a tree in the repository from which to read attributes, instead of the
+  `.gitattributes` file in the working tree. If the value does not resolve to a valid tree object,
+  an empty tree is used instead. When the `GIT_ATTR_SOURCE` environment variable or `--attr-source`
+  command line option are used, this configuration variable has no effect.
+
+bitmapPseudoMerge.<name>.decay: |
+  Determines the rate at which consecutive pseudo-merge bitmap groups decrease in size. Must be non-
+  negative. This parameter can be thought of as `k` in the function `f(n) = C * n^-k`, where `f(n)`
+  is the size of the `n`th group.
+
+bitmapPseudoMerge.<name>.maxMerges: |
+  Determines the maximum number of pseudo-merge commits among which commits may be distributed.
+
+bitmapPseudoMerge.<name>.pattern: |
+  Regular expression used to match reference names. Commits pointed to by references matching this
+  pattern (and meeting the below criteria, like `bitmapPseudoMerge.<name>.sampleRate` and
+  `bitmapPseudoMerge.<name>.threshold`) will be considered for inclusion in a pseudo-merge bitmap.
+
+bitmapPseudoMerge.<name>.sampleRate: |
+  Determines the proportion of non-bitmapped commits (among reference tips) which are selected for
+  inclusion in an unstable pseudo-merge bitmap. Must be greater than `0` and less than or equal to
+  `1`. The default is `1`.
+
+bitmapPseudoMerge.<name>.stableSize: |
+  Determines the size (in number of commits) of a stable psuedo-merge bitmap. The default is `512`.
+
+bitmapPseudoMerge.<name>.stableThreshold: |
+  Determines the minimum age of commits (among reference tips, as above, however stable commits are
+  still considered candidates even when they have been covered by a bitmap) which are candidates for
+  a stable a pseudo-merge bitmap. The default is `1.month.ago`.
+
+bitmapPseudoMerge.<name>.threshold: |
+  Determines the minimum age of non-bitmapped commits (among reference tips, as above) which are
+  candidates for inclusion in an unstable pseudo-merge bitmap. The default is `1.week.ago`.
+
+blame.blankBoundary: |
+  Show blank commit object name for boundary commits in `git-blame(1)`. This option defaults to
+  false.
+
+blame.coloring: |
+  This determines the coloring scheme to be applied to blame output. It can be 'repeatedLines',
+  'highlightRecent', or 'none' which is the default.
+
+blame.date: |
+  Specifies the format used to output dates in `git-blame(1)`. If unset the iso format is used. For
+  supported values, see the discussion of the `--date` option at `git-log(1)`.
+
+blame.ignoreRevsFile: |
+  Ignore revisions listed in the file, one unabbreviated object name per line, in `git-blame(1)`.
+  Whitespace and comments beginning with `#` are ignored. This option may be repeated multiple
+  times. Empty file names will reset the list of ignored revisions. This option will be handled
+  before the command line option `--ignore-revs-file`.
+
+blame.markIgnoredLines: |
+  Mark lines that were changed by an ignored revision that we attributed to another commit with a
+  '?' in the output of `git-blame(1)`.
+
+blame.markUnblamableLines: |
+  Mark lines that were changed by an ignored revision that we could not attribute to another commit
+  with a '*' in the output of `git-blame(1)`.
+
+blame.showEmail: |
+  Show the author email instead of author name in `git-blame(1)`. This option defaults to false.
+
+blame.showRoot: |
+  Do not treat root commits as boundaries in `git-blame(1)`. This option defaults to false.
+
+branch.<branch>.description: |
+  Branch description, can be edited with `git branch --edit-description`. Branch description is
+  automatically added to the `format-patch` cover letter or `request-pull` summary.
+
+branch.<branch>.merge: |
+  Defines, together with `branch.<name>.remote`, the upstream branch for the given branch. It tells
+  `git fetch`/`git pull`/`git rebase` which branch to merge and can also affect `git push` (see
+  `push.default`). When in branch _<name>_, it tells `git fetch` the default refspec to be marked
+  for merging in `FETCH_HEAD`. The value is handled like the remote part of a refspec, and must
+  match a ref which is fetched from the remote given by `branch.<name>.remote`. The merge
+  information is used by `git pull` (which first calls `git fetch`) to lookup the default branch for
+  merging. Without this option, `git pull` defaults to merge the first refspec fetched. Specify
+  multiple values to get an octopus merge. If you wish to setup `git pull` so that it merges into
+  _<name>_ from another branch in the local repository, you can point `branch.<name>.merge` to the
+  desired branch, and use the relative path setting `.` (a period) for `branch.<name>.remote`.
+
+branch.<branch>.mergeOptions: |
+  Sets default options for merging into branch _<name>_. The syntax and supported options are the
+  same as those of `git-merge(1)`, but option values containing whitespace characters are currently
+  not supported.
+
+branch.<branch>.pushRemote: |
+  When on branch _<name>_, it overrides `branch.<name>.remote` for pushing. It also overrides
+  `remote.pushDefault` for pushing from branch _<name>_. When you pull from one place (e.g. your
+  upstream) and push to another place (e.g. your own publishing repository), you would want to set
+  `remote.pushDefault` to specify the remote to push to for all branches, and use this option to
+  override it for a specific branch.
+
+branch.<branch>.rebase: |
+  When true, rebase the branch _<name>_ on top of the fetched branch, instead of merging the default
+  branch from the default remote when `git pull` is run. See `pull.rebase` for doing this in a non
+  branch-specific manner.
+
+branch.<branch>.remote: |
+  When on branch _<name>_, it tells `git fetch` and `git push` which remote to fetch from or push
+  to. The remote to push to may be overridden with `remote.pushDefault` (for all branches). The
+  remote to push to, for the current branch, may be further overridden by
+  `branch.<name>.pushRemote`. If no remote is configured, or if you are not on any branch and there
+  is more than one remote defined in the repository, it defaults to `origin` for fetching and
+  `remote.pushDefault` for pushing. Additionally, `.` (a period) is the current local repository (a
+  dot-repository), see `branch.<name>.merge`'s final note below.
+
+branch.autoSetupMerge: |
+  Tells `git branch`, `git switch` and `git checkout` to set up new branches so that `git-pull(1)`
+  will appropriately merge from the starting point branch. Note that even if this option is not set,
+  this behavior can be chosen per-branch using the `--track` and `--no-track` options. This option
+  defaults to `true`. The valid settings are:
+
+branch.autoSetupRebase: |
+  When a new branch is created with `git branch`, `git switch` or `git checkout` that tracks another
+  branch, this variable tells Git to set up pull to rebase instead of merge (see
+  `branch.<name>.rebase`). The valid settings are:
+
+branch.sort: |
+  This variable controls the sort ordering of branches when displayed by `git-branch(1)`. Without
+  the `--sort=<value>` option provided, the value of this variable will be used as the default. See
+  `git-for-each-ref(1)` field names for valid values.
+
+browser.<tool>.cmd: |
+  Specify the command to invoke the specified browser. The specified command is evaluated in shell
+  with the URLs passed as arguments. (See `git-web{litdd}browse(1)`.)
+
+browser.<tool>.path: |
+  Override the path for the given tool that may be used to browse HTML help (see `-w` option in
+  `git-help(1)`) or a working repository in gitweb (see `git-instaweb(1)`).
+
+bundle.*: |
+  The `bundle.*` keys may appear in a bundle list file found via the `git clone --bundle-uri`
+  option. These keys currently have no effect if placed in a repository config file, though this
+  will change in the future. See link:technical/bundle-uri.html[the bundle URI design document] for
+  more details.
+
+bundle.<id>.*: |
+  The `bundle.<id>.*` keys are used to describe a single item in the bundle list, grouped under
+  `<id>` for identification purposes.
+
+bundle.<id>.uri: |
+  This string value defines the URI by which Git can reach the contents of this `<id>`. This URI may
+  be a bundle file or another bundle list.
+
+bundle.heuristic: |
+  If this string-valued key exists, then the bundle list is designed to work well with incremental
+  `git fetch` commands. The heuristic signals that there are additional keys available for each
+  bundle that help determine which subset of bundles the client should download. The only value
+  currently understood is `creationToken`.
+
+bundle.mode: |
+  This string value should be either `all` or `any`. This value describes whether all of the
+  advertised bundles are required to unbundle a complete understanding of the bundled information
+  (`all`) or if any one of the listed bundle URIs is sufficient (`any`).
+
+bundle.version: |
+  This integer value advertises the version of the bundle list format used by the bundle list.
+  Currently, the only accepted value is `1`.
+
+checkout.defaultRemote: |
+  When you run `git checkout <something>` or `git switch <something>` and only have one remote, it
+  may implicitly fall back on checking out and tracking e.g. `origin/<something>`. This stops
+  working as soon as you have more than one remote with a _<something>_ reference. This setting
+  allows for setting the name of a preferred remote that should always win when it comes to
+  disambiguation. The typical use-case is to set this to `origin`.
+
+checkout.guess: |
+  Provides the default value for the `--guess` or `--no-guess` option in `git checkout` and `git
+  switch`. See `git-switch(1)` and `git-checkout(1)`.
+
+checkout.thresholdForParallelism: |
+  When running parallel checkout with a small number of files, the cost of subprocess spawning and
+  inter-process communication might outweigh the parallelization gains. This setting allows you to
+  define the minimum number of files for which parallel checkout should be attempted. The default is
+  100.
+
+checkout.workers: |
+  The number of parallel workers to use when updating the working tree. The default is one, i.e.
+  sequential execution. If set to a value less than one, Git will use as many workers as the number
+  of logical cores available. This setting and `checkout.thresholdForParallelism` affect all
+  commands that perform checkout. E.g. checkout, clone, reset, sparse-checkout, etc.
+
+clean.requireForce: |
+  A boolean to make git-clean refuse to delete files unless -f is given. Defaults to true.
+
+clone.defaultRemoteName: |
+  The name of the remote to create when cloning a repository. Defaults to `origin`.
+
+clone.filterSubmodules: |
+  If a partial clone filter is provided (see `--filter` in `git-rev-list(1)`) and `--recurse-
+  submodules` is used, also apply the filter to submodules.
+
+clone.rejectShallow: |
+  Reject cloning a repository if it is a shallow one; this can be overridden by passing the
+  `--reject-shallow` option on the command line.
+
+color.advice: |
+  A boolean to enable/disable color in hints (e.g. when a push failed, see `advice.*` for a list).
+  May be set to `always`, `false` (or `never`) or `auto` (or `true`), in which case colors are used
+  only when the error output goes to a terminal. If unset, then the value of `color.ui` is used
+  (`auto` by default).
+
+color.advice.hint: |
+  Use customized color for hints.
+
+color.blame.highlightRecent: |
+  Specify the line annotation color for `git blame --color-by-age` depending upon the age of the
+  line.
+
+color.blame.repeatedLines: |
+  Use the specified color to colorize line annotations for `git blame --color-lines`, if they come
+  from the same commit as the preceding line. Defaults to cyan.
+
+color.branch: |
+  A boolean to enable/disable color in the output of `git-branch(1)`. May be set to `always`,
+  `false` (or `never`) or `auto` (or `true`), in which case colors are used only when the output is
+  to a terminal. If unset, then the value of `color.ui` is used (`auto` by default).
+
+color.branch.<slot>: |
+  Use customized color for branch coloration. `<slot>` is one of `current` (the current branch),
+  `local` (a local branch), `remote` (a remote-tracking branch in refs/remotes/), `upstream`
+  (upstream tracking branch), `plain` (other refs).
+
+color.decorate.<slot>: |
+  Use customized color for 'git log --decorate' output. `<slot>` is one of `branch`, `remoteBranch`,
+  `tag`, `stash` or `HEAD` for local branches, remote-tracking branches, tags, stash and HEAD,
+  respectively and `grafted` for grafted commits.
+
+color.diff: |
+  Whether to use ANSI escape sequences to add color to patches. If this is set to `always`, `git-
+  diff(1)`, `git-log(1)`, and `git-show(1)` will use color for all patches. If it is set to `true`
+  or `auto`, those commands will only use color when output is to the terminal. If unset, then the
+  value of `color.ui` is used (`auto` by default).
+
+color.diff.<slot>: |
+  Use customized color for diff colorization. `<slot>` specifies which part of the patch to use the
+  specified color, and is one of `context` (context text - `plain` is a historical synonym), `meta`
+  (metainformation), `frag` (hunk header), 'func' (function in hunk header), `old` (removed lines),
+  `new` (added lines), `commit` (commit headers), `whitespace` (highlighting whitespace errors),
+  `oldMoved` (deleted lines), `newMoved` (added lines), `oldMovedDimmed`, `oldMovedAlternative`,
+  `oldMovedAlternativeDimmed`, `newMovedDimmed`, `newMovedAlternative` `newMovedAlternativeDimmed`
+  (See the '<mode>' setting of '--color-moved' in `git-diff(1)` for details), `contextDimmed`,
+  `oldDimmed`, `newDimmed`, `contextBold`, `oldBold`, and `newBold` (see `git-range-diff(1)` for
+  details).
+
+color.grep: |
+  When set to `always`, always highlight matches. When `false` (or `never`), never. When set to
+  `true` or `auto`, use color only when the output is written to the terminal. If unset, then the
+  value of `color.ui` is used (`auto` by default).
+
+color.grep.<slot>: |
+  Use customized color for grep colorization. `<slot>` specifies which part of the line to use the
+  specified color, and is one of
+
+color.interactive: |
+  When set to `always`, always use colors for interactive prompts and displays (such as those used
+  by "git-add --interactive" and "git-clean --interactive"). When false (or `never`), never. When
+  set to `true` or `auto`, use colors only when the output is to the terminal. If unset, then the
+  value of `color.ui` is used (`auto` by default).
+
+color.interactive.<slot>: |
+  Use customized color for 'git add --interactive' and 'git clean --interactive' output. `<slot>`
+  may be `prompt`, `header`, `help` or `error`, for four distinct types of normal output from
+  interactive commands.
+
+color.pager: |
+  A boolean to specify whether `auto` color modes should colorize output going to the pager.
+  Defaults to true; set this to false if your pager does not understand ANSI color codes.
+
+color.push: |
+  A boolean to enable/disable color in push errors. May be set to `always`, `false` (or `never`) or
+  `auto` (or `true`), in which case colors are used only when the error output goes to a terminal.
+  If unset, then the value of `color.ui` is used (`auto` by default).
+
+color.push.error: |
+  Use customized color for push errors.
+
+color.remote: |
+  If set, keywords at the start of the line are highlighted. The keywords are "error", "warning",
+  "hint" and "success", and are matched case-insensitively. May be set to `always`, `false` (or
+  `never`) or `auto` (or `true`). If unset, then the value of `color.ui` is used (`auto` by
+  default).
+
+color.remote.<slot>: |
+  Use customized color for each remote keyword. `<slot>` may be `hint`, `warning`, `success` or
+  `error` which match the corresponding keyword.
+
+color.showBranch: |
+  A boolean to enable/disable color in the output of `git-show-branch(1)`. May be set to `always`,
+  `false` (or `never`) or `auto` (or `true`), in which case colors are used only when the output is
+  to a terminal. If unset, then the value of `color.ui` is used (`auto` by default).
+
+color.status: |
+  A boolean to enable/disable color in the output of `git-status(1)`. May be set to `always`,
+  `false` (or `never`) or `auto` (or `true`), in which case colors are used only when the output is
+  to a terminal. If unset, then the value of `color.ui` is used (`auto` by default).
+
+color.status.<slot>: |
+  Use customized color for status colorization. `<slot>` is one of `header` (the header text of the
+  status message), `added` or `updated` (files which are added but not committed), `changed` (files
+  which are changed but not added in the index), `untracked` (files which are not tracked by Git),
+  `branch` (the current branch), `nobranch` (the color the 'no branch' warning is shown in,
+  defaulting to red), `localBranch` or `remoteBranch` (the local and remote branch names,
+  respectively, when branch and tracking information is displayed in the status short-format), or
+  `unmerged` (files which have unmerged changes).
+
+color.transport: |
+  A boolean to enable/disable color when pushes are rejected. May be set to `always`, `false` (or
+  `never`) or `auto` (or `true`), in which case colors are used only when the error output goes to a
+  terminal. If unset, then the value of `color.ui` is used (`auto` by default).
+
+color.transport.rejected: |
+  Use customized color when a push was rejected.
+
+color.ui: |
+  This variable determines the default value for variables such as `color.diff` and `color.grep`
+  that control the use of color per command family. Its scope will expand as more commands learn
+  configuration to set a default for the `--color` option. Set it to `false` or `never` if you
+  prefer Git commands not to use color unless enabled explicitly with some other configuration or
+  the `--color` option. Set it to `always` if you want all output not intended for machine
+  consumption to use color, to `true` or `auto` (this is the default since Git 1.8.4) if you want
+  such output to use color when written to the terminal.
+
+column.branch: |
+  Specify whether to output branch listing in `git branch` in columns. See `column.ui` for details.
+
+column.clean: |
+  Specify the layout when listing items in `git clean -i`, which always shows files and directories
+  in columns. See `column.ui` for details.
+
+column.status: |
+  Specify whether to output untracked files in `git status` in columns. See `column.ui` for details.
+
+column.tag: |
+  Specify whether to output tag listings in `git tag` in columns. See `column.ui` for details.
+
+column.ui: |
+  Specify whether supported commands should output in columns. This variable consists of a list of
+  tokens separated by spaces or commas:
+
+commit.cleanup: |
+  This setting overrides the default of the `--cleanup` option in `git commit`. {see-git-commit}
+  Changing the default can be useful when you always want to keep lines that begin with the comment
+  character (`core.commentChar`, default `#`) in your log message, in which case you would do `git
+  config commit.cleanup whitespace` (note that you will have to remove the help lines that begin
+  with the comment character in the commit log template yourself, if you do this).
+
+commit.gpgSign: |
+  A boolean to specify whether all commits should be GPG signed. Use of this option when doing
+  operations such as rebase can result in a large number of commits being signed. It may be
+  convenient to use an agent to avoid typing your GPG passphrase several times.
+
+commit.status: |
+  A boolean to enable/disable inclusion of status information in the commit message template when
+  using an editor to prepare the commit message. Defaults to `true`.
+
+commit.template: |
+  Specify the pathname of a file to use as the template for new commit messages.
+
+commit.verbose: |
+  A boolean or int to specify the level of verbosity with `git commit`. {see-git-commit}
+
+commitGraph.changedPaths: |
+  If true, then `git commit-graph write` will compute and write changed-path Bloom filters by
+  default, equivalent to passing `--changed-paths`. If false or unset, changed-paths Bloom filters
+  will be written during `git commit-graph write` only if the filters already exist in the current
+  commit-graph file. This matches the default behavior of `git commit-graph write` without any
+  `--[no-]changed-paths` option. To rewrite a commit-graph file without any filters, use the `--no-
+  changed-paths` option. Command-line option `--[no-]changed-paths` always takes precedence over
+  this configuration. Defaults to unset.
+
+commitGraph.changedPathsVersion: |
+  Specifies the version of the changed-path Bloom filters that Git will read and write. May be -1,
+  0, 1, or 2. Note that values greater than 1 may be incompatible with older versions of Git which
+  do not yet understand those versions. Use caution when operating in a mixed-version environment.
+
+commitGraph.generationVersion: |
+  Specifies the type of generation number version to use when writing or reading the commit-graph
+  file. If version 1 is specified, then the corrected commit dates will not be written or read.
+  Defaults to 2.
+
+commitGraph.maxNewFilters: |
+  Specifies the default value for the `--max-new-filters` option of `git commit-graph write` (c.f.,
+  `git-commit-graph(1)`).
+
+commitGraph.readChangedPaths: |
+  Deprecated. Equivalent to commitGraph.changedPathsVersion=-1 if true, and
+  commitGraph.changedPathsVersion=0 if false. (If commitGraph.changedPathVersion is also set,
+  commitGraph.changedPathsVersion takes precedence.)
+
+committer.email: |
+  The `user.name` and `user.email` variables determine what ends up in the `author` and `committer`
+  fields of commit objects. If you need the `author` or `committer` to be different, the
+  `author.name`, `author.email`, `committer.name`, or `committer.email` variables can be set. All of
+  these can be overridden by the `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`,
+  `GIT_COMMITTER_EMAIL`, and `EMAIL` environment variables.
+
+completion.commands: |
+  This is only used by git-completion.bash to add or remove commands from the list of completed
+  commands. Normally only porcelain commands and a few select others are completed. You can add more
+  commands, separated by space, in this variable. Prefixing the command with '-' will remove it from
+  the existing list.
+
+core.abbrev: |
+  Set the length object names are abbreviated to. If unspecified or set to "auto", an appropriate
+  value is computed based on the approximate number of packed objects in your repository, which
+  hopefully is enough for abbreviated object names to stay unique for some time. If set to "no", no
+  abbreviation is made and the object names are shown in their full length. The minimum length is 4.
+
+core.alternateRefsCommand: |
+  When advertising tips of available history from an alternate, use the shell to execute the
+  specified command instead of `git-for-each-ref(1)`. The first argument is the absolute path of the
+  alternate. Output must contain one hex object id per line (i.e., the same as produced by `git for-
+  each-ref --format='%(objectname)'`).
+
+core.alternateRefsPrefixes: |
+  When listing references from an alternate, list only references that begin with the given prefix.
+  Prefixes match as if they were given as arguments to `git-for-each-ref(1)`. To list multiple
+  prefixes, separate them with whitespace. If `core.alternateRefsCommand` is set, setting
+  `core.alternateRefsPrefixes` has no effect.
+
+core.askPass: |
+  Some commands (e.g. svn and http interfaces) that interactively ask for a password can be told to
+  use an external program given via the value of this variable. Can be overridden by the
+  `GIT_ASKPASS` environment variable. If not set, fall back to the value of the `SSH_ASKPASS`
+  environment variable or, failing that, a simple password prompt. The external program shall be
+  given a suitable prompt as command-line argument and write the password on its STDOUT.
+
+core.attributesFile: |
+  Specifies the pathname to the file that contains attributes (see `gitattributes(5)`), in addition
+  to `.gitattributes` (per-directory) and `.git/info/attributes`. Its default value is
+  `$XDG_CONFIG_HOME/git/attributes`. If `$XDG_CONFIG_HOME` is either not set or empty,
+  `$HOME/.config/git/attributes` is used instead.
+
+core.autocrlf: |
+  Setting this variable to "true" is the same as setting the `text` attribute to "auto" on all files
+  and core.eol to "crlf". Set to true if you want to have `CRLF` line endings in your working
+  directory and the repository has LF line endings. This variable can be set to 'input', in which
+  case no output conversion is performed.
+
+core.bare: |
+  If true this repository is assumed to be 'bare' and has no working directory associated with it.
+  If this is the case a number of commands that require a working directory will be disabled, such
+  as `git-add(1)` or `git-merge(1)`.
+
+core.bigFileThreshold: |
+  The size of files considered "big", which as discussed below changes the behavior of numerous git
+  commands, as well as how such files are stored within the repository. The default is 512 MiB.
+  Common unit suffixes of 'k', 'm', or 'g' are supported.
+
+core.checkRoundtripEncoding: |
+  A comma and/or whitespace separated list of encodings that Git performs UTF-8 round trip checks on
+  if they are used in an `working-tree-encoding` attribute (see `gitattributes(5)`). The default
+  value is `SHIFT-JIS`.
+
+core.checkStat: |
+  When missing or is set to `default`, many fields in the stat structure are checked to detect if a
+  file has been modified since Git looked at it. When this configuration variable is set to
+  `minimal`, sub-second part of mtime and ctime, the uid and gid of the owner of the file, the inode
+  number (and the device number, if Git was compiled to use it), are excluded from the check among
+  these fields, leaving only the whole-second part of mtime (and ctime, if `core.trustCtime` is set)
+  and the filesize to be checked.
+
+core.commentString: |
+  Commands such as `commit` and `tag` that let you edit messages consider a line that begins with
+  this character commented, and removes them after the editor returns (default '#').
+
+core.commitGraph: |
+  If true, then git will read the commit-graph file (if it exists) to parse the graph structure of
+  commits. Defaults to true. See `git-commit-graph(1)` for more information.
+
+core.compression: |
+  An integer -1..9, indicating a default compression level. -1 is the zlib default. 0 means no
+  compression, and 1..9 are various speed/size tradeoffs, 9 being slowest. If set, this provides a
+  default to other compression variables, such as `core.looseCompression` and `pack.compression`.
+
+core.createObject: |
+  You can set this to 'link', in which case a hardlink followed by a delete of the source are used
+  to make sure that object creation will not overwrite existing objects.
+
+core.deltaBaseCacheLimit: |
+  Maximum number of bytes per thread to reserve for caching base objects that may be referenced by
+  multiple deltified objects. By storing the entire decompressed base objects in a cache Git is able
+  to avoid unpacking and decompressing frequently used base objects multiple times.
+
+core.editor: |
+  Commands such as `commit` and `tag` that let you edit messages by launching an editor use the
+  value of this variable when it is set, and the environment variable `GIT_EDITOR` is not set. See
+  `git-var(1)`.
+
+core.eol: |
+  Sets the line ending type to use in the working directory for files that are marked as text
+  (either by having the `text` attribute set, or by having `text=auto` and Git auto-detecting the
+  contents as text). Alternatives are 'lf', 'crlf' and 'native', which uses the platform's native
+  line ending. The default value is `native`. See `gitattributes(5)` for more information on end-of-
+  line conversion. Note that this value is ignored if `core.autocrlf` is set to `true` or `input`.
+
+core.excludesFile: |
+  Specifies the pathname to the file that contains patterns to describe paths that are not meant to
+  be tracked, in addition to `.gitignore` (per-directory) and `.git/info/exclude`. Defaults to
+  `$XDG_CONFIG_HOME/git/ignore`. If `$XDG_CONFIG_HOME` is either not set or empty,
+  `$HOME/.config/git/ignore` is used instead. See `gitignore(5)`.
+
+core.fileMode: |
+  Tells Git if the executable bit of files in the working tree is to be honored.
+
+core.filesRefLockTimeout: |
+  The length of time, in milliseconds, to retry when trying to lock an individual reference. Value 0
+  means not to retry at all; -1 means to try indefinitely. Default is 100 (i.e., retry for 100ms).
+
+core.fsmonitor: |
+  If set to true, enable the built-in file system monitor daemon for this working directory (`git-
+  fsmonitor{litdd}daemon(1)`).
+
+core.fsmonitorHookVersion: |
+  Sets the protocol version to be used when invoking the "fsmonitor" hook.
+
+core.fsync: |
+  A comma-separated list of components of the repository that should be hardened via the
+  core.fsyncMethod when created or modified. You can disable hardening of any component by prefixing
+  it with a '-'. Items that are not hardened may be lost in the event of an unclean system shutdown.
+  Unless you have special requirements, it is recommended that you leave this option empty or pick
+  one of `committed`, `added`, or `all`.
+
+core.fsyncMethod: |
+  A value indicating the strategy Git will use to harden repository data using fsync and related
+  primitives.
+
+core.fsyncObjectFiles: |
+  This boolean will enable 'fsync()' when writing object files. This setting is deprecated. Use
+  core.fsync instead.
+
+core.gitProxy: |
+  A "proxy command" to execute (as 'command host port') instead of establishing direct connection to
+  the remote server when using the Git protocol for fetching. If the variable value is in the
+  "COMMAND for DOMAIN" format, the command is applied only on hostnames ending with the specified
+  domain string. This variable may be set multiple times and is matched in the given order; the
+  first match wins.
+
+core.hideDotFiles: |
+  (Windows-only) If true, mark newly-created directories and files whose name starts with a dot as
+  hidden. If 'dotGitOnly', only the `.git/` directory is hidden, but no other files starting with a
+  dot. The default mode is 'dotGitOnly'.
+
+core.hooksPath: |
+  By default Git will look for your hooks in the `$GIT_DIR/hooks` directory. Set this to different
+  path, e.g. `/etc/git/hooks`, and Git will try to find your hooks in that directory, e.g.
+  `/etc/git/hooks/pre-receive` instead of in `$GIT_DIR/hooks/pre-receive`.
+
+core.ignoreCase: |
+  Internal variable which enables various workarounds to enable Git to work better on filesystems
+  that are not case sensitive, like APFS, HFS+, FAT, NTFS, etc. For example, if a directory listing
+  finds "makefile" when Git expects "Makefile", Git will assume it is really the same file, and
+  continue to remember it as "Makefile".
+
+core.ignoreStat: |
+  If true, Git will avoid using lstat() calls to detect if files have changed by setting the
+  "assume-unchanged" bit for those tracked files which it has updated identically in both the index
+  and working tree.
+
+core.lockfilePid: |
+  If true, Git will create a PID file alongside lock files. When a lock acquisition fails and a PID
+  file exists, Git can provide additional diagnostic information about the process holding the lock,
+  including whether it is still running. Defaults to `false`.
+
+core.logAllRefUpdates: |
+  Enable the reflog. Updates to a ref <ref> is logged to the file "`$GIT_DIR/logs/<ref>`", by
+  appending the new and old SHA-1, the date/time and the reason of the update, but only when the
+  file exists. If this configuration variable is set to `true`, missing "`$GIT_DIR/logs/<ref>`" file
+  is automatically created for branch heads (i.e. under `refs/heads/`), remote refs (i.e. under
+  `refs/remotes/`), note refs (i.e. under `refs/notes/`), and the symbolic ref `HEAD`. If it is set
+  to `always`, then a missing reflog is automatically created for any ref under `refs/`.
+
+core.looseCompression: |
+  An integer -1..9, indicating the compression level for objects that are not in a pack file. -1 is
+  the zlib default. 0 means no compression, and 1..9 are various speed/size tradeoffs, 9 being
+  slowest. If not set, defaults to core.compression. If that is not set, defaults to 1 (best speed).
+
+core.maxTreeDepth: |
+  The maximum depth Git is willing to recurse while traversing a tree (e.g., "a/b/cde/f" has a depth
+  of 4). This is a fail-safe to allow Git to abort cleanly, and should not generally need to be
+  adjusted. When Git is compiled with MSVC, the default is 512. Otherwise, the default is 2048.
+
+core.multiPackIndex: |
+  Use the multi-pack-index file to track multiple packfiles using a single index. See `git-multi-
+  pack-index(1)` for more information. Defaults to true.
+
+core.notesRef: |
+  When showing commit messages, also show notes which are stored in the given ref. The ref must be
+  fully qualified. If the given ref does not exist, it is not an error but means that no notes
+  should be printed.
+
+core.packedGitLimit: |
+  Maximum number of bytes to map simultaneously into memory from pack files. If Git needs to access
+  more than this many bytes at once to complete an operation it will unmap existing regions to
+  reclaim virtual address space within the process.
+
+core.packedGitWindowSize: |
+  Number of bytes of a pack file to map into memory in a single mapping operation. Larger window
+  sizes may allow your system to process a smaller number of large pack files more quickly. Smaller
+  window sizes will negatively affect performance due to increased calls to the operating system's
+  memory manager, but may improve performance when accessing a large number of large pack files.
+
+core.packedRefsTimeout: |
+  The length of time, in milliseconds, to retry when trying to lock the `packed-refs` file. Value 0
+  means not to retry at all; -1 means to try indefinitely. Default is 1000 (i.e., retry for 1
+  second).
+
+core.pager: |
+  Text viewer for use by Git commands (e.g., 'less'). The value is meant to be interpreted by the
+  shell. The order of preference is the `$GIT_PAGER` environment variable, then `core.pager`
+  configuration, then `$PAGER`, and then the default chosen at compile time (usually 'less').
+
+core.precomposeUnicode: |
+  This option is only used by Mac OS implementation of Git. When core.precomposeUnicode=true, Git
+  reverts the unicode decomposition of filenames done by Mac OS. This is useful when sharing a
+  repository between Mac OS and Linux or Windows. (Git for Windows 1.7.10 or higher is needed, or
+  Git under cygwin 1.7). When false, file names are handled fully transparent by Git, which is
+  backward compatible with older versions of Git.
+
+core.preferSymlinkRefs: |
+  Instead of the default "symref" format for HEAD and other symbolic reference files, use symbolic
+  links. This is sometimes needed to work with old scripts that expect HEAD to be a symbolic link.
+
+core.preloadIndex: |
+  Enable parallel index preload for operations like 'git diff'
+
+core.protectHFS: |
+  If set to true, do not allow checkout of paths that would be considered equivalent to `.git` on an
+  HFS+ filesystem. Defaults to `true` on Mac OS, and `false` elsewhere.
+
+core.protectNTFS: |
+  If set to true, do not allow checkout of paths that would cause problems with the NTFS filesystem,
+  e.g. conflict with 8.3 "short" names. Defaults to `true` on Windows, and `false` elsewhere.
+
+core.quotePath: |
+  Commands that output paths (e.g. 'ls-files', 'diff'), will quote "unusual" characters in the
+  pathname by enclosing the pathname in double-quotes and escaping those characters with backslashes
+  in the same way C escapes control characters (e.g. `\t` for TAB, `\n` for LF, `\\` for backslash)
+  or bytes with values larger than 0x80 (e.g. octal `\302\265` for "micro" in UTF-8). If this
+  variable is set to false, bytes higher than 0x80 are not considered "unusual" any more. Double-
+  quotes, backslash and control characters are always escaped regardless of the setting of this
+  variable. A simple space character is not considered "unusual". Many commands can output pathnames
+  completely verbatim using the `-z` option. The default value is true.
+
+core.repositoryFormatVersion: |
+  Internal variable identifying the repository format and layout version. See `gitrepository-
+  layout(5)`.
+
+core.safecrlf: |
+  If true, makes Git check if converting `CRLF` is reversible when end-of-line conversion is active.
+  Git will verify if a command modifies a file in the work tree either directly or indirectly. For
+  example, committing a file followed by checking out the same file should yield the original file
+  in the work tree. If this is not the case for the current setting of `core.autocrlf`, Git will
+  reject the file. The variable can be set to "warn", in which case Git will only warn about an
+  irreversible conversion but continue the operation.
+
+core.sharedRepository: |
+  When 'group' (or 'true'), the repository is made shareable between several users in a group
+  (making sure all the files and objects are group-writable). When 'all' (or 'world' or
+  'everybody'), the repository will be readable by all users, additionally to being group-shareable.
+  When 'umask' (or 'false'), Git will use permissions reported by umask(2). When '0xxx', where
+  '0xxx' is an octal number, files in the repository will have this mode value. '0xxx' will override
+  user's umask value (whereas the other options will only override requested parts of the user's
+  umask value). Examples: '0660' will make the repo read/write-able for the owner and group, but
+  inaccessible to others (equivalent to 'group' unless umask is e.g. '0022'). '0640' is a repository
+  that is group-readable but not group-writable. See `git-init(1)`. False by default.
+
+core.sparseCheckout: |
+  Enable "sparse checkout" feature. See `git-sparse-checkout(1)` for more information.
+
+core.sparseCheckoutCone: |
+  Enables the "cone mode" of the sparse checkout feature. When the sparse-checkout file contains a
+  limited set of patterns, this mode provides significant performance advantages. The "non-cone
+  mode" can be requested to allow specifying more flexible patterns by setting this variable to
+  'false'. See `git-sparse-checkout(1)` for more information.
+
+core.splitIndex: |
+  If true, the split-index feature of the index will be used. See `git-update-index(1)`. False by
+  default.
+
+core.sshCommand: |
+  If this variable is set, `git fetch` and `git push` will use the specified command instead of
+  `ssh` when they need to connect to a remote system. The command is in the same form as the
+  `GIT_SSH_COMMAND` environment variable and is overridden when the environment variable is set.
+
+core.symlinks: |
+  If false, symbolic links are checked out as small plain files that contain the link text. `git-
+  update-index(1)` and `git-add(1)` will not change the recorded type to regular file. Useful on
+  filesystems like FAT that do not support symbolic links.
+
+core.trustctime: |
+  If false, the ctime differences between the index and the working tree are ignored; useful when
+  the inode change time is regularly modified by something outside Git (file system crawlers and
+  some backup systems). See `git-update-index(1)`. True by default.
+
+core.unsetenvvars: |
+  Windows-only: comma-separated list of environment variables' names that need to be unset before
+  spawning any other process. Defaults to `PERL5LIB` to account for the fact that Git for Windows
+  insists on using its own Perl interpreter.
+
+core.untrackedCache: |
+  Determines what to do about the untracked cache feature of the index. It will be kept, if this
+  variable is unset or set to `keep`. It will automatically be added if set to `true`. And it will
+  automatically be removed, if set to `false`. Before setting it to `true`, you should check that
+  mtime is working properly on your system. See `git-update-index(1)`. `keep` by default, unless
+  `feature.manyFiles` is enabled which sets this setting to `true` by default.
+
+core.useReplaceRefs: |
+  If set to `false`, behave as if the `--no-replace-objects` option was given on the command line.
+  See `git(1)` and `git-replace(1)` for more information.
+
+core.warnAmbiguousRefs: |
+  If true, Git will warn you if the ref name you passed it is ambiguous and might match multiple
+  refs in the repository. True by default.
+
+core.whitespace: |
+  A comma separated list of common whitespace problems to notice. 'git diff' will use
+  `color.diff.whitespace` to highlight them, and 'git apply --whitespace=error' will consider them
+  as errors. You can prefix `-` to disable any of them (e.g. `-trailing-space`):
+
+core.worktree: |
+  Set the path to the root of the working tree. If `GIT_COMMON_DIR` environment variable is set,
+  core.worktree is ignored and not used for determining the root of working tree. This can be
+  overridden by the `GIT_WORK_TREE` environment variable and the `--work-tree` command-line option.
+  The value can be an absolute path or relative to the path to the .git directory, which is either
+  specified by --git-dir or GIT_DIR, or automatically discovered. If --git-dir or GIT_DIR is
+  specified but none of --work-tree, GIT_WORK_TREE and core.worktree is specified, the current
+  working directory is regarded as the top level of your working tree.
+
+credential.<url>.*: |
+  Any of the credential.* options above can be applied selectively to some credentials. For example,
+  "credential.https://example.com.username" would set the default username only for https
+  connections to example.com. See `gitcredentials(7)` for details on how URLs are matched.
+
+credential.helper: |
+  Specify an external helper to be called when a username or password credential is needed; the
+  helper may consult external storage to avoid prompting the user for the credentials. This is
+  normally the name of a credential helper with possible arguments, but may also be an absolute path
+  with arguments or, if preceded by `!`, shell commands.
+
+credential.interactive: |
+  By default, Git and any configured credential helpers will ask for user input when new credentials
+  are required. Many of these helpers will succeed based on stored credentials if those credentials
+  are still valid. To avoid the possibility of user interactivity from Git, set
+  `credential.interactive=false`. Some credential helpers respect this option as well.
+
+credential.protectProtocol: |
+  By default, Carriage Return characters are not allowed in the protocol that is used when Git talks
+  to a credential helper. This setting allows users to override this default.
+
+credential.sanitizePrompt: |
+  By default, user names and hosts that are shown as part of the password prompt are not allowed to
+  contain control characters (they will be URL-encoded by default). Configure this setting to
+  `false` to override that behavior.
+
+credential.useHttpPath: |
+  When acquiring credentials, consider the "path" component of an http or https URL to be important.
+  Defaults to false. See `gitcredentials(7)` for more information.
+
+credential.username: |
+  If no username is set for a network authentication, use this username by default. See
+  credential.<context>.* below, and `gitcredentials(7)`.
+
+credentialCache.ignoreSIGHUP: |
+  Tell git-credential-cache--daemon to ignore SIGHUP, instead of quitting.
+
+credentialStore.lockTimeoutMS: |
+  The length of time, in milliseconds, for git-credential-store to retry when trying to lock the
+  credentials file. A value of 0 means not to retry at all; -1 means to try indefinitely. Default is
+  1000 (i.e., retry for 1s).
+
+diff.<driver>.binary: |
+  Set this option to `true` to make the diff driver treat files as binary. See `gitattributes(5)`
+  for details.
+
+diff.<driver>.cachetextconv: |
+  Set this option to `true` to make the diff driver cache the text conversion outputs. See
+  `gitattributes(5)` for details.
+
+diff.<driver>.command: |
+  The custom diff driver command. See `gitattributes(5)` for details.
+
+diff.<driver>.textconv: |
+  The command that the diff driver should call to generate the text-converted version of a file. The
+  result of the conversion is used to generate a human-readable diff. See `gitattributes(5)` for
+  details.
+
+diff.<driver>.trustExitCode: |
+  If this boolean value is set to `true` then the `diff.<driver>.command` command is expected to
+  return exit code 0 if it considers the input files to be equal or 1 if it considers them to be
+  different, like `diff`(1). If it is set to `false`, which is the default, then the command is
+  expected to return exit code 0 regardless of equality. Any other exit code causes Git to report a
+  fatal error.
+
+diff.<driver>.wordRegex: |
+  The regular expression that the diff driver should use to split words in a line. See
+  `gitattributes(5)` for details.
+
+diff.<driver>.xfuncname: |
+  The regular expression that the diff driver should use to recognize the hunk header. A built-in
+  pattern may also be used. See `gitattributes(5)` for details.
+
+diff.algorithm: |
+  Choose a diff algorithm. The variants are as follows:
+
+diff.autoRefreshIndex: |
+  When using `git diff` to compare with work tree files, do not consider stat-only changes as
+  changed. Instead, silently run `git update-index --refresh` to update the cached stat information
+  for paths whose contents in the work tree match the contents in the index. This option defaults to
+  `true`. Note that this affects only `git diff` Porcelain, and not lower level `diff` commands such
+  as `git diff-files`.
+
+diff.colorMoved: |
+  If set to either a valid _<mode>_ or a `true` value, moved lines in a diff are colored
+  differently.
+
+diff.colorMovedWS: |
+  When moved lines are colored using e.g. the `diff.colorMoved` setting, this option controls the
+  mode how spaces are treated. For details of valid modes see `--color-moved-ws` in `git-diff(1)`.
+
+diff.context: |
+  Generate diffs with _<n>_ lines of context instead of the default of 3. This value is overridden
+  by the `-U` option.
+
+diff.dstPrefix: |
+  If set, `git diff` uses this destination prefix. Defaults to `b/`.
+
+diff.external: |
+  If this config variable is set, diff generation is not performed using the internal diff
+  machinery, but using the given command. Can be overridden with the `GIT_EXTERNAL_DIFF` environment
+  variable. The command is called with parameters as described under "git Diffs" in `git(1)`. Note:
+  if you want to use an external diff program only on a subset of your files, you might want to use
+  `gitattributes(5)` instead.
+
+diff.guitool: |
+  Controls which diff tool is used by `git-difftool(1)` when the `-g`/`--gui` flag is specified.
+  This variable overrides the value configured in `merge.guitool`. The list below shows the valid
+  built-in values. Any other value is treated as a custom diff tool and requires that a
+  corresponding `difftool.<guitool>.cmd` variable is defined.
+
+diff.ignoreSubmodules: |
+  Sets the default value of `--ignore-submodules`. Note that this affects only `git diff` Porcelain,
+  and not lower level `diff` commands such as `git diff-files`. `git checkout` and `git switch` also
+  honor this setting when reporting uncommitted changes. Setting it to `all` disables the submodule
+  summary normally shown by `git commit` and `git status` when `status.submoduleSummary` is set
+  unless it is overridden by using the `--ignore-submodules` command-line option. The `git
+  submodule` commands are not affected by this setting. By default this is set to untracked so that
+  any untracked submodules are ignored.
+
+diff.indentHeuristic: |
+  Set this option to `false` to disable the default heuristics that shift diff hunk boundaries to
+  make patches easier to read.
+
+diff.interHunkContext: |
+  Show the context between diff hunks, up to the specified number of lines, thereby fusing the hunks
+  that are close to each other. This value serves as the default for the `--inter-hunk-context`
+  command line option.
+
+diff.mnemonicPrefix: |
+  If set, `git diff` uses a prefix pair that is different from the standard `a/` and `b/` depending
+  on what is being compared. When this configuration is in effect, reverse diff output also swaps
+  the order of the prefixes:
+
+diff.noPrefix: |
+  If set, `git diff` does not show any source or destination prefix.
+
+diff.orderFile: |
+  File indicating how to order files within a diff.
+
+diff.relative: |
+  If set to `true`, `git diff` does not show changes outside of the directory and show pathnames
+  relative to the current directory.
+
+diff.renameLimit: |
+  The number of files to consider in the exhaustive portion of copy/rename detection; equivalent to
+  the `git diff` option `-l`. If not set, the default value is currently 1000. This setting has no
+  effect if rename detection is turned off.
+
+diff.renames: |
+  Whether and how Git detects renames. If set to `false`, rename detection is disabled. If set to
+  `true`, basic rename detection is enabled. If set to `copies` or `copy`, Git will detect copies,
+  as well. Defaults to `true`. Note that this affects only `git diff` Porcelain like `git-diff(1)`
+  and `git-log(1)`, and not lower level commands such as `git-diff-files(1)`.
+
+diff.srcPrefix: |
+  If set, `git diff` uses this source prefix. Defaults to `a/`.
+
+diff.statGraphWidth: |
+  Limit the width of the graph part in `--stat` output. If set, applies to all commands generating
+  `--stat` output except `format-patch`.
+
+diff.statNameWidth: |
+  Limit the width of the filename part in `--stat` output. If set, applies to all commands
+  generating `--stat` output except `format-patch`.
+
+diff.submodule: |
+  Specify the format in which differences in submodules are shown. The `short` format just shows the
+  names of the commits at the beginning and end of the range. The `log` format lists the commits in
+  the range like `git-submodule(1)` `summary` does. The `diff` format shows an inline diff of the
+  changed contents of the submodule. Defaults to `short`.
+
+diff.suppressBlankEmpty: |
+  A boolean to inhibit the standard behavior of printing a space before each empty output line.
+  Defaults to `false`.
+
+diff.tool: |
+  Controls which diff tool is used by `git-difftool(1)`. This variable overrides the value
+  configured in `merge.tool`. The list below shows the valid built-in values. Any other value is
+  treated as a custom diff tool and requires that a corresponding `difftool.<tool>.cmd` variable is
+  defined.
+
+diff.trustExitCode: |
+  If this boolean value is set to `true` then the `diff.external` command is expected to return exit
+  code 0 if it considers the input files to be equal or 1 if it considers them to be different, like
+  `diff`(1). If it is set to `false`, which is the default, then the command is expected to return
+  exit code `0` regardless of equality. Any other exit code causes Git to report a fatal error.
+
+diff.wordRegex: |
+  A POSIX Extended Regular Expression used to determine what is a "word" when performing word-by-
+  word difference calculations. Character sequences that match the regular expression are "words",
+  all other characters are *ignorable* whitespace.
+
+diff.wsErrorHighlight: |
+  Highlight whitespace errors in the `context`, `old` or `new` lines of the diff. Multiple values
+  are separated by comma, `none` resets previous values, `default` reset the list to `new` and `all`
+  is a shorthand for `old,new,context`. The whitespace errors are colored with
+  `color.diff.whitespace`. The command line option `--ws-error-highlight=<kind>` overrides this
+  setting.
+
+difftool.<tool>.cmd: |
+  Specify the command to invoke the specified diff tool. The specified command is evaluated in shell
+  with the following variables available: `LOCAL` is set to the name of the temporary file
+  containing the contents of the diff pre-image and `REMOTE` is set to the name of the temporary
+  file containing the contents of the diff post-image.
+
+difftool.<tool>.path: |
+  Override the path for the given tool. This is useful in case your tool is not in the PATH.
+
+difftool.guiDefault: |
+  Set `true` to use the `diff.guitool` by default (equivalent to specifying the `--gui` argument),
+  or `auto` to select `diff.guitool` or `diff.tool` depending on the presence of a `DISPLAY`
+  environment variable value. The default is `false`, where the `--gui` argument must be provided
+  explicitly for the `diff.guitool` to be used.
+
+difftool.prompt: |
+  Prompt before each invocation of the diff tool.
+
+difftool.trustExitCode: |
+  Exit difftool if the invoked diff tool returns a non-zero exit status.
+
+extensions.*: |
+  Unless otherwise stated, is an error to specify an extension if `core.repositoryFormatVersion` is
+  not `1`. See `gitrepository-layout(5)`.
+
+fastimport.unpackLimit: |
+  If the number of objects imported by `git-fast-import(1)` is below this limit, then the objects
+  will be unpacked into loose object files. However, if the number of imported objects equals or
+  exceeds this limit, then the pack will be stored as a pack. Storing the pack from a fast-import
+  can make the import operation complete faster, especially on slow filesystems. If not set, the
+  value of `transfer.unpackLimit` is used instead.
+
+feature.*: |
+  The config settings that start with `feature.` modify the defaults of a group of other config
+  settings. These groups are created by the Git developer community as recommended defaults and are
+  subject to change. In particular, new config options may be added with different defaults.
+
+feature.experimental: |
+  Enable config options that are new to Git, and are being considered for future defaults. Config
+  settings included here may be added or removed with each release, including minor version updates.
+  These settings may have unintended interactions since they are so new. Please enable this setting
+  if you are interested in providing feedback on experimental features. The new default values are:
+
+feature.manyFiles: |
+  Enable config options that optimize for repos with many files in the working directory. With many
+  files, commands such as `git status` and `git checkout` may be slow and these new defaults improve
+  performance:
+
+fetch.all: |
+  If true, fetch will attempt to update all available remotes. This behavior can be overridden by
+  passing `--no-all` or by explicitly specifying one or more remote(s) to fetch from. Defaults to
+  `false`.
+
+fetch.bundleCreationToken: |
+  When using `fetch.bundleURI` to fetch incrementally from a bundle list that uses the
+  "`creationToken`" heuristic, this config value stores the maximum `creationToken` value of the
+  downloaded bundles. This value is used to prevent downloading bundles in the future if the
+  advertised `creationToken` is not strictly larger than this value.
+
+fetch.bundleURI: |
+  This value stores a URI for downloading Git object data from a bundle URI before performing an
+  incremental fetch from the origin Git server. This is similar to how the `--bundle-uri` option
+  behaves in `git-clone(1)`. `git clone --bundle-uri` will set the `fetch.bundleURI` value if the
+  supplied bundle URI contains a bundle list that is organized for incremental fetches.
+
+fetch.fsck.<msg-id>: |
+  Acts like `fsck.<msg-id>`, but is used by `git-fetch-pack(1)` instead of `git-fsck(1)`. See the
+  `fsck.<msg-id>` documentation for details.
+
+fetch.fsck.skipList: |
+  Acts like `fsck.skipList`, but is used by `git-fetch-pack(1)` instead of `git-fsck(1)`. See the
+  `fsck.skipList` documentation for details.
+
+fetch.fsckObjects: |
+  If it is set to true, git-fetch-pack will check all fetched objects. See `transfer.fsckObjects`
+  for what's checked. Defaults to `false`. If not set, the value of `transfer.fsckObjects` is used
+  instead.
+
+fetch.negotiationAlgorithm: |
+  Control how information about the commits in the local repository is sent when negotiating the
+  contents of the packfile to be sent by the server. Set to `consecutive` to use an algorithm that
+  walks over consecutive commits checking each one. Set to `skipping` to use an algorithm that skips
+  commits in an effort to converge faster, but may result in a larger-than-necessary packfile; or
+  set to `noop` to not send any information at all, which will almost certainly result in a larger-
+  than-necessary packfile, but will skip the negotiation step. Set to `default` to override settings
+  made previously and use the default behaviour. The default is normally `consecutive`, but if
+  `feature.experimental` is `true`, then the default is `skipping`. Unknown values will cause `git
+  fetch` to error out.
+
+fetch.output: |
+  Control how ref update status is printed. Valid values are `full` and `compact`. Default value is
+  `full`. See the OUTPUT section in `git-fetch(1)` for details.
+
+fetch.parallel: |
+  Specifies the maximal number of fetch operations to be run in parallel at a time (submodules, or
+  remotes when the `--multiple` option of `git-fetch(1)` is in effect).
+
+fetch.prune: |
+  If true, fetch will automatically behave as if the `--prune` option was given on the command line.
+  See also `remote.<name>.prune` and the PRUNING section of `git-fetch(1)`.
+
+fetch.pruneTags: |
+  If true, fetch will automatically behave as if the `refs/tags/*:refs/tags/*` refspec was provided
+  when pruning, if not set already. This allows for setting both this option and `fetch.prune` to
+  maintain a 1=1 mapping to upstream refs. See also `remote.<name>.pruneTags` and the PRUNING
+  section of `git-fetch(1)`.
+
+fetch.recurseSubmodules: |
+  This option controls whether `git fetch` (and the underlying fetch in `git pull`) will recursively
+  fetch into populated submodules. This option can be set either to a boolean value or to `on-
+  demand`. Setting it to a boolean changes the behavior of fetch and pull to recurse unconditionally
+  into submodules when set to true or to not recurse at all when set to false. When set to `on-
+  demand`, fetch and pull will only recurse into a populated submodule when its superproject
+  retrieves a commit that updates the submodule's reference. Defaults to `on-demand`, or to the
+  value of `submodule.recurse` if set.
+
+fetch.showForcedUpdates: |
+  Set to `false` to enable `--no-show-forced-updates` in `git-fetch(1)` and `git-pull(1)` commands.
+  Defaults to `true`.
+
+fetch.unpackLimit: |
+  If the number of objects fetched over the Git native transfer is below this limit, then the
+  objects will be unpacked into loose object files. However if the number of received objects equals
+  or exceeds this limit then the received pack will be stored as a pack, after adding any missing
+  delta bases. Storing the pack from a push can make the push operation complete faster, especially
+  on slow filesystems. If not set, the value of `transfer.unpackLimit` is used instead.
+
+fetch.writeCommitGraph: |
+  Set to true to write a commit-graph after every `git fetch` command that downloads a pack-file
+  from a remote. Using the `--split` option, most executions will create a very small commit-graph
+  file on top of the existing commit-graph file(s). Occasionally, these files will merge and the
+  write may take longer. Having an updated commit-graph file helps performance of many Git commands,
+  including `git merge-base`, `git push -f`, and `git log --graph`. Defaults to `false`.
+
+filter.<driver>.clean: |
+  The command which is used to convert the content of a worktree file to a blob upon checkin. See
+  `gitattributes(5)` for details.
+
+filter.<driver>.smudge: |
+  The command which is used to convert the content of a blob object to a worktree file upon
+  checkout. See `gitattributes(5)` for details.
+
+format.attach: |
+  Enable multipart/mixed attachments as the default for 'format-patch'. The value can also be a
+  double quoted string which will enable attachments as the default and set the value as the
+  boundary. See the --attach option in `git-format-patch(1)`. To countermand an earlier value, set
+  it to an empty string.
+
+format.cc: |
+  Additional recipients to include in a patch to be submitted by mail. See the --to and --cc options
+  in `git-format-patch(1)`.
+
+format.commitListFormat: |
+  When the `--commit-list-format` option is not given, `format-patch` uses the value of this
+  variable to decide how to format the entry of each commit. Defaults to `shortlog`.
+
+format.coverFromDescription: |
+  The default mode for format-patch to determine which parts of the cover letter will be populated
+  using the branch's description. See the `--cover-from-description` option in `git-format-
+  patch(1)`.
+
+format.coverLetter: |
+  A boolean that controls whether to generate a cover-letter when format-patch is invoked, but in
+  addition can be set to "auto", to generate a cover-letter only when there's more than one patch.
+  Default is false.
+
+format.encodeEmailHeaders: |
+  Encode email headers that have non-ASCII characters with "Q-encoding" (described in RFC 2047) for
+  email transmission. Defaults to true.
+
+format.filenameMaxLength: |
+  The maximum length of the output filenames generated by the `format-patch` command; defaults to
+  64. Can be overridden by the `--filename-max-length=<n>` command line option.
+
+format.forceInBodyFrom: |
+  Provides the default value for the `--[no-]force-in-body-from` option to format-patch. Defaults to
+  false.
+
+format.from: |
+  Provides the default value for the `--from` option to format-patch. Accepts a boolean value, or a
+  name and email address. If false, format-patch defaults to `--no-from`, using commit authors
+  directly in the "From:" field of patch mails. If true, format-patch defaults to `--from`, using
+  your committer identity in the "From:" field of patch mails and including a "From:" field in the
+  body of the patch mail if different. If set to a non-boolean value, format-patch uses that value
+  instead of your committer identity. Defaults to false.
+
+format.headers: |
+  Additional email headers to include in a patch to be submitted by mail. See `git-format-patch(1)`.
+
+format.mboxrd: |
+  A boolean value which enables the robust "mboxrd" format when `--stdout` is in use to escape
+  "^>+From " lines.
+
+format.noprefix: |
+  If set, do not show any source or destination prefix in patches. This is equivalent to the
+  `diff.noprefix` option used by `git diff` (but which is not respected by `format-patch`). Note
+  that by setting this, the receiver of any patches you generate will have to apply them using the
+  `-p0` option.
+
+format.notes: |
+  Provides the default value for the `--notes` option to format-patch. Accepts a boolean value, or a
+  ref which specifies where to get notes. If false, format-patch defaults to `--no-notes`. If true,
+  format-patch defaults to `--notes`. If set to a non-boolean value, format-patch defaults to
+  `--notes=<ref>`, where `ref` is the non-boolean value. Defaults to false.
+
+format.numbered: |
+  A boolean which can enable or disable sequence numbers in patch subjects. It defaults to "auto"
+  which enables it only if there is more than one patch. It can be enabled or disabled for all
+  messages by setting it to "true" or "false". See --numbered option in `git-format-patch(1)`.
+
+format.outputDirectory: |
+  Set a custom directory to store the resulting files instead of the current working directory. All
+  directory components will be created.
+
+format.signOff: |
+  A boolean value which lets you enable the `-s/--signoff` option of format-patch by default.
+  *Note:* Adding the `Signed-off-by` trailer to a patch should be a conscious act and means that you
+  certify you have the rights to submit this work under the same open source license. Please see the
+  'SubmittingPatches' document for further discussion.
+
+format.signature: |
+  The default for format-patch is to output a signature containing the Git version number. Use this
+  variable to change that default. Set this variable to the empty string ("") to suppress signature
+  generation.
+
+format.signatureFile: |
+  Works just like format.signature except the contents of the file specified by this variable will
+  be used as the signature.
+
+format.subjectPrefix: |
+  The default for format-patch is to output files with the '[PATCH]' subject prefix. Use this
+  variable to change that prefix.
+
+format.suffix: |
+  The default for format-patch is to output files with the suffix `.patch`. Use this variable to
+  change that suffix (make sure to include the dot if you want it).
+
+format.thread: |
+  The default threading style for 'git format-patch'. Can be a boolean value, or `shallow` or
+  `deep`. `shallow` threading makes every mail a reply to the head of the series, where the head is
+  chosen from the cover letter, the `--in-reply-to`, and the first patch mail, in this order. `deep`
+  threading makes every mail a reply to the previous one. A true boolean value is the same as
+  `shallow`, and a false value disables threading.
+
+format.useAutoBase: |
+  A boolean value which lets you enable the `--base=auto` option of format-patch by default. Can
+  also be set to "whenAble" to allow enabling `--base=auto` if a suitable base is available, but to
+  skip adding base info otherwise without the format dying.
+
+fsck.<msg-id>: |
+  During fsck git may find issues with legacy data which wouldn't be generated by current versions
+  of git, and which wouldn't be sent over the wire if `transfer.fsckObjects` was set. This feature
+  is intended to support working with legacy repositories containing such data.
+
+fsck.skipList: |
+  The path to a list of object names (i.e. one unabbreviated SHA-1 per line) that are known to be
+  broken in a non-fatal way and should be ignored. On versions of Git 2.20 and later, comments
+  ('#'), empty lines, and any leading and trailing whitespace are ignored. Everything but a SHA-1
+  per line will error out on older versions.
+
+gc.<pattern>.reflogExpire: |
+  'git reflog expire' removes reflog entries older than this time; defaults to 90 days. The value
+  "now" expires all entries immediately, and "never" suppresses expiration altogether. With
+  "<pattern>" (e.g. "refs/stash") in the middle the setting applies only to the refs that match the
+  <pattern>.
+
+gc.<pattern>.reflogExpireUnreachable: |
+  'git reflog expire' removes reflog entries older than this time and are not reachable from the
+  current tip; defaults to 30 days. The value "now" expires all entries immediately, and "never"
+  suppresses expiration altogether. With "<pattern>" (e.g. "refs/stash") in the middle, the setting
+  applies only to the refs that match the <pattern>.
+
+gc.aggressiveDepth: |
+  The depth parameter used in the delta compression algorithm used by 'git gc --aggressive'. This
+  defaults to 50, which is the default for the `--depth` option when `--aggressive` isn't in use.
+
+gc.aggressiveWindow: |
+  The window size parameter used in the delta compression algorithm used by 'git gc --aggressive'.
+  This defaults to 250, which is a much more aggressive window size than the default `--window` of
+  10.
+
+gc.auto: |
+  When there are approximately more than this many loose objects in the repository, `git gc --auto`
+  will pack them. Some Porcelain commands use this command to perform a light-weight garbage
+  collection from time to time. The default value is 6700.
+
+gc.autoDetach: |
+  Make `git gc --auto` return immediately and run in the background if the system supports it.
+  Default is true. This config variable acts as a fallback in case `maintenance.autoDetach` is not
+  set.
+
+gc.autoPackLimit: |
+  When there are more than this many packs that are not marked with `*.keep` file in the repository,
+  `git gc --auto` consolidates them into one larger pack. The default value is 50. Setting this to 0
+  disables it. Setting `gc.auto` to 0 will also disable this.
+
+gc.bigPackThreshold: |
+  If non-zero, all non-cruft packs larger than this limit are kept when `git gc` is run. This is
+  very similar to `--keep-largest-pack` except that all non-cruft packs that meet the threshold are
+  kept, not just the largest pack. Defaults to zero. Common unit suffixes of 'k', 'm', or 'g' are
+  supported.
+
+gc.cruftPacks: |
+  Store unreachable objects in a cruft pack (see `git-repack(1)`) instead of as loose objects. The
+  default is `true`.
+
+gc.logExpiry: |
+  If the file gc.log exists, then `git gc --auto` will print its content and exit with status zero
+  instead of running unless that file is more than 'gc.logExpiry' old. Default is "1.day". See
+  `gc.pruneExpire` for more ways to specify its value.
+
+gc.maxCruftSize: |
+  Limit the size of new cruft packs when repacking. When specified in addition to `--max-cruft-
+  size`, the command line option takes priority. See the `--max-cruft-size` option of `git-
+  repack(1)`.
+
+gc.packRefs: |
+  Running `git pack-refs` in a repository renders it unclonable by Git versions prior to 1.5.1.2
+  over dumb transports such as HTTP. This variable determines whether 'git gc' runs `git pack-refs`.
+  This can be set to `notbare` to enable it within all non-bare repos or it can be set to a boolean
+  value. The default is `true`.
+
+gc.pruneExpire: |
+  When 'git gc' is run, it will call 'prune --expire 2.weeks.ago' (and 'repack --cruft --cruft-
+  expiration 2.weeks.ago' if using cruft packs via `gc.cruftPacks` or `--cruft`). Override the grace
+  period with this config variable. The value "now" may be used to disable this grace period and
+  always prune unreachable objects immediately, or "never" may be used to suppress pruning. This
+  feature helps prevent corruption when 'git gc' runs concurrently with another process writing to
+  the repository; see the "NOTES" section of `git-gc(1)`.
+
+gc.recentObjectsHook: |
+  When considering whether or not to remove an object (either when generating a cruft pack or
+  storing unreachable objects as loose), use the shell to execute the specified command(s).
+  Interpret their output as object IDs which Git will consider as "recent", regardless of their age.
+  By treating their mtimes as "now", any objects (and their descendants) mentioned in the output
+  will be kept regardless of their true age.
+
+gc.repackFilter: |
+  When repacking, use the specified filter to move certain objects into a separate packfile. See the
+  `--filter=<filter-spec>` option of `git-repack(1)`.
+
+gc.repackFilterTo: |
+  When repacking and using a filter, see `gc.repackFilter`, the specified location will be used to
+  create the packfile containing the filtered out objects. **WARNING:** The specified location
+  should be accessible, using for example the Git alternates mechanism, otherwise the repo could be
+  considered corrupt by Git as it might not be able to access the objects in that packfile. See the
+  `--filter-to=<dir>` option of `git-repack(1)` and the `objects/info/alternates` section of
+  `gitrepository-layout(5)`.
+
+gc.rerereResolved: |
+  Records of conflicted merge you resolved earlier are kept for this many days when 'git rerere gc'
+  is run. You can also use more human-readable "1.month.ago", etc. The default is 60 days. See `git-
+  rerere(1)`.
+
+gc.rerereUnresolved: |
+  Records of conflicted merge you have not resolved are kept for this many days when 'git rerere gc'
+  is run. You can also use more human-readable "1.month.ago", etc. The default is 15 days. See `git-
+  rerere(1)`.
+
+gc.worktreePruneExpire: |
+  When 'git gc' is run, it calls 'git worktree prune --expire 3.months.ago'. This config variable
+  can be used to set a different grace period. The value "now" may be used to disable the grace
+  period and prune `$GIT_DIR/worktrees` immediately, or "never" may be used to suppress pruning.
+
+gc.writeCommitGraph: |
+  If true, then gc will rewrite the commit-graph file when `git-gc(1)` is run. When using `git gc
+  --auto` the commit-graph will be updated if housekeeping is required. Default is true. See `git-
+  commit-graph(1)` for details.
+
+gitcvs.allBinary: |
+  This is used if `gitcvs.usecrlfattr` does not resolve the correct '-kb' mode to use. If true, all
+  unresolved files are sent to the client in mode '-kb'. This causes the client to treat them as
+  binary files, which suppresses any newline munging it otherwise might do. Alternatively, if it is
+  set to "guess", then the contents of the file are examined to decide if it is binary, similar to
+  `core.autocrlf`.
+
+gitcvs.commitMsgAnnotation: |
+  Append this string to each commit message. Set to empty string to disable this feature. Defaults
+  to "via git-CVS emulator".
+
+gitcvs.dbDriver: |
+  Used Perl DBI driver. You can specify any available driver for this here, but it might not work.
+  git-cvsserver is tested with 'DBD::SQLite', reported to work with 'DBD::Pg', and reported *not* to
+  work with 'DBD::mysql'. Experimental feature. May not contain double colons (`:`). Default:
+  'SQLite'. See `git-cvsserver(1)`.
+
+gitcvs.dbName: |
+  Database used by git-cvsserver to cache revision information derived from the Git repository. The
+  exact meaning depends on the used database driver, for SQLite (which is the default driver) this
+  is a filename. Supports variable substitution (see `git-cvsserver(1)` for details). May not
+  contain semicolons (`;`). Default: '%Ggitcvs.%m.sqlite'
+
+gitcvs.dbPass: |
+  Database user and password. Only useful if setting `gitcvs.dbDriver`, since SQLite has no concept
+  of database users and/or passwords. 'gitcvs.dbUser' supports variable substitution (see `git-
+  cvsserver(1)` for details).
+
+gitcvs.dbTableNamePrefix: |
+  Database table name prefix. Prepended to the names of any database tables used, allowing a single
+  database to be used for several repositories. Supports variable substitution (see `git-
+  cvsserver(1)` for details). Any non-alphabetic characters will be replaced with underscores.
+
+gitcvs.enabled: |
+  Whether the CVS server interface is enabled for this repository. See `git-cvsserver(1)`.
+
+gitcvs.logFile: |
+  Path to a log file where the CVS server interface well... logs various stuff. See `git-
+  cvsserver(1)`.
+
+gitcvs.usecrlfattr: |
+  If true, the server will look up the end-of-line conversion attributes for files to determine the
+  `-k` modes to use. If the attributes force Git to treat a file as text, the `-k` mode will be left
+  blank so CVS clients will treat it as text. If they suppress text conversion, the file will be set
+  with '-kb' mode, which suppresses any newline munging the client might otherwise do. If the
+  attributes do not allow the file type to be determined, then `gitcvs.allBinary` is used. See
+  `gitattributes(5)`.
+
+gitweb.snapshot: |
+  See `gitweb.conf(5)` for description.
+
+gitweb.url: |
+  See `gitweb(1)` for description.
+
+gpg.<format>.program: |
+  Use this to customize the program used for the signing format you chose. (see `gpg.program` and
+  `gpg.format`) `gpg.program` can still be used as a legacy synonym for `gpg.openpgp.program`. The
+  default value for `gpg.x509.program` is "gpgsm" and `gpg.ssh.program` is "ssh-keygen".
+
+gpg.format: |
+  Specifies which key format to use when signing with `--gpg-sign`. Default is "openpgp". Other
+  possible values are "x509", "ssh".
+
+gpg.minTrustLevel: |
+  Specifies a minimum trust level for signature verification. If this option is unset, then
+  signature verification for merge operations requires a key with at least `marginal` trust. Other
+  operations that perform signature verification require a key with at least `undefined` trust.
+  Setting this option overrides the required trust-level for all operations. Supported values, in
+  increasing order of significance:
+
+gpg.program: |
+  Pathname of the program to use instead of "`gpg`" when making or verifying a PGP signature. The
+  program must support the same command-line interface as GPG, namely, to verify a detached
+  signature, "`gpg --verify $signature - <$file`" is run, and the program is expected to signal a
+  good signature by exiting with code 0. To generate an ASCII-armored detached signature, the
+  standard input of "`gpg -bsau $key`" is fed with the contents to be signed, and the program is
+  expected to send the result to its standard output.
+
+gpg.ssh.allowedSignersFile: |
+  A file containing ssh public keys which you are willing to trust. The file consists of one or more
+  lines of principals followed by an ssh public key. e.g.: `user1@example.com,user2@example.com ssh-
+  rsa AAAAX1...` See ssh-keygen(1) "ALLOWED SIGNERS" for details. The principal is only used to
+  identify the key and is available when verifying a signature.
+
+gpg.ssh.defaultKeyCommand: |
+  This command will be run when user.signingkey is not set and a ssh signature is requested. On
+  successful exit a valid ssh public key prefixed with `key::` is expected in the first line of its
+  output. This allows for a script doing a dynamic lookup of the correct public key when it is
+  impractical to statically configure `user.signingKey`. For example when keys or SSH Certificates
+  are rotated frequently or selection of the right key depends on external factors unknown to git.
+
+gpg.ssh.revocationFile: |
+  Either a SSH KRL or a list of revoked public keys (without the principal prefix). See ssh-
+  keygen(1) for details. If a public key is found in this file then it will always be treated as
+  having trust level "never" and signatures will show as invalid.
+
+grep.column: |
+  If set to `true`, enable the `--column` option by default.
+
+grep.extendedRegexp: |
+  If set to `true`, enable `--extended-regexp` option by default. This option is ignored when the
+  `grep.patternType` option is set to a value other than `default`.
+
+grep.fallbackToNoIndex: |
+  If set to `true`, fall back to `git grep --no-index` if `git grep` is executed outside of a git
+  repository. Defaults to `false`.
+
+grep.fullName: |
+  If set to `true`, enable `--full-name` option by default.
+
+grep.lineNumber: |
+  If set to `true`, enable `-n` option by default.
+
+grep.patternType: |
+  Set the default matching behavior. Using a value of `basic`, `extended`, `fixed`, or `perl` will
+  enable the `--basic-regexp`, `--extended-regexp`, `--fixed-strings`, or `--perl-regexp` option
+  accordingly, while the value `default` will use the `grep.extendedRegexp` option to choose between
+  `basic` and `extended`.
+
+grep.threads: |
+  Number of grep worker threads to use. If unset (or set to 0), Git will use as many threads as the
+  number of logical cores available.
+
+gui.GCWarning: |
+  Determines whether `git-gui(1)` should prompt for garbage collection when git detects a large
+  number of loose objects in the repository. The default value is "true".
+
+gui.blamehistoryctx: |
+  Specifies the radius of history context in days to show in `gitk(1)` for the selected commit, when
+  the `Show History Context` menu item is invoked from 'git gui blame'. If this variable is set to
+  zero, the whole history is shown.
+
+gui.commitMsgWidth: |
+  Defines how wide the commit message window is in the `git-gui(1)`. "75" is the default.
+
+gui.copyBlameThreshold: |
+  Specifies the threshold to use in 'git gui blame' original location detection, measured in
+  alphanumeric characters. See the `git-blame(1)` manual for more information on copy detection.
+
+gui.diffContext: |
+  Specifies how many context lines should be used in calls to diff made by the `git-gui(1)`. The
+  default is "5".
+
+gui.displayUntracked: |
+  Determines if `git-gui(1)` shows untracked files in the file list. The default is "true".
+
+gui.encoding: |
+  Specifies the default character encoding to use for displaying of file contents in `git-gui(1)`
+  and `gitk(1)`. It can be overridden by setting the 'encoding' attribute for relevant files (see
+  `gitattributes(5)`). If this option is not set, the tools default to the locale encoding.
+
+gui.fastCopyBlame: |
+  If true, 'git gui blame' uses `-C` instead of `-C -C` for original location detection. It makes
+  blame significantly faster on huge repositories at the expense of less thorough copy detection.
+
+gui.matchTrackingBranch: |
+  Determines if new branches created with `git-gui(1)` should default to tracking remote branches
+  with matching names or not. Default: "false".
+
+gui.newBranchTemplate: |
+  Is used as a suggested name when creating new branches using the `git-gui(1)`.
+
+gui.pruneDuringFetch: |
+  "true" if `git-gui(1)` should prune remote-tracking branches when performing a fetch. The default
+  value is "false".
+
+gui.spellingDictionary: |
+  Specifies the dictionary used for spell checking commit messages in the `git-gui(1)`. When set to
+  "none" spell checking is turned off.
+
+gui.trustmtime: |
+  Determines if `git-gui(1)` should trust the file modification timestamp or not. By default the
+  timestamps are not trusted.
+
+guitool.<name>.argPrompt: |
+  Request a string argument from the user, and pass it to the tool through the `ARGS` environment
+  variable. Since requesting an argument implies confirmation, the 'confirm' option has no effect if
+  this is enabled. If the option is set to 'true', 'yes', or '1', the dialog uses a built-in generic
+  prompt; otherwise the exact value of the variable is used.
+
+guitool.<name>.cmd: |
+  Specifies the shell command line to execute when the corresponding item of the `git-gui(1)`
+  `Tools` menu is invoked. This option is mandatory for every tool. The command is executed from the
+  root of the working directory, and in the environment it receives the name of the tool as
+  `GIT_GUITOOL`, the name of the currently selected file as 'FILENAME', and the name of the current
+  branch as 'CUR_BRANCH' (if the head is detached, 'CUR_BRANCH' is empty).
+
+guitool.<name>.confirm: |
+  Show a confirmation dialog before actually running the tool.
+
+guitool.<name>.needsFile: |
+  Run the tool only if a diff is selected in the GUI. It guarantees that 'FILENAME' is not empty.
+
+guitool.<name>.noConsole: |
+  Run the command silently, without creating a window to display its output.
+
+guitool.<name>.noRescan: |
+  Don't rescan the working directory for changes after the tool finishes execution.
+
+guitool.<name>.prompt: |
+  Specifies the general prompt string to display at the top of the dialog, before subsections for
+  'argPrompt' and 'revPrompt'. The default value includes the actual command.
+
+guitool.<name>.revPrompt: |
+  Request a single valid revision from the user, and set the `REVISION` environment variable. In
+  other aspects this option is similar to 'argPrompt', and can be used together with it.
+
+guitool.<name>.revUnmerged: |
+  Show only unmerged branches in the 'revPrompt' subdialog. This is useful for tools similar to
+  merge or rebase, but not for things like checkout or reset.
+
+guitool.<name>.title: |
+  Specifies the title to use for the prompt dialog. The default is the tool name.
+
+help.autoCorrect: |
+  If git detects typos and can identify exactly one valid command similar to the error, git will try
+  to suggest the correct command or even run the suggestion automatically. Possible config values
+  are: - 0, "false", "off", "no", "show": show the suggested command (default). - 1, "true", "on",
+  "yes", "immediate": run the suggested command
+
+help.browser: |
+  Specify the browser that will be used to display help in the 'web' format. See `git-help(1)`.
+
+help.format: |
+  Override the default help format used by `git-help(1)`. Values 'man', 'info', 'web' and 'html' are
+  supported. 'man' is the default. 'web' and 'html' are the same.
+
+help.htmlPath: |
+  Specify the path where the HTML documentation resides. File system paths and URLs are supported.
+  HTML pages will be prefixed with this path when help is displayed in the 'web' format. This
+  defaults to the documentation path of your Git installation.
+
+hook.<event>.enabled: |
+  Switch to enable or disable all hooks for the `<event>` hook event. When set to `false`, no hooks
+  fire for that event, regardless of any per-hook `hook.<friendly-name>.enabled` settings. Defaults
+  to `true`. {see-git-hook}
+
+hook.<event>.jobs: |
+  Specifies how many hooks can be run simultaneously for the `<event>` hook event (e.g. `hook.post-
+  receive.jobs = 4`). Overrides `hook.jobs` for this specific event. The same parallelism
+  restrictions apply: this setting has no effect unless all configured hooks for the event have
+  `hook.<friendly-name>.parallel` set to `true`. Set to `-1` to use the number of available CPU
+  cores. Must be a positive integer or `-1`; zero is rejected with a warning. {see-git-hook}
+
+hook.<hook>.command: |
+  The command to execute for `hook.<friendly-name>`. `<friendly-name>` is a unique name that
+  identifies this hook. The hook events that trigger the command are configured with
+  `hook.<friendly-name>.event`. The value can be an executable path or a shell oneliner. If more
+  than one value is specified for the same `<friendly-name>`, only the last value parsed is used.
+  {see-git-hook}
+
+hook.<hook>.enabled: |
+  Whether the hook `hook.<friendly-name>` is enabled. Defaults to `true`. Set to `false` to disable
+  the hook without removing its configuration. This is particularly useful when a hook is defined in
+  a system or global config file and needs to be disabled for a specific repository. {see-git-hook}
+
+hook.<hook>.event: |
+  The hook events that trigger `hook.<friendly-name>`. The value is the name of a hook event, like
+  "pre-commit" or "update". (See `githooks(5)` for a complete list of hook events.) On the specified
+  event, the associated `hook.<friendly-name>.command` is executed. This is a multi-valued key. To
+  run `hook.<friendly-name>` on multiple events, specify the key more than once. An empty value
+  resets the list of events, clearing any previously defined events for `hook.<friendly-name>`.
+  {see-git-hook}
+
+hook.<hook>.parallel: |
+  Whether the hook `hook.<friendly-name>` may run in parallel with other hooks for the same event.
+  Defaults to `false`. Set to `true` only when the hook script is safe to run concurrently with
+  other hooks for the same event. If any hook for an event does not have this set to `true`, all
+  hooks for that event run sequentially regardless of `hook.jobs`. Only configured (named) hooks
+  need to declare this. Traditional hooks found in the hooks directory do not need to, and run in
+  parallel when the effective job count is greater than 1. {see-git-hook}
+
+hook.jobs: |
+  Specifies how many hooks can be run simultaneously during parallelized hook execution. If
+  unspecified, defaults to 1 (serial execution). Set to `-1` to use the number of available CPU
+  cores. Can be overridden on a per-event basis with `hook.<event>.jobs`. Some hooks always run
+  sequentially regardless of this setting because they operate on shared data and cannot safely be
+  parallelized:
+
+http.<url>.*: |
+  Any of the http.* options above can be applied selectively to some URLs. For a config key to match
+  a URL, each element of the config key is compared to that of the URL, in the following order:
+
+http.cookieFile: |
+  The pathname of a file containing previously stored cookie lines, which should be used in the Git
+  http session, if they match the server. The file format of the file to read cookies from should be
+  plain HTTP headers or the Netscape/Mozilla cookie file format (see `curl(1)`). Set it to an empty
+  string, to accept only new cookies from the server and send them back in successive requests
+  within same connection. NOTE that the file specified with http.cookieFile is used only as input
+  unless http.saveCookies is set.
+
+http.curloptResolve: |
+  Hostname resolution information that will be used first by libcurl when sending HTTP requests.
+  This information should be in one of the following formats: - [+]HOST:PORT:ADDRESS[,ADDRESS] -
+  -HOST:PORT
+
+http.delegation: |
+  Control GSSAPI credential delegation. The delegation is disabled by default in libcurl since
+  version 7.21.7. Set parameter to tell the server what it is allowed to delegate when it comes to
+  user credentials. Used with GSS/kerberos. Possible values are:
+
+http.emptyAuth: |
+  Attempt authentication without seeking a username or password. This can be used to attempt GSS-
+  Negotiate authentication without specifying a username in the URL, as libcurl normally requires a
+  username for authentication. Possible values are:
+
+http.extraHeader: |
+  Pass an additional HTTP header when communicating with a server. If more than one such entry
+  exists, all of them are added as extra headers. To allow overriding the settings inherited from
+  the system config, an empty value will reset the extra headers to the empty list.
+
+http.followRedirects: |
+  Whether git should follow HTTP redirects. If set to `true`, git will transparently follow any
+  redirect issued by a server it encounters. If set to `false`, git will treat all redirects as
+  errors. If set to `initial`, git will follow redirects only for the initial request to a remote,
+  but not for subsequent follow-up HTTP requests. Since git uses the redirected URL as the base for
+  the follow-up requests, this is generally sufficient. The default is `initial`.
+
+http.keepAliveCount: |
+  Specifies how many TCP keepalive probes to send before giving up and terminating the connection
+  (if supported by the OS). If unset, curl's default value is used. Can be overridden by the
+  `GIT_HTTP_KEEPALIVE_COUNT` environment variable.
+
+http.keepAliveIdle: |
+  Specifies how long in seconds to wait on an idle connection before sending TCP keepalive probes
+  (if supported by the OS). If unset, curl's default value is used. Can be overridden by the
+  `GIT_HTTP_KEEPALIVE_IDLE` environment variable.
+
+http.keepAliveInterval: |
+  Specifies how long in seconds to wait between TCP keepalive probes (if supported by the OS). If
+  unset, curl's default value is used. Can be overridden by the `GIT_HTTP_KEEPALIVE_INTERVAL`
+  environment variable.
+
+http.lowSpeedTime: |
+  If the HTTP transfer speed, in bytes per second, is less than 'http.lowSpeedLimit' for longer than
+  'http.lowSpeedTime' seconds, the transfer is aborted. Can be overridden by the
+  `GIT_HTTP_LOW_SPEED_LIMIT` and `GIT_HTTP_LOW_SPEED_TIME` environment variables.
+
+http.maxRequests: |
+  How many HTTP requests to launch in parallel. Can be overridden by the `GIT_HTTP_MAX_REQUESTS`
+  environment variable. Default is 5.
+
+http.maxRetries: |
+  Maximum number of times to retry after receiving HTTP 429 (Too Many Requests) responses. Set to 0
+  (the default) to disable retries. Can be overridden by the `GIT_HTTP_MAX_RETRIES` environment
+  variable. See also `http.retryAfter` and `http.maxRetryTime`.
+
+http.maxRetryTime: |
+  Maximum time in seconds to wait for a single retry attempt when handling HTTP 429 (Too Many
+  Requests) responses. If the server requests a delay (via Retry-After header) or if
+  `http.retryAfter` is configured with a value that exceeds this maximum, Git will fail immediately
+  rather than waiting. Default is 300 seconds (5 minutes). Can be overridden by the
+  `GIT_HTTP_MAX_RETRY_TIME` environment variable. See also `http.retryAfter` and `http.maxRetries`.
+
+http.minSessions: |
+  The number of curl sessions (counted across slots) to be kept across requests. They will not be
+  ended with curl_easy_cleanup() until http_cleanup() is invoked. If USE_CURL_MULTI is not defined,
+  this value will be capped at 1. Defaults to 1.
+
+http.noEPSV: |
+  A boolean which disables using of EPSV ftp command by curl. This can be helpful with some "poor"
+  ftp servers which don't support EPSV mode. Can be overridden by the `GIT_CURL_FTP_NO_EPSV`
+  environment variable. Default is false (curl will use EPSV).
+
+http.pinnedPubkey: |
+  Public key of the https service. It may either be the filename of a PEM or DER encoded public key
+  file or a string starting with 'sha256//' followed by the base64 encoded sha256 hash of the public
+  key. See also libcurl 'CURLOPT_PINNEDPUBLICKEY'. git will exit with an error if this option is set
+  but not supported by cURL.
+
+http.postBuffer: |
+  Maximum size in bytes of the buffer used by smart HTTP transports when POSTing data to the remote
+  system. For requests larger than this buffer size, HTTP/1.1 and Transfer-Encoding: chunked is used
+  to avoid creating a massive pack file locally. Default is 1 MiB, which is sufficient for most
+  requests.
+
+http.proactiveAuth: |
+  Attempt authentication without first making an unauthenticated attempt and receiving a 401
+  response. This can be used to ensure that all requests are authenticated. If `http.emptyAuth` is
+  set to true, this value has no effect.
+
+http.proxy: |
+  Override the HTTP proxy, normally configured using the 'http_proxy', 'https_proxy', and
+  'all_proxy' environment variables (see `curl(1)`). In addition to the syntax understood by curl,
+  it is possible to specify a proxy string with a user name but no password, in which case git will
+  attempt to acquire one in the same way it does for other credentials. See `gitcredentials(7)` for
+  more information. The syntax thus is '[protocol://][user[:password]@]proxyhost[:port][/path]'.
+  This can be overridden on a per-remote basis; see remote.<name>.proxy
+
+http.proxyAuthMethod: |
+  Set the method with which to authenticate against the HTTP proxy. This only takes effect if the
+  configured proxy string contains a user name part (i.e. is of the form 'user@host' or
+  'user@host:port'). This can be overridden on a per-remote basis; see
+  `remote.<name>.proxyAuthMethod`. Both can be overridden by the `GIT_HTTP_PROXY_AUTHMETHOD`
+  environment variable. Possible values are:
+
+http.proxySSLCAInfo: |
+  Pathname to the file containing the certificate bundle that should be used to verify the proxy
+  with when using an HTTPS proxy. Can be overridden by the `GIT_PROXY_SSL_CAINFO` environment
+  variable.
+
+http.proxySSLCert: |
+  The pathname of a file that stores a client certificate to use to authenticate with an HTTPS
+  proxy. Can be overridden by the `GIT_PROXY_SSL_CERT` environment variable.
+
+http.proxySSLCertPasswordProtected: |
+  Enable Git's password prompt for the proxy SSL certificate. Otherwise OpenSSL will prompt the
+  user, possibly many times, if the certificate or private key is encrypted. Can be overridden by
+  the `GIT_PROXY_SSL_CERT_PASSWORD_PROTECTED` environment variable.
+
+http.proxySSLKey: |
+  The pathname of a file that stores a private key to use to authenticate with an HTTPS proxy. Can
+  be overridden by the `GIT_PROXY_SSL_KEY` environment variable.
+
+http.retryAfter: |
+  Default wait time in seconds before retrying when a server returns HTTP 429 (Too Many Requests)
+  without a Retry-After header. Defaults to 0 (retry immediately). When a Retry-After header is
+  present, its value takes precedence over this setting; however, automatic use of the server-
+  provided `Retry-After` header requires libcurl 7.66.0 or later. On older versions, configure this
+  setting manually to control the retry delay. Can be overridden by the `GIT_HTTP_RETRY_AFTER`
+  environment variable. See also `http.maxRetries` and `http.maxRetryTime`.
+
+http.saveCookies: |
+  If set, store cookies received during requests to the file specified by http.cookieFile. Has no
+  effect if http.cookieFile is unset, or set to an empty string.
+
+http.schannelCheckRevoke: |
+  Used to enforce or disable certificate revocation checks in cURL when http.sslBackend is set to
+  "schannel". Defaults to `true` if unset. Only necessary to disable this if Git consistently errors
+  and the message is about checking the revocation status of a certificate. This option is ignored
+  if cURL lacks support for setting the relevant SSL option at runtime.
+
+http.schannelUseSSLCAInfo: |
+  As of cURL v7.60.0, the Secure Channel backend can use the certificate bundle provided via
+  `http.sslCAInfo`, but that would override the Windows Certificate Store. Since this is not
+  desirable by default, Git will tell cURL not to use that bundle by default when the `schannel`
+  backend was configured via `http.sslBackend`, unless `http.schannelUseSSLCAInfo` overrides this
+  behavior.
+
+http.sslBackend: |
+  Name of the SSL backend to use (e.g. "openssl" or "schannel"). This option is ignored if cURL
+  lacks support for choosing the SSL backend at runtime.
+
+http.sslCAInfo: |
+  File containing the certificates to verify the peer with when fetching or pushing over HTTPS. Can
+  be overridden by the `GIT_SSL_CAINFO` environment variable.
+
+http.sslCAPath: |
+  Path containing files with the CA certificates to verify the peer with when fetching or pushing
+  over HTTPS. Can be overridden by the `GIT_SSL_CAPATH` environment variable.
+
+http.sslCert: |
+  File containing the SSL certificate when fetching or pushing over HTTPS. Can be overridden by the
+  `GIT_SSL_CERT` environment variable.
+
+http.sslCertPasswordProtected: |
+  Enable Git's password prompt for the SSL certificate. Otherwise OpenSSL will prompt the user,
+  possibly many times, if the certificate or private key is encrypted. Can be overridden by the
+  `GIT_SSL_CERT_PASSWORD_PROTECTED` environment variable.
+
+http.sslCertType: |
+  Type of client certificate used when fetching or pushing over HTTPS. "PEM", "DER" are supported
+  when using openssl or gnutls backends. "P12" is supported on "openssl", "schannel",
+  "securetransport", and gnutls 8.11+. See also libcurl `CURLOPT_SSLCERTTYPE`. Can be overridden by
+  the `GIT_SSL_CERT_TYPE` environment variable.
+
+http.sslKey: |
+  File containing the SSL private key when fetching or pushing over HTTPS. Can be overridden by the
+  `GIT_SSL_KEY` environment variable.
+
+http.sslKeyType: |
+  Type of client private key used when fetching or pushing over HTTPS. (e.g. "PEM", "DER", or
+  "ENG"). Only applicable when using "openssl" backend. "DER" is not supported with openssl.
+  Particularly useful when set to "ENG" for authenticating with PKCS#11 tokens, with a PKCS#11 URL
+  in sslCert option. See also libcurl `CURLOPT_SSLKEYTYPE`. Can be overridden by the
+  `GIT_SSL_KEY_TYPE` environment variable.
+
+http.sslTry: |
+  Attempt to use AUTH SSL/TLS and encrypted data transfers when connecting via regular FTP protocol.
+  This might be needed if the FTP server requires it for security reasons or you wish to connect
+  securely whenever remote FTP server supports it. Default is false since it might trigger
+  certificate verification errors on misconfigured servers.
+
+http.sslVerify: |
+  Whether to verify the SSL certificate when fetching or pushing over HTTPS. Defaults to true. Can
+  be overridden by the `GIT_SSL_NO_VERIFY` environment variable.
+
+http.sslVersion: |
+  The SSL version to use when negotiating an SSL connection, if you want to force the default. The
+  available and default version depend on whether libcurl was built against NSS or OpenSSL and the
+  particular configuration of the crypto library in use. Internally this sets the
+  'CURLOPT_SSL_VERSION' option; see the libcurl documentation for more details on the format of this
+  option and for the ssl version supported. Currently the possible values of this option are: -
+  sslv2 - sslv3 - tlsv1 - tlsv1.0 - tlsv1.1 - tlsv1.2 - tlsv1.3
+
+http.userAgent: |
+  The HTTP USER_AGENT string presented to an HTTP server. The default value represents the version
+  of the Git client such as git/1.7.1. This option allows you to override this value to a more
+  common value such as Mozilla/4.0. This may be necessary, for instance, if connecting through a
+  firewall that restricts HTTP connections to a set of common USER_AGENT strings (but not including
+  those like git/1.7.1). Can be overridden by the `GIT_HTTP_USER_AGENT` environment variable.
+
+http.version: |
+  Use the specified HTTP protocol version when communicating with a server. If you want to force the
+  default. The available and default version depend on libcurl. Currently the possible values of
+  this option are: - HTTP/2 - HTTP/1.1
+
+i18n.commitEncoding: |
+  Character encoding the commit messages are stored in; Git itself does not care per se, but this
+  information is necessary e.g. when importing commits from emails or in the gitk graphical history
+  browser (and possibly in other places in the future or in other porcelains). See e.g. `git-
+  mailinfo(1)`. Defaults to 'utf-8'.
+
+i18n.logOutputEncoding: |
+  Character encoding the commit messages are converted to when running 'git log' and friends.
+
+imap.authMethod: |
+  Specify the authentication method for authenticating with the IMAP server. If Git was built with
+  the NO_CURL option, or if your curl version is older than 7.34.0, or if you're running git-imap-
+  send with the `--no-curl` option, the only supported methods are `PLAIN`, `CRAM-MD5`,
+  `OAUTHBEARER` and `XOAUTH2`. If this is not set then `git imap-send` uses the basic IMAP plaintext
+  `LOGIN` command.
+
+imap.folder: |
+  The folder to drop the mails into, which is typically the Drafts folder. For example:
+  `INBOX.Drafts`, `INBOX/Drafts` or `[Gmail]/Drafts`. The IMAP folder to interact with MUST be
+  specified; the value of this configuration variable is used as the fallback default value when the
+  `--folder` option is not given.
+
+imap.host: |
+  A URL identifying the server. Use an `imap://` prefix for non-secure connections and an `imaps://`
+  prefix for secure connections. Ignored when `imap.tunnel` is set, but required otherwise.
+
+imap.pass: |
+  The password to use when logging in to the server.
+
+imap.port: |
+  An integer port number to connect to on the server. Defaults to 143 for `imap://` hosts and 993
+  for `imaps://` hosts. Ignored when `imap.tunnel` is set.
+
+imap.preformattedHTML: |
+  A boolean to enable/disable the use of html encoding when sending a patch. An html encoded patch
+  will be bracketed with `<pre>` and have a content type of text/html. Ironically, enabling this
+  option causes Thunderbird to send the patch as a plain/text, format=fixed email. Default is
+  `false`.
+
+imap.sslverify: |
+  A boolean to enable/disable verification of the server certificate used by the SSL/TLS connection.
+  Default is `true`. Ignored when `imap.tunnel` is set.
+
+imap.tunnel: |
+  Command used to set up a tunnel to the IMAP server through which commands will be piped instead of
+  using a direct network connection to the server. Required when `imap.host` is not set.
+
+imap.user: |
+  The username to use when logging in to the server.
+
+includeIf.<condition>.path: |
+  Special variables to include other configuration files. See the "CONFIGURATION FILE" section in
+  the main `git-config(1)` documentation, specifically the "Includes" and "Conditional Includes"
+  subsections.
+
+index.recordEndOfIndexEntries: |
+  Specifies whether the index file should include an "End Of Index Entry" section. This reduces
+  index load time on multiprocessor machines but produces a message "ignoring EOIE extension" when
+  reading the index using Git versions before 2.20. Defaults to 'true' if index.threads has been
+  explicitly enabled, 'false' otherwise.
+
+index.recordOffsetTable: |
+  Specifies whether the index file should include an "Index Entry Offset Table" section. This
+  reduces index load time on multiprocessor machines but produces a message "ignoring IEOT
+  extension" when reading the index using Git versions before 2.20. Defaults to 'true' if
+  index.threads has been explicitly enabled, 'false' otherwise.
+
+index.skipHash: |
+  When enabled, do not compute the trailing hash for the index file. This accelerates Git commands
+  that manipulate the index, such as `git add`, `git commit`, or `git status`. Instead of storing
+  the checksum, write a trailing set of bytes with value zero, indicating that the computation was
+  skipped.
+
+index.sparse: |
+  When enabled, write the index using sparse-directory entries. This has no effect unless
+  `core.sparseCheckout` and `core.sparseCheckoutCone` are both enabled. Defaults to 'false'.
+
+index.threads: |
+  Specifies the number of threads to spawn when loading the index. This is meant to reduce index
+  load time on multiprocessor machines. Specifying 0 or 'true' will cause Git to auto-detect the
+  number of CPUs and set the number of threads accordingly. Specifying 1 or 'false' will disable
+  multithreading. Defaults to 'true'.
+
+index.version: |
+  Specify the version with which new index files should be initialized. This does not affect
+  existing repositories. If `feature.manyFiles` is enabled, then the default is 4.
+
+init.defaultBranch: |
+  Allows overriding the default branch name e.g. when initializing a new repository.
+
+init.defaultObjectFormat: |
+  Allows overriding the default object format for new repositories. See `--object-format=` in `git-
+  init(1)`. Both the command line option and the `GIT_DEFAULT_HASH` environment variable take
+  precedence over this config.
+
+init.defaultRefFormat: |
+  Allows overriding the default ref storage format for new repositories. See `--ref-format=` in
+  `git-init(1)`. Both the command line option and the `GIT_DEFAULT_REF_FORMAT` environment variable
+  take precedence over this config.
+
+init.defaultSubmodulePathConfig: |
+  A boolean that specifies if `git init` and `git clone` should automatically set
+  `extensions.submodulePathConfig` to `true`. This allows all new repositories to automatically use
+  the submodule path extension. Defaults to `false` when unset.
+
+init.templateDir: |
+  Specify the directory from which templates will be copied. {see-git-init}
+
+instaweb.browser: |
+  Specify the program that will be used to browse your working repository in gitweb. See `git-
+  instaweb(1)`.
+
+instaweb.httpd: |
+  The HTTP daemon command-line to start gitweb on your working repository. See `git-instaweb(1)`.
+
+instaweb.local: |
+  If true the web server started by `git-instaweb(1)` will be bound to the local IP (127.0.0.1).
+
+instaweb.modulePath: |
+  The default module path for `git-instaweb(1)` to use instead of /usr/lib/apache2/modules. Only
+  used if httpd is Apache.
+
+instaweb.port: |
+  The port number to bind the gitweb httpd to. See `git-instaweb(1)`.
+
+interactive.diffFilter: |
+  When an interactive command (such as `git add --patch`) shows a colorized diff, git will pipe the
+  diff through the shell command defined by this configuration variable. The command may mark up the
+  diff further for human consumption, provided that it retains a one-to-one correspondence with the
+  lines in the original diff. Defaults to disabled (no filtering).
+
+interactive.singleKey: |
+  When set to true, allow the user to provide one-letter input with a single key (i.e., without
+  hitting the Enter key) in interactive commands. This is currently used by the `--patch` mode of
+  `git-add(1)`, `git-checkout(1)`, `git-restore(1)`, `git-commit(1)`, `git-reset(1)`, and `git-
+  stash(1)`.
+
+log.abbrevCommit: |
+  If `true`, make
+
+log.date: |
+  Set the default date-time mode for the `log` command. Setting a value for log.date is similar to
+  using `git log`'s `--date` option. See `git-log(1)` for details.
+
+log.decorate: |
+  Print out the ref names of any commits that are shown by the log command. Possible values are:
+
+log.diffMerges: |
+  Set diff format to be used when `--diff-merges=on` is specified, see `--diff-merges` in `git-
+  log(1)` for details. Defaults to `separate`.
+
+log.excludeDecoration: |
+  Exclude the specified patterns from the log decorations. This is similar to the `--decorate-refs-
+  exclude` command-line option, but the config option can be overridden by the `--decorate-refs`
+  option.
+
+log.follow: |
+  If `true`, `git log` will act as if the `--follow` option was used when a single <path> is given.
+  This has the same limitations as `--follow`, i.e. it cannot be used to follow multiple files and
+  does not work well on non-linear history.
+
+log.graphColors: |
+  A list of colors, separated by commas, that can be used to draw history lines in `git log
+  --graph`.
+
+log.initialDecorationSet: |
+  By default, `git log` only shows decorations for certain known ref namespaces. If 'all' is
+  specified, then show all refs as decorations.
+
+log.mailmap: |
+  If true, makes `git-log(1)`, `git-show(1)`, and `git-whatchanged(1)` assume `--use-mailmap`,
+  otherwise assume `--no-use-mailmap`. True by default.
+
+log.showRoot: |
+  If true, the initial commit will be shown as a big creation event. This is equivalent to a diff
+  against an empty tree. Tools like `git-log(1)` or `git-whatchanged(1)`, which normally hide the
+  root commit will now show it. True by default.
+
+log.showSignature: |
+  If true, makes `git-log(1)`, `git-show(1)`, and `git-whatchanged(1)` assume `--show-signature`.
+
+lsrefs.unborn: |
+  May be "advertise" (the default), "allow", or "ignore". If "advertise", the server will respond to
+  the client sending "unborn" (as described in `gitprotocol-v2(5)`) and will advertise support for
+  this feature during the protocol v2 capability advertisement. "allow" is the same as "advertise"
+  except that the server will not advertise support for this feature; this is useful for load-
+  balanced servers that cannot be updated atomically (for example), since the administrator could
+  configure "allow", then after a delay, configure "advertise".
+
+mailinfo.scissors: |
+  If true, makes `git-mailinfo(1)` (and therefore `git-am(1)`) act by default as if the --scissors
+  option was provided on the command-line. When active, this feature removes everything from the
+  message body before a scissors line (i.e. consisting mainly of ">8", "8<" and "-").
+
+mailmap.blob: |
+  Like `mailmap.file`, but consider the value as a reference to a blob in the repository. If both
+  `mailmap.file` and `mailmap.blob` are given, both are parsed, with entries from `mailmap.file`
+  taking precedence. In a bare repository, this defaults to `HEAD:.mailmap`. In a non-bare
+  repository, it defaults to empty.
+
+mailmap.file: |
+  The location of an augmenting mailmap file. The default mailmap, located in the root of the
+  repository, is loaded first, then the mailmap file pointed to by this variable. The location of
+  the mailmap file may be in a repository subdirectory, or somewhere outside of the repository
+  itself. See `git-shortlog(1)` and `git-blame(1)`.
+
+maintenance.<task>.enabled: |
+  This boolean config option controls whether the maintenance task with name `<task>` is run when no
+  `--task` option is specified to `git maintenance run`. These config values are ignored if a
+  `--task` option exists. By default, only `maintenance.gc.enabled` is true.
+
+maintenance.<task>.schedule: |
+  This config option controls whether or not the given `<task>` runs during a `git maintenance run
+  --schedule=<frequency>` command. The value must be one of "hourly", "daily", or "weekly".
+
+maintenance.auto: |
+  This boolean config option controls whether some commands run `git maintenance run --auto` after
+  doing their normal work. Defaults to true.
+
+maintenance.autoDetach: |
+  Many Git commands trigger automatic maintenance after they have written data into the repository.
+  This boolean config option controls whether this automatic maintenance shall happen in the
+  foreground or whether the maintenance process shall detach and continue to run in the background.
+
+maintenance.commit-graph.auto: |
+  This integer config option controls how often the `commit-graph` task should be run as part of
+  `git maintenance run --auto`. If zero, then the `commit-graph` task will not run with the `--auto`
+  option. A negative value will force the task to run every time. Otherwise, a positive value
+  implies the command should run when the number of reachable commits that are not in the commit-
+  graph file is at least the value of `maintenance.commit-graph.auto`. The default value is 100.
+
+maintenance.geometric-repack.auto: |
+  This integer config option controls how often the `geometric-repack` task should be run as part of
+  `git maintenance run --auto`. If zero, then the `geometric-repack` task will not run with the
+  `--auto` option. A negative value will force the task to run every time. Otherwise, a positive
+  value implies the command should run either when there are packfiles that need to be merged
+  together to retain the geometric progression, or when there are at least this many loose objects
+  that would be written into a new packfile. The default value is 100.
+
+maintenance.geometric-repack.splitFactor: |
+  This integer config option controls the factor used for the geometric sequence. See the
+  `--geometric=` option in `git-repack(1)` for more details. Defaults to `2`.
+
+maintenance.incremental-repack.auto: |
+  This integer config option controls how often the `incremental-repack` task should be run as part
+  of `git maintenance run --auto`. If zero, then the `incremental-repack` task will not run with the
+  `--auto` option. A negative value will force the task to run every time. Otherwise, a positive
+  value implies the command should run when the number of pack-files not in the multi-pack-index is
+  at least the value of `maintenance.incremental-repack.auto`. The default value is 10.
+
+maintenance.loose-objects.auto: |
+  This integer config option controls how often the `loose-objects` task should be run as part of
+  `git maintenance run --auto`. If zero, then the `loose-objects` task will not run with the
+  `--auto` option. A negative value will force the task to run every time. Otherwise, a positive
+  value implies the command should run when the number of loose objects is at least the value of
+  `maintenance.loose-objects.auto`. The default value is 100.
+
+maintenance.loose-objects.batchSize: |
+  This integer config option controls the maximum number of loose objects written into a packfile
+  during the `loose-objects` task. The default is fifty thousand. Use value `0` to indicate no
+  limit.
+
+maintenance.reflog-expire.auto: |
+  This integer config option controls how often the `reflog-expire` task should be run as part of
+  `git maintenance run --auto`. If zero, then the `reflog-expire` task will not run with the
+  `--auto` option. A negative value will force the task to run every time. Otherwise, a positive
+  value implies the command should run when the number of expired reflog entries in the "HEAD"
+  reflog is at least the value of `maintenance.loose-objects.auto`. The default value is 100.
+
+maintenance.rerere-gc.auto: |
+  This integer config option controls how often the `rerere-gc` task should be run as part of `git
+  maintenance run --auto`. If zero, then the `rerere-gc` task will not run with the `--auto` option.
+  A negative value will force the task to run every time. Otherwise, any positive value implies the
+  command will run when the "rr-cache" directory exists and has at least one entry, regardless of
+  whether it is stale or not. This heuristic may be refined in the future. The default value is 1.
+
+maintenance.strategy: |
+  This string config option provides a way to specify one of a few recommended strategies for
+  repository maintenance. This affects which tasks are run during `git maintenance run`, provided no
+  `--task=<task>` arguments are provided. This setting impacts manual maintenance, auto-maintenance
+  as well as scheduled maintenance. The tasks that run may be different depending on the maintenance
+  type.
+
+maintenance.worktree-prune.auto: |
+  This integer config option controls how often the `worktree-prune` task should be run as part of
+  `git maintenance run --auto`. If zero, then the `worktree-prune` task will not run with the
+  `--auto` option. A negative value will force the task to run every time. Otherwise, a positive
+  value implies the command should run when the number of prunable worktrees exceeds the value. The
+  default value is 1.
+
+man.<tool>.cmd: |
+  Specify the command to invoke the specified man viewer. The specified command is evaluated in
+  shell with the man page passed as an argument. (See `git-help(1)`.)
+
+man.<tool>.path: |
+  Override the path for the given tool that may be used to display help in the 'man' format. See
+  `git-help(1)`.
+
+man.viewer: |
+  Specify the programs that may be used to display help in the 'man' format. See `git-help(1)`.
+
+merge.<driver>.driver: |
+  Defines the command that implements a custom low-level merge driver. See `gitattributes(5)` for
+  details.
+
+merge.<driver>.name: |
+  Defines a human-readable name for a custom low-level merge driver. See `gitattributes(5)` for
+  details.
+
+merge.<driver>.recursive: |
+  Names a low-level merge driver to be used when performing an internal merge between common
+  ancestors. See `gitattributes(5)` for details.
+
+merge.autoStash: |
+  When set to `true`, automatically create a temporary stash entry before the operation begins, and
+  apply it after the operation ends. This means that you can run merge on a dirty worktree. However,
+  use with care: the final stash application after a successful merge might result in non-trivial
+  conflicts. This option can be overridden by the `--no-autostash` and `--autostash` options of
+  `git-merge(1)`. Defaults to `false`.
+
+merge.branchdesc: |
+  In addition to branch names, populate the log message with the branch description text associated
+  with them. Defaults to false.
+
+merge.conflictStyle: |
+  Specify the style in which conflicted hunks are written out to working tree files upon merge. The
+  default is "merge", which shows a +<<<<<<<+ conflict marker, changes made by one side, a `=======`
+  marker, changes made by the other side, and then a +>>>>>>>+ marker. An alternate style, "diff3",
+  adds a +|||||||+ marker and the original text before the `=======` marker. The "merge" style tends
+  to produce smaller conflict regions than diff3, both because of the exclusion of the original
+  text, and because when a subset of lines match on the two sides, they are just pulled out of the
+  conflict region. Another alternate style, "zdiff3", is similar to diff3 but removes matching lines
+  on the two sides from the conflict region when those matching lines appear near either the
+  beginning or end of a conflict region.
+
+merge.defaultToUpstream: |
+  If merge is called without any commit argument, merge the upstream branches configured for the
+  current branch by using their last observed values stored in their remote-tracking branches. The
+  values of the `branch.<current branch>.merge` that name the branches at the remote named by
+  `branch.<current-branch>.remote` are consulted, and then they are mapped via
+  `remote.<remote>.fetch` to their corresponding remote-tracking branches, and the tips of these
+  tracking branches are merged. Defaults to true.
+
+merge.directoryRenames: |
+  Whether Git detects directory renames, affecting what happens at merge time to new files added to
+  a directory on one side of history when that directory was renamed on the other side of history.
+  Possible values are:
+
+merge.ff: |
+  By default, Git does not create an extra merge commit when merging a commit that is a descendant
+  of the current commit. Instead, the tip of the current branch is fast-forwarded. When set to
+  `false`, this variable tells Git to create an extra merge commit in such a case (equivalent to
+  giving the `--no-ff` option from the command line). When set to `only`, only such fast-forward
+  merges are allowed (equivalent to giving the `--ff-only` option from the command line).
+
+merge.guitool: |
+  Controls which merge tool is used by `git-mergetool(1)` when the `-g`/`--gui` flag is specified.
+  The list below shows the valid built-in values. Any other value is treated as a custom merge tool
+  and requires that a corresponding `mergetool.<guitool>.cmd` variable is defined.
+
+merge.log: |
+  In addition to branch names, populate the log message with at most the specified number of one-
+  line descriptions from the actual commits that are being merged. Defaults to false, and true is a
+  synonym for 20.
+
+merge.renameLimit: |
+  The number of files to consider in the exhaustive portion of rename detection during a merge. If
+  not specified, defaults to the value of `diff.renameLimit`. If neither `merge.renameLimit` nor
+  `diff.renameLimit` are specified, currently defaults to 7000. This setting has no effect if rename
+  detection is turned off.
+
+merge.renames: |
+  Whether Git detects renames. If set to `false`, rename detection is disabled. If set to `true`,
+  basic rename detection is enabled. Defaults to the value of diff.renames.
+
+merge.renormalize: |
+  Tell Git that canonical representation of files in the repository has changed over time (e.g.
+  earlier commits record text files with _CRLF_ line endings, but recent ones use _LF_ line
+  endings). In such a repository, for each file where a three-way content merge is needed, Git can
+  convert the data recorded in commits to a canonical form before performing a merge to reduce
+  unnecessary conflicts. For more information, see section "Merging branches with differing
+  checkin/checkout attributes" in `gitattributes(5)`.
+
+merge.stat: |
+  What, if anything, to print between `ORIG_HEAD` and the merge result at the end of the merge.
+  Possible values are:
+
+merge.suppressDest: |
+  By adding a glob that matches the names of integration branches to this multi-valued configuration
+  variable, the default merge message computed for merges into these integration branches will omit
+  "into _<branch-name>_" from its title.
+
+merge.tool: |
+  Controls which merge tool is used by `git-mergetool(1)`. The list below shows the valid built-in
+  values. Any other value is treated as a custom merge tool and requires that a corresponding
+  `mergetool.<tool>.cmd` variable is defined.
+
+merge.verbosity: |
+  Controls the amount of output shown by the recursive merge strategy. Level 0 outputs nothing
+  except a final error message if conflicts were detected. Level 1 outputs only conflicts, 2 outputs
+  conflicts and file changes. Level 5 and above outputs debugging information. The default is level
+  2. Can be overridden by the `GIT_MERGE_VERBOSITY` environment variable.
+
+merge.verifySignatures: |
+  If true, this is equivalent to the `--verify-signatures` command line option. See `git-merge(1)`
+  for details.
+
+mergetool.<tool>.cmd: |
+  Specify the command to invoke the specified merge tool. The specified command is evaluated in
+  shell with the following variables available: `BASE` is the name of a temporary file containing
+  the common base of the files to be merged, if available; `LOCAL` is the name of a temporary file
+  containing the contents of the file on the current branch; `REMOTE` is the name of a temporary
+  file containing the contents of the file from the branch being merged; `MERGED` contains the name
+  of the file to which the merge tool should write the results of a successful merge.
+
+mergetool.<tool>.hideResolved: |
+  Allows the user to override the global `mergetool.hideResolved` value for a specific tool. See
+  `mergetool.hideResolved` for the full description.
+
+mergetool.<tool>.path: |
+  Override the path for the given tool. This is useful in case your tool is not in the `$PATH`.
+
+mergetool.<tool>.trustExitCode: |
+  For a custom merge command, specify whether the exit code of the merge command can be used to
+  determine whether the merge was successful. If this is not set to true then the merge target file
+  timestamp is checked, and the merge is assumed to have been successful if the file has been
+  updated; otherwise, the user is prompted to indicate the success of the merge.
+
+mergetool.<variant>.layout: |
+  Configure the split window layout for vimdiff's _<variant>_, which is any of `vimdiff`,
+  `nvimdiff`, `gvimdiff`. Upon launching `git mergetool` with `--tool=<variant>` (or without
+  `--tool` if `merge.tool` is configured as _<variant>_), Git will consult
+  `mergetool.<variant>.layout` to determine the tool's layout. If the variant-specific configuration
+  is not available, `vimdiff` ' s is used as fallback. If that too is not available, a default
+  layout with 4 windows will be used.
+
+mergetool.guiDefault: |
+  Set `true` to use the `merge.guitool` by default (equivalent to specifying the `--gui` argument),
+  or `auto` to select `merge.guitool` or `merge.tool` depending on the presence of a `DISPLAY`
+  environment variable value. The default is `false`, where the `--gui` argument must be provided
+  explicitly for the `merge.guitool` to be used.
+
+mergetool.hideResolved: |
+  During a merge, Git will automatically resolve as many conflicts as possible and write the
+  `$MERGED` file containing conflict markers around any conflicts that it cannot resolve; `$LOCAL`
+  and `$REMOTE` normally are the versions of the file from before Git's conflict resolution. This
+  flag causes `$LOCAL` and `$REMOTE` to be overwritten so that only the unresolved conflicts are
+  presented to the merge tool. Can be configured per-tool via the `mergetool.<tool>.hideResolved`
+  configuration variable. Defaults to `false`.
+
+mergetool.keepBackup: |
+  After performing a merge, the original file with conflict markers can be saved as a file with a
+  `.orig` extension. If this variable is set to `false` then this file is not preserved. Defaults to
+  `true` (i.e. keep the backup files).
+
+mergetool.keepTemporaries: |
+  When invoking a custom merge tool, Git uses a set of temporary files to pass to the tool. If the
+  tool returns an error and this variable is set to `true`, then these temporary files will be
+  preserved; otherwise, they will be removed after the tool has exited. Defaults to `false`.
+
+mergetool.meld.hasOutput: |
+  Older versions of `meld` do not support the `--output` option. Git will attempt to detect whether
+  `meld` supports `--output` by inspecting the output of `meld --help`. Configuring
+  `mergetool.meld.hasOutput` will make Git skip these checks and use the configured value instead.
+  Setting `mergetool.meld.hasOutput` to `true` tells Git to unconditionally use the `--output`
+  option, and `false` avoids using `--output`.
+
+mergetool.meld.useAutoMerge: |
+  When the `--auto-merge` is given, meld will merge all non-conflicting parts automatically,
+  highlight the conflicting parts, and wait for user decision. Setting `mergetool.meld.useAutoMerge`
+  to `true` tells Git to unconditionally use the `--auto-merge` option with `meld`. Setting this
+  value to `auto` makes git detect whether `--auto-merge` is supported and will only use `--auto-
+  merge` when available. A value of `false` avoids using `--auto-merge` altogether, and is the
+  default value.
+
+mergetool.prompt: |
+  Prompt before each invocation of the merge resolution program.
+
+mergetool.writeToTemp: |
+  Git writes temporary `BASE`, `LOCAL`, and `REMOTE` versions of conflicting files in the worktree
+  by default. Git will attempt to use a temporary directory for these files when set `true`.
+  Defaults to `false`.
+
+notes.<name>.mergeStrategy: |
+  Which merge strategy to choose when doing a notes merge into `refs/notes/<name>`. This overrides
+  the more general `notes.mergeStrategy`. See the "NOTES MERGE STRATEGIES" section in `git-notes(1)`
+  for more information on the available strategies.
+
+notes.displayRef: |
+  Which ref (or refs, if a glob or specified more than once), in addition to the default set by
+  `core.notesRef` or `GIT_NOTES_REF`, to read notes from when showing commit messages with the `git
+  log` family of commands.
+
+notes.mergeStrategy: |
+  Which merge strategy to choose by default when resolving notes conflicts. Must be one of `manual`,
+  `ours`, `theirs`, `union`, or `cat_sort_uniq`. Defaults to `manual`. See the "NOTES MERGE
+  STRATEGIES" section of `git-notes(1)` for more information on each strategy.
+
+notes.rewrite.<command>: |
+  When rewriting commits with _<command>_ (currently `amend` or `rebase`), if this variable is
+  `false`, git will not copy notes from the original to the rewritten commit. Defaults to `true`.
+  See also `notes.rewriteRef` below.
+
+notes.rewriteMode: |
+  When copying notes during a rewrite (see the `notes.rewrite.<command>` option), determines what to
+  do if the target commit already has a note. Must be one of `overwrite`, `concatenate`,
+  `cat_sort_uniq`, or `ignore`. Defaults to `concatenate`.
+
+notes.rewriteRef: |
+  When copying notes during a rewrite, specifies the (fully qualified) ref whose notes should be
+  copied. May be a glob, in which case notes in all matching refs will be copied. You may also
+  specify this configuration several times.
+
+pack.allowPackReuse: |
+  When true or "single", and when reachability bitmaps are enabled, pack-objects will try to send
+  parts of the bitmapped packfile verbatim. When "multi", and when a multi-pack reachability bitmap
+  is available, pack-objects will try to send parts of all packs in the MIDX.
+
+pack.compression: |
+  An integer -1..9, indicating the compression level for objects in a pack file. -1 is the zlib
+  default. 0 means no compression, and 1..9 are various speed/size tradeoffs, 9 being slowest. If
+  not set, defaults to core.compression. If that is not set, defaults to -1, the zlib default, which
+  is "a default compromise between speed and compression (currently equivalent to level 6)."
+
+pack.deltaCacheLimit: |
+  The maximum size of a delta, that is cached in `git-pack-objects(1)`. This cache is used to speed
+  up the writing object phase by not having to recompute the final delta result once the best match
+  for all objects is found. Defaults to 1000. Maximum value is 65535.
+
+pack.deltaCacheSize: |
+  The maximum memory in bytes used for caching deltas in `git-pack-objects(1)` before writing them
+  out to a pack. This cache is used to speed up the writing object phase by not having to recompute
+  the final delta result once the best match for all objects is found. Repacking large repositories
+  on machines which are tight with memory might be badly impacted by this though, especially if this
+  cache pushes the system into swapping. A value of 0 means no limit. The smallest size of 1 byte
+  may be used to virtually disable this cache. Defaults to 256 MiB.
+
+pack.depth: |
+  The maximum delta depth used by `git-pack-objects(1)` when no maximum depth is given on the
+  command line. Defaults to 50. Maximum value is 4095.
+
+pack.indexVersion: |
+  Specify the default pack index version. Valid values are 1 for legacy pack index used by Git
+  versions prior to 1.5.2, and 2 for the new pack index with capabilities for packs larger than 4 GB
+  as well as proper protection against the repacking of corrupted packs. Version 2 is the default.
+  Note that version 2 is enforced and this config option is ignored whenever the corresponding pack
+  is larger than 2 GB.
+
+pack.island: |
+  An extended regular expression configuring a set of delta islands. See "DELTA ISLANDS" in `git-
+  pack-objects(1)` for details.
+
+pack.islandCore: |
+  Specify an island name which gets to have its objects be packed first. This creates a kind of
+  pseudo-pack at the front of one pack, so that the objects from the specified island are hopefully
+  faster to copy into any pack that should be served to a user requesting these objects. In practice
+  this means that the island specified should likely correspond to what is the most commonly cloned
+  in the repo. See also "DELTA ISLANDS" in `git-pack-objects(1)`.
+
+pack.packSizeLimit: |
+  The maximum size of a pack. This setting only affects packing to a file when repacking, i.e. the
+  git:// protocol is unaffected. It can be overridden by the `--max-pack-size` option of `git-
+  repack(1)`. Reaching this limit results in the creation of multiple packfiles.
+
+pack.preferBitmapTips: |
+  Specifies a ref hierarchy (e.g., "refs/heads/"); can be given multiple times to specify more than
+  one hierarchy. When selecting which commits will receive bitmaps, prefer a commit at the tip of a
+  reference that is contained in any of the configured hierarchies.
+
+pack.readReverseIndex: |
+  When true, git will read any .rev file(s) that may be available (see: `gitformat-pack(5)`). When
+  false, the reverse index will be generated from scratch and stored in memory. Defaults to true.
+
+pack.threads: |
+  Specifies the number of threads to spawn when searching for best delta matches. This requires that
+  `git-pack-objects(1)` be compiled with pthreads otherwise this option is ignored with a warning.
+  This is meant to reduce packing time on multiprocessor machines. The required amount of memory for
+  the delta search window is however multiplied by the number of threads. Specifying 0 will cause
+  Git to auto-detect the number of CPUs and set the number of threads accordingly.
+
+pack.useBitmapBoundaryTraversal: |
+  When true, Git will use an experimental algorithm for computing reachability queries with bitmaps.
+  Instead of building up complete bitmaps for all of the negated tips and then OR-ing them together,
+  consider negated tips with existing bitmaps as additive (i.e. OR-ing them into the result if they
+  exist, ignoring them otherwise), and build up a bitmap at the boundary instead.
+
+pack.useBitmaps: |
+  When true, git will use pack bitmaps (if available) when packing to stdout (e.g., during the
+  server side of a fetch). Defaults to true. You should not generally need to turn this off unless
+  you are debugging pack bitmaps.
+
+pack.usePathWalk: |
+  Enable the `--path-walk` option by default for `git pack-objects` processes. See `git-pack-
+  objects(1)` for full details.
+
+pack.useSparse: |
+  When true, git will default to using the '--sparse' option in 'git pack-objects' when the '--revs'
+  option is present. This algorithm only walks trees that appear in paths that introduce new
+  objects. This can have significant performance benefits when computing a pack to send a small
+  change. However, it is possible that extra objects are added to the pack-file if the included
+  commits contain certain types of direct renames. Default is `true`.
+
+pack.window: |
+  The size of the window used by `git-pack-objects(1)` when no window size is given on the command
+  line. Defaults to 10.
+
+pack.windowMemory: |
+  The maximum size of memory that is consumed by each thread in `git-pack-objects(1)` for pack
+  window memory when no limit is given on the command line. The value can be suffixed with "k", "m",
+  or "g". When left unconfigured (or set explicitly to 0), there will be no limit.
+
+pack.writeBitmapHashCache: |
+  When true, git will include a "hash cache" section in the bitmap index (if one is written). This
+  cache can be used to feed git's delta heuristics, potentially leading to better deltas between
+  bitmapped and non-bitmapped objects (e.g., when serving a fetch between an older, bitmapped pack
+  and objects that have been pushed since the last gc). The downside is that it consumes 4 bytes per
+  object of disk space. Defaults to true.
+
+pack.writeBitmapLookupTable: |
+  When true, Git will include a "lookup table" section in the bitmap index (if one is written). This
+  table is used to defer loading individual bitmaps as late as possible. This can be beneficial in
+  repositories that have relatively large bitmap indexes. Defaults to false.
+
+pack.writeReverseIndex: |
+  When true, git will write a corresponding .rev file (see: `gitformat-pack(5)`) for each new
+  packfile that it writes in all places except for `git-fast-import(1)` and in the bulk checkin
+  mechanism. Defaults to true.
+
+pager.<cmd>: |
+  If the value is boolean, turns on or off pagination of the output of a particular Git subcommand
+  when writing to a tty. Otherwise, turns on pagination for the subcommand using the pager specified
+  by the value of `pager.<cmd>`. If `--paginate` or `--no-pager` is specified on the command line,
+  it takes precedence over this option. To disable pagination for all commands, set `core.pager` or
+  `GIT_PAGER` to `cat`.
+
+pretty.<name>: |
+  Alias for a --pretty= format string, as specified in `git-log(1)`. Any aliases defined here can be
+  used just as the built-in pretty formats could. For example, running `git config pretty.changelog
+  "format:* %H %s"` would cause the invocation `git log --pretty=changelog` to be equivalent to
+  running `git log "--pretty=format:* %H %s"`. Note that an alias with the same name as a built-in
+  format will be silently ignored.
+
+promisor.acceptFromServer: |
+  If set to "all", a client will accept all the promisor remotes a server might advertise using the
+  "promisor-remote" capability. If set to "knownName" the client will accept promisor remotes which
+  are already configured on the client and have the same name as those advertised by the client.
+  This is not very secure, but could be used in a corporate setup where servers and clients are
+  trusted to not switch name and URLs. If set to "knownUrl", the client will accept promisor remotes
+  which have both the same name and the same URL configured on the client as the name and URL
+  advertised by the server. This is more secure than "all" or "knownName", so it should be used if
+  possible instead of those options. Default is "none", which means no promisor remote advertised by
+  a server will be accepted. By accepting a promisor remote, the client agrees that the server might
+  omit objects that are lazily fetchable from this promisor remote from its responses to "fetch" and
+  "clone" requests from the client. Name and URL comparisons are case sensitive. See
+  `gitprotocol-v2(5)`.
+
+promisor.advertise: |
+  If set to "true", a server will use the "promisor-remote" capability, see `gitprotocol-v2(5)`, to
+  advertise the promisor remotes it is using, if it uses some. Default is "false", which means the
+  "promisor-remote" capability is not advertised.
+
+promisor.checkFields: |
+  A comma or space separated list of additional remote related field names. A client checks if the
+  values of these fields transmitted by a server correspond to the values of these fields in its own
+  configuration before accepting a promisor remote. Currently, "partialCloneFilter" and "token" are
+  the only supported field names.
+
+promisor.quiet: |
+  If set to "true" assume `--quiet` when fetching additional objects for a partial clone.
+
+promisor.sendFields: |
+  A comma or space separated list of additional remote related field names. A server sends these
+  field names and the associated field values from its configuration when advertising its promisor
+  remotes using the "promisor-remote" capability, see `gitprotocol-v2(5)`. Currently, only the
+  "partialCloneFilter" and "token" field names are supported.
+
+promisor.storeFields: |
+  A comma or space separated list of additional remote related field names. If a client accepts an
+  advertised remote, the client will store the values associated with these field names taken from
+  the remote advertisement into its configuration, and then reload its remote configuration.
+  Currently, "partialCloneFilter" and "token" are the only supported field names.
+
+protocol.<name>.allow: |
+  Set a policy to be used by protocol `<name>` with clone/fetch/push commands. See `protocol.allow`
+  above for the available policies.
+
+protocol.allow: |
+  If set, provide a user defined default policy for all protocols which don't explicitly have a
+  policy (`protocol.<name>.allow`). By default, if unset, known-safe protocols (http, https, git,
+  ssh) have a default policy of `always`, known-dangerous protocols (ext) have a default policy of
+  `never`, and all other protocols (including file) have a default policy of `user`. Supported
+  policies:
+
+protocol.version: |
+  If set, clients will attempt to communicate with a server using the specified protocol version. If
+  the server does not support it, communication falls back to version 0. If unset, the default is
+  `2`. Supported versions:
+
+pull.autoStash: |
+  When set to true, automatically create a temporary stash entry to record the local changes before
+  the operation begins, and restore them after the operation completes. When your "git pull" rebases
+  (instead of merges), this may be convenient, since unlike merging pull that tolerates local
+  changes that do not interfere with the merge, rebasing pull refuses to work with any local
+  changes.
+
+pull.ff: |
+  By default, Git does not create an extra merge commit when merging a commit that is a descendant
+  of the current commit. Instead, the tip of the current branch is fast-forwarded. When set to
+  `false`, this variable tells Git to create an extra merge commit in such a case (equivalent to
+  giving the `--no-ff` option from the command line). When set to `only`, only such fast-forward
+  merges are allowed (equivalent to giving the `--ff-only` option from the command line). This
+  setting overrides `merge.ff` when pulling.
+
+pull.octopus: |
+  The default merge strategy to use when pulling multiple branches at once.
+
+pull.rebase: |
+  When true, rebase branches on top of the fetched branch, instead of merging the default branch
+  from the default remote when "git pull" is run. See "branch.<name>.rebase" for setting this on a
+  per-branch basis.
+
+pull.twohead: |
+  The default merge strategy to use when pulling a single branch.
+
+push.autoSetupRemote: |
+  If set to `true` assume `--set-upstream` on default push when no upstream tracking exists for the
+  current branch; this option takes effect with `push.default` options `simple`, `upstream`, and
+  `current`. It is useful if by default you want new branches to be pushed to the default remote
+  (like the behavior of `push.default=current`) and you also want the upstream tracking to be set.
+  Workflows most likely to benefit from this option are `simple` central workflows where all
+  branches are expected to have the same name on the remote.
+
+push.default: |
+  Defines the action `git push` should take if no refspec is given (whether from the command-line,
+  config, or elsewhere). Different values are well-suited for specific workflows; for instance, in a
+  purely central workflow (i.e. the fetch source is equal to the push destination), `upstream` is
+  probably what you want. Possible values are:
+
+push.followTags: |
+  If set to true, enable `--follow-tags` option by default. You may override this configuration at
+  time of push by specifying `--no-follow-tags`.
+
+push.gpgSign: |
+  May be set to a boolean value, or the string `if-asked`. A true value causes all pushes to be GPG
+  signed, as if `--signed` is passed to `git-push(1)`. The string `if-asked` causes pushes to be
+  signed if the server supports it, as if `--signed=if-asked` is passed to `git push`. A false value
+  may override a value from a lower-priority config file. An explicit command-line flag always
+  overrides this config option.
+
+push.negotiate: |
+  If set to `true`, attempt to reduce the size of the packfile sent by rounds of negotiation in
+  which the client and the server attempt to find commits in common. If `false`, Git will rely
+  solely on the server's ref advertisement to find commits in common.
+
+push.pushOption: |
+  When no `--push-option=<option>` argument is given from the command line, `git push` behaves as if
+  each _<option>_ of this variable is given as `--push-option=<option>`.
+
+push.recurseSubmodules: |
+  May be `check`, `on-demand`, `only`, or `no`, with the same behavior as that of `push --recurse-
+  submodules`. If not set, `no` is used by default, unless `submodule.recurse` is set (in which case
+  a `true` value means `on-demand`).
+
+push.useBitmaps: |
+  If set to `false`, disable use of bitmaps for `git push` even if `pack.useBitmaps` is `true`,
+  without preventing other git operations from using bitmaps. Default is `true`.
+
+push.useForceIfIncludes: |
+  If set to `true`, it is equivalent to specifying `--force-if-includes` as an option to `git-
+  push(1)` in the command line. Adding `--no-force-if-includes` at the time of push overrides this
+  configuration setting.
+
+rebase.abbreviateCommands: |
+  If set to true, `git rebase` will use abbreviated command names in the todo list resulting in
+  something like this:
+
+rebase.autoSquash: |
+  If set to true, enable the `--autosquash` option of `git-rebase(1)` by default for interactive
+  mode. This can be overridden with the `--no-autosquash` option.
+
+rebase.autoStash: |
+  When set to true, automatically create a temporary stash entry before the operation begins, and
+  apply it after the operation ends. This means that you can run rebase on a dirty worktree.
+  However, use with care: the final stash application after a successful rebase might result in non-
+  trivial conflicts. This option can be overridden by the `--no-autostash` and `--autostash` options
+  of `git-rebase(1)`. Defaults to false.
+
+rebase.backend: |
+  Default backend to use for rebasing. Possible choices are 'apply' or 'merge'. In the future, if
+  the merge backend gains all remaining capabilities of the apply backend, this setting may become
+  unused.
+
+rebase.forkPoint: |
+  If set to false set `--no-fork-point` option by default.
+
+rebase.instructionFormat: |
+  A format string, as specified in `git-log(1)`, to be used for the todo list during an interactive
+  rebase. The format will automatically have the commit hash prepended to the format.
+
+rebase.maxLabelLength: |
+  When generating label names from commit subjects, truncate the names to this length. By default,
+  the names are truncated to a little less than `NAME_MAX` (to allow e.g. `.lock` files to be
+  written for the corresponding loose refs).
+
+rebase.missingCommitsCheck: |
+  If set to "warn", git rebase -i will print a warning if some commits are removed (e.g. a line was
+  deleted), however the rebase will still proceed. If set to "error", it will print the previous
+  warning and stop the rebase, 'git rebase --edit-todo' can then be used to correct the error. If
+  set to "ignore", no checking is done. To drop a commit without warning or error, use the `drop`
+  command in the todo list. Defaults to "ignore".
+
+rebase.rebaseMerges: |
+  Whether and how to set the `--rebase-merges` option by default. Can be `rebase-cousins`, `no-
+  rebase-cousins`, or a boolean. Setting to true or to `no-rebase-cousins` is equivalent to
+  `--rebase-merges=no-rebase-cousins`, setting to `rebase-cousins` is equivalent to `--rebase-
+  merges=rebase-cousins`, and setting to false is equivalent to `--no-rebase-merges`. Passing
+  `--rebase-merges` on the command line, with or without an argument, overrides any
+  `rebase.rebaseMerges` configuration.
+
+rebase.rescheduleFailedExec: |
+  Automatically reschedule `exec` commands that failed. This only makes sense in interactive mode
+  (or when an `--exec` option was provided). This is the same as specifying the `--reschedule-
+  failed-exec` option.
+
+rebase.stat: |
+  Whether to show a diffstat of what changed upstream since the last rebase. False by default.
+
+rebase.updateRefs: |
+  If set to true enable `--update-refs` option by default.
+
+receive.advertiseAtomic: |
+  By default, git-receive-pack will advertise the atomic push capability to its clients. If you
+  don't want to advertise this capability, set this variable to false.
+
+receive.advertisePushOptions: |
+  When set to true, git-receive-pack will advertise the push options capability to its clients.
+  False by default.
+
+receive.autogc: |
+  By default, git-receive-pack will run "git maintenance run --auto" after receiving data from git-
+  push and updating refs. You can stop it by setting this variable to false.
+
+receive.certNonceSeed: |
+  By setting this variable to a string, `git receive-pack` will accept a `git push --signed` and
+  verify it by using a "nonce" protected by HMAC using this string as a secret key.
+
+receive.certNonceSlop: |
+  When a `git push --signed` sends a push certificate with a "nonce" that was issued by a receive-
+  pack serving the same repository within this many seconds, export the "nonce" found in the
+  certificate to `GIT_PUSH_CERT_NONCE` to the hooks (instead of what the receive-pack asked the
+  sending side to include). This may allow writing checks in `pre-receive` and `post-receive` a bit
+  easier. Instead of checking `GIT_PUSH_CERT_NONCE_SLOP` environment variable that records by how
+  many seconds the nonce is stale to decide if they want to accept the certificate, they only can
+  check `GIT_PUSH_CERT_NONCE_STATUS` is `OK`.
+
+receive.denyCurrentBranch: |
+  If set to true or "refuse", git-receive-pack will deny a ref update to the currently checked out
+  branch of a non-bare repository. Such a push is potentially dangerous because it brings the HEAD
+  out of sync with the index and working tree. If set to "warn", print a warning of such a push to
+  stderr, but allow the push to proceed. If set to false or "ignore", allow such pushes with no
+  message. Defaults to "refuse".
+
+receive.denyDeleteCurrent: |
+  If set to true, git-receive-pack will deny a ref update that deletes the currently checked out
+  branch of a non-bare repository.
+
+receive.denyDeletes: |
+  If set to true, git-receive-pack will deny a ref update that deletes the ref. Use this to prevent
+  such a ref deletion via a push.
+
+receive.denyNonFastForwards: |
+  If set to true, git-receive-pack will deny a ref update which is not a fast-forward. Use this to
+  prevent such an update via a push, even if that push is forced. This configuration variable is set
+  when initializing a shared repository.
+
+receive.fsck.<msg-id>: |
+  Acts like `fsck.<msg-id>`, but is used by `git-receive-pack(1)` instead of `git-fsck(1)`. See the
+  `fsck.<msg-id>` documentation for details.
+
+receive.fsck.skipList: |
+  Acts like `fsck.skipList`, but is used by `git-receive-pack(1)` instead of `git-fsck(1)`. See the
+  `fsck.skipList` documentation for details.
+
+receive.fsckObjects: |
+  If it is set to true, git-receive-pack will check all received objects. See `transfer.fsckObjects`
+  for what's checked. Defaults to false. If not set, the value of `transfer.fsckObjects` is used
+  instead.
+
+receive.hideRefs: |
+  This variable is the same as `transfer.hideRefs`, but applies only to `receive-pack` (and so
+  affects pushes, but not fetches). An attempt to update or delete a hidden ref by `git push` is
+  rejected.
+
+receive.keepAlive: |
+  After receiving the pack from the client, `receive-pack` may produce no output (if `--quiet` was
+  specified) while processing the pack, causing some networks to drop the TCP connection. With this
+  option set, if `receive-pack` does not transmit any data in this phase for `receive.keepAlive`
+  seconds, it will send a short keepalive packet. The default is 5 seconds; set to 0 to disable
+  keepalives entirely.
+
+receive.maxInputSize: |
+  If the size of the incoming pack stream is larger than this limit, then git-receive-pack will
+  error out, instead of accepting the pack file. If not set or set to 0, then the size is unlimited.
+
+receive.procReceiveRefs: |
+  This is a multi-valued variable that defines reference prefixes to match the commands in `receive-
+  pack`. Commands matching the prefixes will be executed by an external hook "proc-receive", instead
+  of the internal `execute_commands` function. If this variable is not defined, the "proc-receive"
+  hook will never be used, and all commands will be executed by the internal `execute_commands`
+  function.
+
+receive.shallowUpdate: |
+  If set to true, .git/shallow can be updated when new refs require new shallow roots. Otherwise
+  those refs are rejected.
+
+receive.unpackLimit: |
+  If the number of objects received in a push is below this limit then the objects will be unpacked
+  into loose object files. However if the number of received objects equals or exceeds this limit
+  then the received pack will be stored as a pack, after adding any missing delta bases. Storing the
+  pack from a push can make the push operation complete faster, especially on slow filesystems. If
+  not set, the value of `transfer.unpackLimit` is used instead.
+
+receive.updateServerInfo: |
+  If set to true, git-receive-pack will run git-update-server-info after receiving data from git-
+  push and updating refs.
+
+reftable.blockSize: |
+  The size in bytes used by the reftable backend when writing blocks. The block size is determined
+  by the writer, and does not have to be a power of 2. The block size must be larger than the
+  longest reference name or log entry used in the repository, as references cannot span blocks.
+
+reftable.geometricFactor: |
+  Whenever the reftable backend appends a new table to the stack, it performs auto compaction to
+  ensure that there is only a handful of tables. The backend does this by ensuring that tables form
+  a geometric sequence regarding the respective sizes of each table.
+
+reftable.indexObjects: |
+  Whether the reftable backend shall write object blocks. Object blocks are a reverse mapping of
+  object ID to the references pointing to them.
+
+reftable.lockTimeout: |
+  Whenever the reftable backend appends a new table to the stack, it has to lock the central
+  "tables.list" file before updating it. This config controls how long the process will wait to
+  acquire the lock in case another process has already acquired it. Value 0 means not to retry at
+  all; -1 means to try indefinitely. Default is 100 (i.e., retry for 100ms).
+
+reftable.restartInterval: |
+  The interval at which to create restart points. The reftable backend determines the restart points
+  at file creation. Every 16 may be more suitable for smaller block sizes (4k or 8k), every 64 for
+  larger block sizes (64k).
+
+remote.<remote>.fetch: |
+  The default set of "refspec" for `git-fetch(1)`. See `git-fetch(1)`.
+
+remote.<remote>.followRemoteHEAD: |
+  How `git-fetch(1)` should handle updates to `remotes/<name>/HEAD` when fetching using the
+  configured refspecs of a remote. The default value is "create", which will create
+  `remotes/<name>/HEAD` if it exists on the remote, but not locally; this will not touch an already
+  existing local reference. Setting it to "warn" will print a message if the remote has a different
+  value than the local one; in case there is no local reference, it behaves like "create". A variant
+  on "warn" is "warn-if-not-$branch", which behaves like "warn", but if `HEAD` on the remote is
+  `$branch` it will be silent. Setting it to "always" will silently update `remotes/<name>/HEAD` to
+  the value on the remote. Finally, setting it to "never" will never change or create the local
+  reference.
+
+remote.<remote>.mirror: |
+  If true, pushing to this remote will automatically behave as if the `--mirror` option was given on
+  the command line.
+
+remote.<remote>.negotiationInclude: |
+  When negotiating with this remote during `git fetch`, the client advertises a list of commits that
+  exist locally. In repos with many references, this list of "haves" can be truncated. Depending on
+  data shape, dropping certain references may be expensive. This multi-valued config option
+  specifies references, commit hashes, or ref pattern globs whose tips should always be sent as
+  "have" commits during fetch negotiation with this remote.
+
+remote.<remote>.negotiationRestrict: |
+  When negotiating with this remote during `git fetch`, restrict the commits advertised as "have"
+  lines to only those reachable from refs matching the given patterns. This multi-valued config
+  option behaves like `--negotiation-restrict` on the command line.
+
+remote.<remote>.partialclonefilter: |
+  The filter that will be applied when fetching from this promisor remote. Changing or clearing this
+  value will only affect fetches for new commits. To fetch associated objects for commits already
+  present in the local object database, use the `--refetch` option of `git-fetch(1)`.
+
+remote.<remote>.promisor: |
+  When set to true, this remote will be used to fetch promisor objects.
+
+remote.<remote>.proxy: |
+  For remotes that require curl (http, https and ftp), the URL to the proxy to use for that remote.
+  Set to the empty string to disable proxying for that remote.
+
+remote.<remote>.proxyAuthMethod: |
+  For remotes that require curl (http, https and ftp), the method to use for authenticating against
+  the proxy in use (probably set in `remote.<name>.proxy`). See `http.proxyAuthMethod`.
+
+remote.<remote>.prune: |
+  When set to true, fetching from this remote by default will also remove any remote-tracking
+  references that no longer exist on the remote (as if the `--prune` option was given on the command
+  line). Overrides `fetch.prune` settings, if any.
+
+remote.<remote>.pruneTags: |
+  When set to true, fetching from this remote by default will also remove any local tags that no
+  longer exist on the remote if pruning is activated in general via `remote.<name>.prune`,
+  `fetch.prune` or `--prune`. Overrides `fetch.pruneTags` settings, if any.
+
+remote.<remote>.push: |
+  The default set of "refspec" for `git-push(1)`. See `git-push(1)`.
+
+remote.<remote>.pushurl: |
+  The push URL of a remote repository. See `git-push(1)`. If a `pushurl` option is present in a
+  configured remote, it is used for pushing instead of `remote.<name>.url`. A configured remote can
+  have multiple push URLs; in this case a push goes to all of them. Setting this key to the empty
+  string clears the list of urls, allowing you to override earlier config.
+
+remote.<remote>.receivepack: |
+  The default program to execute on the remote side when pushing. See option --receive-pack of `git-
+  push(1)`.
+
+remote.<remote>.serverOption: |
+  The default set of server options used when fetching from this remote. These server options can be
+  overridden by the `--server-option=` command line arguments.
+
+remote.<remote>.skipDefaultUpdate: |
+  A deprecated synonym to `remote.<name>.skipFetchAll` (if both are set in the configuration files
+  with different values, the value of the last occurrence will be used).
+
+remote.<remote>.skipFetchAll: |
+  If true, this remote will be skipped when updating using `git-fetch(1)`, the `update` subcommand
+  of `git-remote(1)`, and ignored by the prefetch task of `git maintenance`.
+
+remote.<remote>.tagOpt: |
+  Setting this value to --no-tags disables automatic tag following when fetching from remote <name>.
+  Setting it to --tags will fetch every tag from remote <name>, even if they are not reachable from
+  remote branch heads. Passing these flags directly to `git-fetch(1)` can override this setting. See
+  options --tags and --no-tags of `git-fetch(1)`.
+
+remote.<remote>.uploadpack: |
+  The default program to execute on the remote side when fetching. See option --upload-pack of `git-
+  fetch-pack(1)`.
+
+remote.<remote>.url: |
+  The URL of a remote repository. See `git-fetch(1)` or `git-push(1)`. A configured remote can have
+  multiple URLs; in this case the first is used for fetching, and all are used for pushing (assuming
+  no `remote.<name>.pushurl` is defined). Setting this key to the empty string clears the list of
+  urls, allowing you to override earlier config.
+
+remote.<remote>.vcs: |
+  Setting this to a value <vcs> will cause Git to interact with the remote with the git-remote-<vcs>
+  helper.
+
+remote.pushDefault: |
+  The remote to push to by default. Overrides `branch.<name>.remote` for all branches, and is
+  overridden by `branch.<name>.pushRemote` for specific branches.
+
+remotes.<group>: |
+  The list of remotes which are fetched by "git remote update <group>". See `git-remote(1)`.
+
+repack.cruftThreads: |
+  Parameters used by `git-pack-objects(1)` when generating a cruft pack and the respective
+  parameters are not given over the command line. See similarly named `pack.*` configuration
+  variables for defaults and meaning.
+
+repack.midxMustContainCruft: |
+  When set to true, `git-repack(1)` will unconditionally include cruft pack(s), if any, in the
+  multi-pack index when invoked with `--write-midx`. When false, cruft packs are only included in
+  the MIDX when necessary (e.g., because they might be required to form a reachability closure with
+  MIDX bitmaps). Defaults to true.
+
+repack.midxNewLayerThreshold: |
+  The minimum number of packs in the tip MIDX layer before those packs are considered as candidates
+  for geometric repacking during `git repack --write-midx=incremental`.
+
+repack.midxSplitFactor: |
+  The factor used in the geometric merging condition when compacting incremental MIDX layers during
+  `git repack` when invoked with the `--write-midx=incremental` option.
+
+repack.packKeptObjects: |
+  If set to true, makes `git repack` act as if `--pack-kept-objects` was passed. See `git-repack(1)`
+  for details. Defaults to `false` normally, but `true` if a bitmap index is being written (either
+  via `--write-bitmap-index` or `repack.writeBitmaps`).
+
+repack.updateServerInfo: |
+  If set to false, `git-repack(1)` will not run `git-update-server-info(1)`. Defaults to true. Can
+  be overridden when true by the `-n` option of `git-repack(1)`.
+
+repack.useDeltaBaseOffset: |
+  By default, `git-repack(1)` creates packs that use delta-base offset. If you need to share your
+  repository with Git older than version 1.4.4, either directly or via a dumb protocol such as http,
+  then you need to set this option to "false" and repack. Access from old Git versions over the
+  native protocol are unaffected by this option.
+
+repack.useDeltaIslands: |
+  If set to true, makes `git repack` act as if `--delta-islands` was passed. Defaults to `false`.
+
+repack.writeBitmaps: |
+  When true, git will write a bitmap index when packing all objects to disk (e.g., when `git repack
+  -a` is run). This index can speed up the "counting objects" phase of subsequent packs created for
+  clones and fetches, at the cost of some disk space and extra time spent on the initial repack.
+  This has no effect if multiple packfiles are created. Defaults to true on bare repos, false
+  otherwise.
+
+replay.refAction: |
+  Specifies the default mode for handling reference updates in `git replay`. The value can be:
+
+rerere.autoUpdate: |
+  When set to true, `git-rerere` updates the index with the resulting contents after it cleanly
+  resolves conflicts using previously recorded resolutions. Defaults to false.
+
+rerere.enabled: |
+  Activate recording of resolved conflicts, so that identical conflict hunks can be resolved
+  automatically, should they be encountered again. By default, `git-rerere(1)` is enabled if there
+  is an `rr-cache` directory under the `$GIT_DIR`, e.g. if "rerere" was previously used in the
+  repository.
+
+revert.reference: |
+  Setting this variable to true makes `git revert` behave as if the `--reference` option is given.
+
+safe.bareRepository: |
+  Specifies which bare repositories Git will work with. The currently supported values are:
+
+safe.directory: |
+  These config entries specify Git-tracked directories that are considered safe even if they are
+  owned by someone other than the current user. By default, Git will refuse to even parse a Git
+  config of a repository owned by someone else, let alone run its hooks, and this config setting
+  allows users to specify exceptions, e.g. for intentionally shared repositories (see the `--shared`
+  option in `git-init(1)`).
+
+sendemail.<identity>.*: |
+  Identity-specific versions of the `sendemail.*` parameters found below, taking precedence over
+  those when this identity is selected, through either the command-line or `sendemail.identity`.
+
+sendemail.aliasFileType: |
+  Format of the file(s) specified in sendemail.aliasesFile. Must be one of `mutt`, `mailrc`, `pine`,
+  `elm`, `gnus`, or `sendmail`.
+
+sendemail.aliasesFile: |
+  To avoid typing long email addresses, point this to one or more email aliases files. You must also
+  supply `sendemail.aliasFileType`.
+
+sendemail.confirm: |
+  Sets the default for whether to confirm before sending. Must be one of `always`, `never`, `cc`,
+  `compose`, or `auto`. See `--confirm` in the `git-send-email(1)` documentation for the meaning of
+  these values.
+
+sendemail.forbidSendmailVariables: |
+  To avoid common misconfiguration mistakes, `git-send-email(1)` will abort with a warning if any
+  configuration options for `sendmail` exist. Set this variable to bypass the check.
+
+sendemail.identity: |
+  A configuration identity. When given, causes values in the `sendemail.<identity>` subsection to
+  take precedence over values in the `sendemail` section. The default identity is the value of
+  `sendemail.identity`.
+
+sendemail.mailmap: |
+  If `true`, makes `git-send-email(1)` assume `--mailmap`, otherwise assume `--no-mailmap`. `False`
+  by default.
+
+sendemail.mailmap.blob: |
+  Like `sendemail.mailmap.file`, but consider the value as a reference to a blob in the repository.
+  Entries in `sendemail.mailmap.file` take precedence over entries here. See `gitmailmap(5)`.
+
+sendemail.mailmap.file: |
+  The location of a `git-send-email(1)` specific augmenting mailmap file. The default mailmap and
+  `mailmap.file` are loaded first. Thus, entries in this file take precedence over entries in the
+  default mailmap locations. See `gitmailmap(5)`.
+
+sendemail.multiEdit: |
+  If `true` (default), a single editor instance will be spawned to edit files you have to edit
+  (patches when `--annotate` is used, and the summary when `--compose` is used). If `false`, files
+  will be edited one after the other, spawning a new editor each time.
+
+sendemail.outlookidfix: |
+  If `true`, makes `git-send-email(1)` assume `--outlook-id-fix`, and if `false` assume `--no-
+  outlook-id-fix`. If not specified, it will behave the same way as if `--outlook-id-fix` is not
+  specified.
+
+sendemail.smtpBatchSize: |
+  Number of messages to be sent per connection, after that a relogin will happen. If the value is
+  `0` or undefined, send all messages in one connection. See also the `--batch-size` option of `git-
+  send-email(1)`.
+
+sendemail.smtpEncryption: |
+  See `git-send-email(1)` for description. Note that this setting is not subject to the `identity`
+  mechanism.
+
+sendemail.smtpReloginDelay: |
+  Seconds to wait before reconnecting to the smtp server. See also the `--relogin-delay` option of
+  `git-send-email(1)`.
+
+sendemail.smtpSSLCertPath: |
+  Path to ca-certificates (either a directory or a single file). Set it to an empty string to
+  disable certificate verification.
+
+sendemail.smtpSSLClientCert: |
+  Path to the client certificate file to present if requested by the server. This is required when
+  the server is set up to verify client certificates. If the corresponding private key is not
+  included in the file, it must be supplied using `sendemail.smtpSSLClientKey` or the `--smtp-ssl-
+  client-key` option.
+
+sendemail.smtpSSLClientKey: |
+  Path to the client private key file that corresponds to the client certificate. To avoid
+  misconfiguration, this configuration must be used in conjunction with
+  `sendemail.smtpSSLClientCert` or the `--smtp-ssl-client-cert` option. If the client key is
+  included in the client certificate, the choice of private key depends on the format of the
+  certificate. Visit https://metacpan.org/pod/IO::Socket::SSL for more details.
+
+sendemail.xmailer: |
+  These configuration variables all provide a default for `git-send-email(1)` command-line options.
+  See its documentation for details.
+
+sequence.editor: |
+  Text editor used by `git rebase -i` for editing the rebase instruction file. The value is meant to
+  be interpreted by the shell when it is used. It can be overridden by the `GIT_SEQUENCE_EDITOR`
+  environment variable. When not configured, the default commit message editor is used instead.
+
+showBranch.default: |
+  The default set of branches for `git-show-branch(1)`. See `git-show-branch(1)`.
+
+sideband.<url>.*: |
+  Apply the `sideband.*` option selectively to specific URLs. The same URL matching logic applies as
+  for `http.<url>.*` settings.
+
+sideband.allowControlCharacters: |
+  By default, control characters that are delivered via the sideband are masked, except ANSI color
+  sequences. This prevents potentially unwanted ANSI escape sequences from being sent to the
+  terminal. Use this config setting to override this behavior (the value can be a comma-separated
+  list of the following keywords):
+
+sparse.expectFilesOutsideOfPatterns: |
+  Typically with sparse checkouts, files not matching any sparsity patterns are marked with a
+  SKIP_WORKTREE bit in the index and are missing from the working tree. Accordingly, Git will
+  ordinarily check whether files with the SKIP_WORKTREE bit are in fact present in the working tree
+  contrary to expectations. If Git finds any, it marks those paths as present by clearing the
+  relevant SKIP_WORKTREE bits. This option can be used to tell Git that such present-despite-skipped
+  files are expected and to stop checking for them.
+
+splitIndex.maxPercentChange: |
+  When the split index feature is used, this specifies the percent of entries the split index can
+  contain compared to the total number of entries in both the split index and the shared index
+  before a new shared index is written. The value should be between 0 and 100. If the value is 0,
+  then a new shared index is always written; if it is 100, a new shared index is never written. By
+  default, the value is 20, so a new shared index is written if the number of entries in the split
+  index would be greater than 20 percent of the total number of entries. See `git-update-index(1)`.
+
+splitIndex.sharedIndexExpire: |
+  When the split index feature is used, shared index files that were not modified since the time
+  this variable specifies will be removed when a new shared index file is created. The value "now"
+  expires all entries immediately, and "never" suppresses expiration altogether. The default value
+  is "2.weeks.ago". Note that a shared index file is considered modified (for the purpose of
+  expiration) each time a new split-index file is either created based on it or read from it. See
+  `git-update-index(1)`.
+
+ssh.variant: |
+  By default, Git determines the command line arguments to use based on the basename of the
+  configured SSH command (configured using the environment variable `GIT_SSH` or `GIT_SSH_COMMAND`
+  or the config setting `core.sshCommand`). If the basename is unrecognized, Git will attempt to
+  detect support of OpenSSH options by first invoking the configured SSH command with the `-G`
+  (print configuration) option and will subsequently use OpenSSH options (if that is successful) or
+  no options besides the host and remote command (if it fails).
+
+stash.index: |
+  If this is set to true, `git stash apply` and `git stash pop` will behave as if `--index` was
+  supplied. Defaults to false.
+
+stash.showIncludeUntracked: |
+  If this is set to true, the `git stash show` command will show the untracked files of a stash
+  entry. Defaults to false. {see-show}
+
+stash.showPatch: |
+  If this is set to true, the `git stash show` command without an option will show the stash entry
+  in patch form. Defaults to false. {see-show}
+
+stash.showStat: |
+  If this is set to true, the `git stash show` command without an option will show a diffstat of the
+  stash entry. Defaults to true. {see-show}
+
+status.aheadBehind: |
+  Set to true to enable `--ahead-behind` and false to enable `--no-ahead-behind` by default in `git-
+  status(1)` for non-porcelain status formats. Defaults to true.
+
+status.branch: |
+  Set to true to enable --branch by default in `git-status(1)`. The option --no-branch takes
+  precedence over this variable.
+
+status.compareBranches: |
+  A space-separated list of branch comparison specifiers to use in `git-status(1)`. Currently, only
+  `@{upstream}` and `@{push}` are supported. They are interpreted as `branch@{upstream}` and
+  `branch@{push}` for the current branch.
+
+status.displayCommentPrefix: |
+  If set to true, `git-status(1)` will insert a comment prefix before each output line (starting
+  with `core.commentChar`, i.e. `#` by default). This was the behavior of `git-status(1)` in Git
+  1.8.4 and previous. Defaults to false.
+
+status.relativePaths: |
+  By default, `git-status(1)` shows paths relative to the current directory. Setting this variable
+  to `false` shows paths relative to the repository root (this was the default for Git prior to
+  v1.5.4).
+
+status.renameLimit: |
+  The number of files to consider when performing rename detection in `git-status(1)` and `git-
+  commit(1)`. Defaults to the value of diff.renameLimit.
+
+status.renames: |
+  Whether and how Git detects renames in `git-status(1)` and `git-commit(1)` . If set to "false",
+  rename detection is disabled. If set to "true", basic rename detection is enabled. If set to
+  "copies" or "copy", Git will detect copies, as well. Defaults to the value of diff.renames.
+
+status.short: |
+  Set to true to enable --short by default in `git-status(1)`. The option --no-short takes
+  precedence over this variable.
+
+status.showStash: |
+  If set to true, `git-status(1)` will display the number of entries currently stashed away.
+  Defaults to false.
+
+status.showUntrackedFiles: |
+  By default, `git-status(1)` and `git-commit(1)` show files which are not currently tracked by Git.
+  Directories which contain only untracked files, are shown with the directory name only. Showing
+  untracked files means that Git needs to lstat() all the files in the whole repository, which might
+  be slow on some systems. So, this variable controls how the commands display the untracked files.
+  Possible values are:
+
+status.submoduleSummary: |
+  Defaults to false. If this is set to a non-zero number or true (identical to -1 or an unlimited
+  number), the submodule summary will be enabled and a summary of commits for modified submodules
+  will be shown (see --summary-limit option of `git-submodule(1)`). Please note that the summary
+  output command will be suppressed for all submodules when `diff.ignoreSubmodules` is set to 'all'
+  or only for those submodules where `submodule.<name>.ignore=all`. The only exception to that rule
+  is that status and commit will show staged submodule changes. To also view the summary for ignored
+  submodules you can either use the --ignore-submodules=dirty command-line option or the 'git
+  submodule summary' command, which shows a similar output but does not honor these settings.
+
+submodule.<submodule>.active: |
+  Boolean value indicating if the submodule is of interest to git commands. This config option takes
+  precedence over the submodule.active config option. See `gitsubmodules(7)` for details.
+
+submodule.<submodule>.branch: |
+  The remote branch name for a submodule, used by `git submodule update --remote`. Set this option
+  to override the value found in the `.gitmodules` file. See `git-submodule(1)` and `gitmodules(5)`
+  for details.
+
+submodule.<submodule>.fetchRecurseSubmodules: |
+  This option can be used to control recursive fetching of this submodule. It can be overridden by
+  using the --[no-]recurse-submodules command-line option to "git fetch" and "git pull". This
+  setting will override that from in the `gitmodules(5)` file.
+
+submodule.<submodule>.gitdir: |
+  This sets the gitdir path for submodule <name>. This configuration is respected when
+  `extensions.submodulePathConfig` is enabled, otherwise it has no effect. When enabled, this config
+  becomes the single source of truth for submodule gitdir paths and Git will error if it is missing.
+  See `git-config(1)` for details.
+
+submodule.<submodule>.ignore: |
+  Defines under what circumstances "git status" and the diff family show a submodule as modified.
+  When set to "all" will never consider the submodule modified. It can nevertheless be staged using
+  the option --force and it will then show up in the output of status. When set to "dirty" will
+  ignore all changes to the submodule's work tree and takes only differences between the HEAD of the
+  submodule and the commit recorded in the superproject into account. "untracked" will additionally
+  let submodules with modified tracked files in their work tree show up. When set to "none"
+  (default) it also shows submodules as changed if they have untracked files in their work tree.
+  This setting overrides any setting made in .gitmodules for this submodule, both settings can be
+  overridden on the command line by using the "--ignore-submodules" option. The 'git submodule'
+  commands are not affected by this setting.
+
+submodule.<submodule>.update: |
+  The method by which a submodule is updated by 'git submodule update', which is the only affected
+  command, others such as 'git checkout --recurse-submodules' are unaffected. It exists for
+  historical reasons, when 'git submodule' was the only command to interact with submodules;
+  settings like `submodule.active` and `pull.rebase` are more specific. It is populated by `git
+  submodule init` from the `gitmodules(5)` file. See description of 'update' command in `git-
+  submodule(1)`.
+
+submodule.<submodule>.url: |
+  The URL for a submodule. This variable is copied from the .gitmodules file to the git config via
+  'git submodule init'. The user can change the configured URL before obtaining the submodule via
+  'git submodule update'. If neither submodule.<name>.active nor submodule.active are set, the
+  presence of this variable is used as a fallback to indicate whether the submodule is of interest
+  to git commands. See `git-submodule(1)` and `gitmodules(5)` for details.
+
+submodule.active: |
+  A repeated field which contains a pathspec used to match against a submodule's path to determine
+  if the submodule is of interest to git commands. See `gitsubmodules(7)` for details.
+
+submodule.alternateErrorStrategy: |
+  Specifies how to treat errors with the alternates for a submodule as computed via
+  `submodule.alternateLocation`. Possible values are `ignore`, `info`, `die`. Default is `die`. Note
+  that if set to `ignore` or `info`, and if there is an error with the computed alternate, the clone
+  proceeds as if no alternate was specified.
+
+submodule.alternateLocation: |
+  Specifies how the submodules obtain alternates when submodules are cloned. Possible values are
+  `no`, `superproject`. By default `no` is assumed, which doesn't add references. When the value is
+  set to `superproject` the submodule to be cloned computes its alternates location relative to the
+  superprojects alternate.
+
+submodule.fetchJobs: |
+  Specifies how many submodules are fetched/cloned at the same time. A positive integer allows up to
+  that number of submodules fetched in parallel. A value of 0 will give some reasonable default. If
+  unset, it defaults to 1.
+
+submodule.propagateBranches: |
+  [EXPERIMENTAL] A boolean that enables branching support when using `--recurse-submodules` or
+  `submodule.recurse=true`. Enabling this will allow certain commands to accept `--recurse-
+  submodules` and certain commands that already accept `--recurse-submodules` will now consider
+  branches. Defaults to false.
+
+submodule.recurse: |
+  A boolean indicating if commands should enable the `--recurse-submodules` option by default.
+  Defaults to false.
+
+tag.forceSignAnnotated: |
+  A boolean to specify whether annotated tags created should be GPG signed. If `--annotate` is
+  specified on the command line, it takes precedence over this option.
+
+tag.gpgSign: |
+  A boolean to specify whether all tags should be GPG signed. Use of this option when running in an
+  automated script can result in a large number of tags being signed. It is therefore convenient to
+  use an agent to avoid typing your GPG passphrase several times. Note that this option doesn't
+  affect tag signing behavior enabled by `-u <keyid>` or `--local-user=<keyid>` options.
+
+tar.umask: |
+  This variable can be used to restrict the permission bits of tar archive entries. The default is
+  0002, which turns off the world write bit. The special value "user" indicates that the archiving
+  user's umask will be used instead. See umask(2) and `git-archive(1)`.
+
+trace2.configParams: |
+  A comma-separated list of patterns of "important" config settings that should be recorded in the
+  trace2 output. For example, `core.*,remote.*.url` would cause the trace2 output to contain events
+  listing each configured remote. May be overridden by the `GIT_TRACE2_CONFIG_PARAMS` environment
+  variable. Unset by default.
+
+trace2.destinationDebug: |
+  Boolean. When true Git will print error messages when a trace target destination cannot be opened
+  for writing. By default, these errors are suppressed and tracing is silently disabled. May be
+  overridden by the `GIT_TRACE2_DST_DEBUG` environment variable.
+
+trace2.envVars: |
+  A comma-separated list of "important" environment variables that should be recorded in the trace2
+  output. For example, `GIT_HTTP_USER_AGENT,GIT_CONFIG` would cause the trace2 output to contain
+  events listing the overrides for HTTP user agent and the location of the Git configuration file
+  (assuming any are set). May be overridden by the `GIT_TRACE2_ENV_VARS` environment variable. Unset
+  by default.
+
+trace2.eventBrief: |
+  Boolean. When true `time`, `filename`, and `line` fields are omitted from event output. May be
+  overridden by the `GIT_TRACE2_EVENT_BRIEF` environment variable. Defaults to false.
+
+trace2.eventNesting: |
+  Integer. Specifies desired depth of nested regions in the event output. Regions deeper than this
+  value will be omitted. May be overridden by the `GIT_TRACE2_EVENT_NESTING` environment variable.
+  Defaults to 2.
+
+trace2.eventTarget: |
+  This variable controls the event target destination. It may be overridden by the
+  `GIT_TRACE2_EVENT` environment variable. The following table shows possible values.
+
+trace2.maxFiles: |
+  Integer. When writing trace files to a target directory, do not write additional traces if doing
+  so would exceed this many files. Instead, write a sentinel file that will block further tracing to
+  this directory. Defaults to 0, which disables this check.
+
+trace2.normalBrief: |
+  Boolean. When true `time`, `filename`, and `line` fields are omitted from normal output. May be
+  overridden by the `GIT_TRACE2_BRIEF` environment variable. Defaults to false.
+
+trace2.normalTarget: |
+  This variable controls the normal target destination. It may be overridden by the `GIT_TRACE2`
+  environment variable. The following table shows possible values.
+
+trace2.perfBrief: |
+  Boolean. When true `time`, `filename`, and `line` fields are omitted from PERF output. May be
+  overridden by the `GIT_TRACE2_PERF_BRIEF` environment variable. Defaults to false.
+
+trace2.perfTarget: |
+  This variable controls the performance target destination. It may be overridden by the
+  `GIT_TRACE2_PERF` environment variable. The following table shows possible values.
+
+trailer.<key-alias>.cmd: |
+  This option can be used to specify a shell command that will be called once to automatically add a
+  trailer with the specified _<key-alias>_, and then called each time a `--trailer <key-
+  alias>=<value>` argument is specified to modify the _<value>_ of the trailer that this option
+  would produce.
+
+trailer.<key-alias>.command: |
+  Deprecated in favor of `trailer.<key-alias>.cmd`. This option behaves in the same way as
+  `trailer.<key-alias>.cmd`, except that it doesn't pass anything as argument to the specified
+  command. Instead the first occurrence of substring `$ARG` is replaced by the _<value>_ that would
+  be passed as argument.
+
+trailer.<key-alias>.ifexists: |
+  This option takes the same values as the `trailer.ifexists` configuration variable and it
+  overrides what is specified by that option for trailers with the specified _<key-alias>_.
+
+trailer.<key-alias>.ifmissing: |
+  This option takes the same values as the `trailer.ifmissing` configuration variable and it
+  overrides what is specified by that option for trailers with the specified _<key-alias>_.
+
+trailer.<key-alias>.key: |
+  Defines a _<key-alias>_ for the _<key>_. The _<key-alias>_ must be a prefix (case does not matter)
+  of the _<key>_. For example, in `git config trailer.ack.key "Acked-by"` the `Acked-by` is the
+  _<key>_ and the `ack` is the _<key-alias>_. This configuration allows the shorter `--trailer
+  "ack:..."` invocation on the command line using the "ack" `<key-alias>` instead of the longer
+  `--trailer "Acked-by:..."`.
+
+trailer.<key-alias>.where: |
+  This option takes the same values as the `trailer.where` configuration variable and it overrides
+  what is specified by that option for trailers with the specified _<key-alias>_.
+
+trailer.ifexists: |
+  This option makes it possible to choose what action will be performed when there is already at
+  least one trailer with the same _<key>_ in the input.
+
+trailer.ifmissing: |
+  This option makes it possible to choose what action will be performed when there is not yet any
+  trailer with the same _<key>_ in the input.
+
+trailer.separators: |
+  This option tells which characters are recognized as trailer separators. By default only `:` is
+  recognized as a trailer separator, except that `=` is always accepted on the command line for
+  compatibility with other git commands.
+
+trailer.where: |
+  This option tells where a new trailer will be added.
+
+transfer.advertiseObjectInfo: |
+  When `true`, the `object-info` capability is advertised by servers. Defaults to false.
+
+transfer.advertiseSID: |
+  Boolean. When true, client and server processes will advertise their unique session IDs to their
+  remote counterpart. Defaults to false.
+
+transfer.bundleURI: |
+  When `true`, local `git clone` commands will request bundle information from the remote server (if
+  advertised) and download bundles before continuing the clone through the Git protocol. Defaults to
+  `false`.
+
+transfer.credentialsInUrl: |
+  A configured URL can contain plaintext credentials in the form
+  `<protocol>://<user>:<password>@<domain>/<path>`. You may want to warn or forbid the use of such
+  configuration (in favor of using `git-credential(1)`). This will be used on `git-clone(1)`, `git-
+  fetch(1)`, `git-push(1)`, and any other direct use of the configured URL.
+
+transfer.fsckObjects: |
+  When `fetch.fsckObjects` or `receive.fsckObjects` are not set, the value of this variable is used
+  instead. Defaults to false.
+
+transfer.hideRefs: |
+  String(s) `receive-pack` and `upload-pack` use to decide which refs to omit from their initial
+  advertisements. Use more than one definition to specify multiple prefix strings. A ref that is
+  under the hierarchies listed in the value of this variable is excluded, and is hidden when
+  responding to `git push` or `git fetch`. See `receive.hideRefs` and `uploadpack.hideRefs` for
+  program-specific versions of this config.
+
+transfer.unpackLimit: |
+  When `fetch.unpackLimit` or `receive.unpackLimit` are not set, the value of this variable is used
+  instead. The default value is 100.
+
+uploadarchive.allowUnreachable: |
+  If true, allow clients to use `git archive --remote` to request any tree, whether reachable from
+  the ref tips or not. See the discussion in the "SECURITY" section of `git-upload-archive(1)` for
+  more details. Defaults to `false`.
+
+uploadpack.allowAnySHA1InWant: |
+  Allow `upload-pack` to accept a fetch request that asks for any object at all. It implies
+  `uploadpack.allowTipSHA1InWant` and `uploadpack.allowReachableSHA1InWant`. If set to `true` it
+  will enable both of them, it set to `false` it will disable both of them. By default not set.
+
+uploadpack.allowFilter: |
+  If this option is set, `upload-pack` will support partial clone and partial fetch object
+  filtering.
+
+uploadpack.allowReachableSHA1InWant: |
+  Allow `upload-pack` to accept a fetch request that asks for an object that is reachable from any
+  ref tip. However, note that calculating object reachability is computationally expensive. Defaults
+  to `false`. Even if this is false, a client may be able to steal objects via the techniques
+  described in the "SECURITY" section of the `gitnamespaces(7)` man page; it's best to keep private
+  data in a separate repository.
+
+uploadpack.allowRefInWant: |
+  If this option is set, `upload-pack` will support the `ref-in-want` feature of the protocol
+  version 2 `fetch` command. This feature is intended for the benefit of load-balanced servers which
+  may not have the same view of what OIDs their refs point to due to replication delay.
+
+uploadpack.allowTipSHA1InWant: |
+  When `uploadpack.hideRefs` is in effect, allow `upload-pack` to accept a fetch request that asks
+  for an object at the tip of a hidden ref (by default, such a request is rejected). See also
+  `uploadpack.hideRefs`. Even if this is false, a client may be able to steal objects via the
+  techniques described in the "SECURITY" section of the `gitnamespaces(7)` man page; it's best to
+  keep private data in a separate repository.
+
+uploadpack.hideRefs: |
+  This variable is the same as `transfer.hideRefs`, but applies only to `upload-pack` (and so
+  affects only fetches, not pushes). An attempt to fetch a hidden ref by `git fetch` will fail. See
+  also `uploadpack.allowTipSHA1InWant`.
+
+uploadpack.keepAlive: |
+  When `upload-pack` has started `pack-objects`, there may be a quiet period while `pack-objects`
+  prepares the pack. Normally it would output progress information, but if `--quiet` was used for
+  the fetch, `pack-objects` will output nothing at all until the pack data begins. Some clients and
+  networks may consider the server to be hung and give up. Setting this option instructs `upload-
+  pack` to send an empty keepalive packet every `uploadpack.keepAlive` seconds. Setting this option
+  to 0 disables keepalive packets entirely. The default is 5 seconds.
+
+uploadpack.packObjectsHook: |
+  If this option is set, when `upload-pack` would run `git pack-objects` to create a packfile for a
+  client, it will run this shell command instead. The `pack-objects` command and arguments it
+  _would_ have run (including the `git pack-objects` at the beginning) are appended to the shell
+  command. The stdin and stdout of the hook are treated as if `pack-objects` itself was run. I.e.,
+  `upload-pack` will feed input intended for `pack-objects` to the hook, and expects a completed
+  packfile on stdout.
+
+uploadpackfilter.<filter>.allow: |
+  Explicitly allow or ban the object filter corresponding to `<filter>`, where `<filter>` may be one
+  of: `blob:none`, `blob:limit`, `object:type`, `tree`, `sparse:oid`, or `combine`. If using
+  combined filters, both `combine` and all of the nested filter kinds must be allowed. Defaults to
+  `uploadpackfilter.allow`.
+
+uploadpackfilter.allow: |
+  Provides a default value for unspecified object filters (see: the below configuration variable).
+  If set to `true`, this will also enable all filters which get added in the future. Defaults to
+  `true`.
+
+uploadpackfilter.tree.maxDepth: |
+  Only allow `--filter=tree:<n>` when `<n>` is no more than the value of
+  `uploadpackfilter.tree.maxDepth`. If set, this also implies `uploadpackfilter.tree.allow=true`,
+  unless this configuration variable had already been set. Has no effect if unset.
+
+url.<base>.insteadOf: |
+  Any URL that starts with this value will be rewritten to start, instead, with <base>. In cases
+  where some site serves a large number of repositories, and serves them with multiple access
+  methods, and some users need to use different access methods, this feature allows people to
+  specify any of the equivalent URLs and have Git automatically rewrite the URL to the best
+  alternative for the particular user, even for a never-before-seen repository on the site. When
+  more than one insteadOf strings match a given URL, the longest match is used.
+
+url.<base>.pushInsteadOf: |
+  Any URL that starts with this value will not be pushed to; instead, it will be rewritten to start
+  with <base>, and the resulting URL will be pushed to. In cases where some site serves a large
+  number of repositories, and serves them with multiple access methods, some of which do not allow
+  push, this feature allows people to specify a pull-only URL and have Git automatically use an
+  appropriate URL to push, even for a never-before-seen repository on the site. When more than one
+  pushInsteadOf strings match a given URL, the longest match is used. If a remote has an explicit
+  pushurl, Git will ignore this setting for that remote.
+
+user.signingKey: |
+  If `git-tag(1)` or `git-commit(1)` is not selecting the key you want it to automatically when
+  creating a signed tag or commit, you can override the default selection with this variable. This
+  option is passed unchanged to gpg's --local-user parameter, so you may specify a key using any
+  method that gpg supports. If gpg.format is set to `ssh` this can contain the path to either your
+  private ssh key or the public key when ssh-agent is used. Alternatively it can contain a public
+  key prefixed with `key::` directly (e.g.: "key::ssh-rsa XXXXXX identifier"). The private key needs
+  to be available via ssh-agent. If not set Git will call gpg.ssh.defaultKeyCommand (e.g.: "ssh-add
+  -L") and try to use the first key available. For backward compatibility, a raw key which begins
+  with "ssh-", such as "ssh-rsa XXXXXX identifier", is treated as "key::ssh-rsa XXXXXX identifier",
+  but this form is deprecated; use the `key::` form instead.
+
+user.useConfigOnly: |
+  Instruct Git to avoid trying to guess defaults for `user.email` and `user.name`, and instead
+  retrieve the values only from the configuration. For example, if you have multiple email addresses
+  and would like to use a different one for each repository, then with this configuration option set
+  to `true` in the global config along with a name, Git will prompt you to set up an email before
+  making new commits in a newly cloned repository. Defaults to `false`.
+
+versionsort.suffix: |
+  Even when version sort is used in `git-tag(1)`, tagnames with the same base version but different
+  suffixes are still sorted lexicographically, resulting e.g. in prerelease tags appearing after the
+  main release (e.g. "1.0-rc1" after "1.0"). This variable can be specified to determine the sorting
+  order of tags with different suffixes.
+
+web.browser: |
+  Specify a web browser that may be used by some commands. Currently only `git-instaweb(1)` and
+  `git-help(1)` may use it.
+
+worktree.guessRemote: |
+  If no branch is specified and neither `-b` nor `-B` nor `--detach` is used, then `git worktree
+  add` defaults to creating a new branch from HEAD. If `worktree.guessRemote` is set to true,
+  `worktree add` tries to find a remote-tracking branch whose name uniquely matches the new branch
+  name. If such a branch exists, it is checked out and set as "upstream" for the new branch. If no
+  such match can be found, it falls back to creating a new branch from the current `HEAD`.
+
+worktree.useRelativePaths: |
+  Link worktrees using relative paths (when "`true`") or absolute paths (when "`false`"). This is
+  particularly useful for setups where the repository and worktrees may be moved between different
+  locations or environments. Defaults to "`false`".
+

--- a/pkg/actions/tools/git/config.go
+++ b/pkg/actions/tools/git/config.go
@@ -35,6 +35,7 @@ func ActionConfigs() carapace.Action {
 			}
 
 			return carapace.ActionValues(vals...).
+				UidF(Uid("config")).
 				MultiPartsP(".", "<.*>", func(placeholder string, matches map[string]string) carapace.Action {
 					// TODO support more placeholders
 					switch placeholder {
@@ -51,7 +52,7 @@ func ActionConfigs() carapace.Action {
 					}
 				})
 		})
-	}).UidF(Uid("config"))
+	})
 }
 
 // ActionDateFormats completes date formats


### PR DESCRIPTION
Move UidF before MultiPartsP so that full config keys (e.g.
core.editor) get stable git://config/<key> UIDs while inner
placeholder actions (branches, remotes, hooks) keep their own
UIDs instead of being overwritten by the outer UidF.

Add man/git/config/config.yaml with 689 config key descriptions
sourced from git's Documentation/config/*.adoc files.

Assisted-by: Crush:glm-5.2
