### PR TITLE
fix(nushell): fallback to default completions on empty

### DIFF
--- a/cmd/carapace/cmd/snippet/nushell.go
+++ b/cmd/carapace/cmd/snippet/nushell.go
@@ -29,8 +29,11 @@ let carapace_completer = {|spans|
     $spans | skip 1 | prepend ($spans.0%v)
   })
 
-  carapace $spans.0 nushell ...$spans
-  | from json
+  if ($spans | length) == 1 {
+    null
+  } else {
+    carapace $spans.0 nushell ...$spans | from json
+  }
 }
 
 mut current = (($env | default {} config).config | default {} completions)


### PR DESCRIPTION
FIXES: #3612

This wraps the output of the carapace completer inside Nushell with an `is-empty` check. If the completions are empty, it returns `null` instead of `[]`. This signals to Nushell that it should fall back to native completion (like file paths) rather than displaying "NO RECORDS FOUND" and blocking completions.
