### PR TITLE
paru: add root-level and pacman operation flags

### DIFF
--- a/completers/linux/paru_completer/cmd/root.go
+++ b/completers/linux/paru_completer/cmd/root.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/linux/paru_completer/cmd/common"
 	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/paru"
 	"github.com/carapace-sh/carapace-bin/pkg/util/embed"
+	"github.com/carapace-sh/carapace/pkg/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -22,10 +24,39 @@ func Execute() error {
 func init() {
 	carapace.Gen(rootCmd).Standalone()
 
+	rootCmd.Flags().String("arch", "", "set an alternate architecture")
+	rootCmd.Flags().String("ask", "", "pre-specify answers for questions")
+	rootCmd.Flags().String("cachedir", "", "set an alternate package cache location")
 	rootCmd.Flags().CountP("clean", "c", "Remove unneeded dependencies")
+	rootCmd.Flags().String("color", "", "colorize the output")
+	rootCmd.Flags().String("config", "", "set an alternate configuration file")
+	rootCmd.Flags().Bool("confirm", false, "always ask for confirmation")
+	rootCmd.Flags().StringP("dbpath", "b", "", "set an alternate database location")
+	rootCmd.Flags().Bool("debug", false, "display debug messages")
+	rootCmd.Flags().Bool("disable-download-timeout", false, "use relaxed timeouts for download")
 	rootCmd.Flags().Bool("gendb", false, "Generates development package DB used for updating")
+	rootCmd.Flags().String("gpgdir", "", "set an alternate home directory for GnuPG")
 	rootCmd.Flags().BoolP("help", "h", false, "show help")
+	rootCmd.Flags().String("hookdir", "", "set an alternate hook location")
+	rootCmd.Flags().String("logfile", "", "set an alternate log file")
+	rootCmd.Flags().Bool("noconfirm", false, "do not ask for any confirmation")
+	rootCmd.Flags().StringP("root", "r", "", "set an alternate installation root")
+	rootCmd.Flags().Bool("sysroot", false, "operate on a mounted guest system (root-only)")
+	rootCmd.Flags().BoolP("verbose", "v", false, "be verbose")
 	rootCmd.Flags().BoolP("version", "V", false, "show version")
+	common.AddNewFlags(rootCmd)
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"arch":     carapace.ActionValues("i686", "x86_64"),
+		"cachedir": carapace.ActionDirectories(),
+		"color":    carapace.ActionValues("auto", "never", "always").StyleF(style.ForKeyword),
+		"config":   carapace.ActionFiles(),
+		"dbpath":   carapace.ActionFiles(),
+		"gpgdir":   carapace.ActionDirectories(),
+		"hookdir":  carapace.ActionDirectories(),
+		"logfile":  carapace.ActionFiles(),
+		"root":     carapace.ActionDirectories(),
+	})
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {


### PR DESCRIPTION
Closes #3657.

## Before

```
$ carapace paru export paru --makepkg ""
{"messages":["unknown flag: --makepkg"], "values":[]}
```

paru accepts its own options and the pacman globals *before* an operation, but the root command declared only a handful (`-c`, `--gendb`, `-h`, `-V`), so completing any of the rest failed.

## After

```
--makepkg   -> usage "makepkg command to use", completes files/executables
--bottomup  -> ok, consumes nothing
--sortby    -> base, baseid, id, modified, name, popularity, submitted, votes
--color     -> always (green), auto (yellow), never (red)
--repo      -> ok
--nosuchflag -> still "unknown flag: --nosuchflag"
```

## Following the yay precedent

You did this exact thing for yay in e731880f, so I mirrored it — same alphabetical ordering, same lowercase pacman-style descriptions, same `FlagCompletion(carapace.ActionMap{...})` shape with `style.ForKeyword` for `--color`.

One deliberate difference: yay had no shared helper, so that commit inlined ~26 flag declarations. paru already has `cmd/common/new.go` with `common.AddNewFlags`, carrying all ~85 paru-specific "new options" with their completions — every operation subcommand applies it, but root never did. So rather than duplicating that block, root now calls `common.AddNewFlags(rootCmd)`, which is one line and keeps root in sync with the subcommands automatically. The 19 explicit declarations are the pacman globals (`--arch`, `--dbpath`, `--color`, `--noconfirm`, …) that `common` doesn't carry.

## Where the flag list came from

Not from memory: paru's own source at `Morganamilo/paru@master` — `src/command_line.rs` (the `handle_arg` match arms are the authoritative long-flag list, and `takes_value()` says which take a String), plus `PACMAN_GLOBALS` in `src/args.rs`. Cross-checked against `man/paru.8`. The completion descriptions for the globals are copied from paru's own `sync.go` so the wording matches the rest of the repo.

## One thing this does not fix

The issue's full repro line still errors, now differently:

```
$ carapace paru export paru --makepkg X --nocheck -Ql refin
unknown shorthand flag: 'Q' in -Ql
```

That's a separate limitation in `embed.SubcommandsAsFlags`, which only inspects `args[0]`, so an operation shorthand appearing *after* other flags is never mapped to its subcommand. `yay --makepkg /bin/makepkg -Ql refin` behaves identically, so e731880f didn't address it either. Happy to look at that separately if you want it — it seemed like a different change from the one reported.

`go build ./...` is clean.
