### PR TITLE
Fix typo in git_remote_show command description

### DIFF
--- a/completers/common/git_completer/cmd/remote_show.go
+++ b/completers/common/git_completer/cmd/remote_show.go
@@ -8,7 +8,7 @@ import (
 
 var remote_showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "Give some inforemation about the remote",
+	Short: "Give some information about the remote",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 

--- a/man/cmd/git/git.remote.show.yaml
+++ b/man/cmd/git/git.remote.show.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 name: show
-description: Give some inforemation about the remote
+description: Give some information about the remote
 flags:
   -n: do not query remotes
 documentation:


### PR DESCRIPTION
# Simple typo fix 
`inforemation` -> `information`