### PR TITLE
Add Pixi installation instructions for carapace

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -57,6 +57,14 @@ Install from [nixpkgs](https://search.nixos.org/packages?show=carapace)
 nix-shell -p carapace
 ```
 
+## Pixi
+
+Install from [conda-forge](https://anaconda.org/channels/conda-forge/packages/carapace/overview)
+
+```sh
+pixi global install carapace
+```
+
 ## PKGX
 
 Install from [pkgx.dev](https://pkgx.dev/pkgs/carapace.sh/)


### PR DESCRIPTION
Thanks for the cool tool! I've been using it for some time now!

Pixi can install carapace in a self contained environment for all major platforms (Linux, macOS, Windows)
