### PR TITLE
Add git bundle list-heads dash completion

### DIFF
--- a/completers/common/git_completer/cmd/bundle_listHeads.go
+++ b/completers/common/git_completer/cmd/bundle_listHeads.go
@@ -26,4 +26,8 @@ func init() {
 			return git.ActionBundleHeads(c.Args[0])
 		}),
 	)
+
+	carapace.Gen(bundle_listHeadsCmd).DashAnyCompletion(
+		carapace.ActionPositional(bundle_listHeadsCmd),
+	)
 }


### PR DESCRIPTION
Adds dash completion for `git bundle list-heads`, matching the existing `bundle verify` behavior.

Refs #2125.
