### PR TITLE
fix: preserve native shell completions over bridge-only variants

### DIFF
--- a/cmd/carapace/cmd/snippet/snippet.go
+++ b/cmd/carapace/cmd/snippet/snippet.go
@@ -4,10 +4,30 @@ import (
 	"sort"
 
 	"github.com/carapace-sh/carapace-bin/cmd/carapace/cmd/completers"
+	"github.com/carapace-sh/carapace-bin/pkg/completer"
 	"github.com/carapace-sh/carapace-bridge/pkg/bridges"
 	"github.com/carapace-sh/carapace-bridge/pkg/choices"
 	envbridges "github.com/carapace-sh/carapace-bridge/pkg/env"
 )
+
+func filterNativeCompletions(uniqueNames map[string]bool, nativeNames []string, m completer.CompleterMap, chosenNames map[string]bool) {
+	for _, name := range nativeNames {
+		if chosenNames[name] {
+			continue
+		}
+
+		hasNonBridgeCompleter := false
+		for _, variant := range m[name] {
+			if variant.Group != "bridge" {
+				hasNonBridgeCompleter = true
+				break
+			}
+		}
+		if !hasNonBridgeCompleter {
+			delete(uniqueNames, name)
+		}
+	}
+}
 
 func Snippet(shell string) string {
 	uniqueNames := map[string]bool{
@@ -38,27 +58,13 @@ func Snippet(shell string) string {
 		}
 	}
 
-	switch shell { // don't bridge native completions
-	case "bash":
-		for _, name := range bridges.Bash() {
-			delete(uniqueNames, name)
-		}
-	case "fish":
-		for _, name := range bridges.Fish() {
-			delete(uniqueNames, name)
-		}
-	case "zsh":
-		for _, name := range bridges.Zsh() {
-			delete(uniqueNames, name)
-		}
-	}
-
+	chosenNames := make(map[string]bool)
 	if list, err := choices.List(false); err == nil {
 		for _, choice := range list {
 			// TODO filter by variant?? would need to read contents for that
 			//  if s != shell { // don't bridge native completions
 			uniqueNames[choice.Name] = true
-
+			chosenNames[choice.Name] = true
 		}
 	}
 
@@ -71,6 +77,16 @@ func Snippet(shell string) string {
 	for name := range m { // TODO already includes bridges and such
 		uniqueNames[name] = true
 	}
+
+	switch shell { // don't bridge native completions
+	case "bash":
+		filterNativeCompletions(uniqueNames, bridges.Bash(), m, chosenNames)
+	case "fish":
+		filterNativeCompletions(uniqueNames, bridges.Fish(), m, chosenNames)
+	case "zsh":
+		filterNativeCompletions(uniqueNames, bridges.Zsh(), m, chosenNames)
+	}
+
 	completers.RemoveExcludes(uniqueNames)
 
 	completerNames := make([]string, 0)

--- a/cmd/carapace/cmd/snippet/snippet_test.go
+++ b/cmd/carapace/cmd/snippet/snippet_test.go
@@ -1,0 +1,150 @@
+package snippet
+
+import (
+	"testing"
+
+	"github.com/carapace-sh/carapace-bin/cmd/carapace/cmd/completers"
+	"github.com/carapace-sh/carapace-bin/pkg/completer"
+)
+
+func TestFilterNativeCompletions(t *testing.T) {
+	tests := map[string]struct {
+		nativeNames []string
+		completers  completer.CompleterMap
+		chosenNames map[string]bool
+		expected    map[string]bool
+	}{
+		"bridge only": {
+			nativeNames: []string{"native"},
+			completers: completer.CompleterMap{
+				"native": {
+					{Group: "bridge", Variant: "bash"},
+					{Group: "bridge", Variant: "zsh"},
+				},
+			},
+			expected: map[string]bool{"other": true},
+		},
+		"bridge and non-bridge": {
+			nativeNames: []string{"common", "other-group", "platform", "system", "user"},
+			completers: completer.CompleterMap{
+				"common":      {{Group: "bridge"}, {Group: "common"}},
+				"other-group": {{Group: "bridge"}, {Group: "custom"}},
+				"platform":    {{Group: "bridge"}, {Group: "darwin"}},
+				"system":      {{Group: "bridge"}, {Group: "system"}},
+				"user":        {{Group: "bridge"}, {Group: "user"}},
+			},
+			expected: map[string]bool{
+				"common":      true,
+				"other":       true,
+				"other-group": true,
+				"platform":    true,
+				"system":      true,
+				"user":        true,
+			},
+		},
+		"chosen bridge": {
+			nativeNames: []string{"chosen", "unchosen"},
+			completers: completer.CompleterMap{
+				"chosen":   {{Group: "bridge"}},
+				"unchosen": {{Group: "bridge"}},
+			},
+			chosenNames: map[string]bool{"chosen": true},
+			expected:    map[string]bool{"chosen": true, "other": true},
+		},
+		"non-native bridge": {
+			nativeNames: []string{"native"},
+			completers: completer.CompleterMap{
+				"native":     {{Group: "bridge"}},
+				"non-native": {{Group: "bridge"}},
+			},
+			expected: map[string]bool{"non-native": true, "other": true},
+		},
+		"missing variants": {
+			nativeNames: []string{"empty", "missing"},
+			completers: completer.CompleterMap{
+				"empty": {},
+			},
+			expected: map[string]bool{"other": true},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			uniqueNames := map[string]bool{"other": true}
+			for completerName := range test.completers {
+				uniqueNames[completerName] = true
+			}
+
+			filterNativeCompletions(uniqueNames, test.nativeNames, test.completers, test.chosenNames)
+
+			if !equalNames(uniqueNames, test.expected) {
+				t.Fatalf("expected %#v, got %#v", test.expected, uniqueNames)
+			}
+		})
+	}
+}
+
+func TestFilterNativeCompletionsShells(t *testing.T) {
+	for _, shell := range []string{"bash", "fish", "zsh"} {
+		t.Run(shell, func(t *testing.T) {
+			uniqueNames := map[string]bool{
+				"native":     true,
+				"non-native": true,
+			}
+			m := completer.CompleterMap{
+				"native":     {{Group: "bridge"}},
+				"non-native": {{Group: "bridge"}},
+			}
+
+			filterNativeCompletions(uniqueNames, []string{"native"}, m, nil)
+
+			expected := map[string]bool{"non-native": true}
+			if !equalNames(uniqueNames, expected) {
+				t.Fatalf("expected %#v, got %#v", expected, uniqueNames)
+			}
+		})
+	}
+}
+
+func TestRemoveExcludesAfterFilterNativeCompletions(t *testing.T) {
+	tests := map[string]struct {
+		completers  completer.Completers
+		chosenNames map[string]bool
+	}{
+		"chosen bridge": {
+			completers:  completer.Completers{{Group: "bridge"}},
+			chosenNames: map[string]bool{"native": true},
+		},
+		"mixed variants": {
+			completers: completer.Completers{{Group: "bridge"}, {Group: "common"}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("CARAPACE_EXCLUDES", "native")
+
+			uniqueNames := map[string]bool{"native": true}
+			m := completer.CompleterMap{"native": test.completers}
+
+			filterNativeCompletions(uniqueNames, []string{"native"}, m, test.chosenNames)
+			completers.RemoveExcludes(uniqueNames)
+
+			if len(uniqueNames) != 0 {
+				t.Fatalf("expected excluded native completer to be removed, got %#v", uniqueNames)
+			}
+		})
+	}
+}
+
+func equalNames(actual, expected map[string]bool) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for name, value := range expected {
+		if actual[name] != value {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Build the complete completer map before applying the target shell's native-name filter, and factor the filter/predicate into a small testable unit in `snippet.go` so it can distinguish bridge-only entries from entries containing any `user`, `system`, platform, `common`, or other non-bridge variant. `cmd/carapace/cmd/root.go` routes `_carapace <shell>` startup generation through `snippet.Snippet`, which is therefore the wiring point that decides which command names carapace registers in Bash, Fish, and Zsh.

Happy path: with a command present in the target shell's native-name set and represented only by one or more `Group: "bridge"` variants, the filtering helper removes it so the rendered startup registration can leave completion to the native shell; Happy path: with the same native name represented by both a bridge and a `common`, platform, `system`, or `user` variant, the name remains registered so carapace's higher-priority completer wins.

Fixes #3606
