### PR TITLE
fix: guard the error in filepath.Walk callbacks

### DIFF
--- a/pkg/actions/tools/golang/funcs.go
+++ b/pkg/actions/tools/golang/funcs.go
@@ -51,6 +51,9 @@ func ActionFuncs(files ...string) carapace.Action {
 		// TODO optimize performance - goroutines?
 		if len(files) == 0 {
 			filepath.Walk(filepath.Dir(root), func(path string, info fs.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
 				if !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
 					for _, name := range readFuncs(path) {
 						names[name] = true

--- a/pkg/actions/tools/golang/golang.go
+++ b/pkg/actions/tools/golang/golang.go
@@ -28,6 +28,9 @@ func ActionBuildTags() carapace.Action {
 		tags := make(map[string]bool)
 
 		filepath.Walk(filepath.Dir(root), func(path string, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if !info.IsDir() && strings.HasSuffix(path, ".go") {
 				for _, tag := range readTags(path) {
 					tags[tag] = true

--- a/pkg/actions/tools/pass/pass.go
+++ b/pkg/actions/tools/pass/pass.go
@@ -48,6 +48,9 @@ func ActionPasswords() carapace.Action {
 		} else {
 			names := make([]string, 0)
 			filepath.Walk(path, func(walkPath string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
 				if !info.IsDir() && strings.HasSuffix(info.Name(), ".gpg") {
 					names = append(names, strings.TrimSuffix(strings.TrimPrefix(walkPath, path+"/"), ".gpg"))
 				}


### PR DESCRIPTION
Closes #3704.

## The crash

`filepath.Walk` calls the callback as `fn(root, nil, err)` when it can't `Lstat` the root. Three callbacks reach for `info` before looking at `err`, so a missing or unreadable directory panics instead of completing nothing:

```
$ PASSWORD_STORE_DIR=/tmp/does-not-exist carapace pass export bash pass show ""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18]
...ActionPasswords.func1.1(...) pkg/actions/tools/pass/pass.go:51
```

after:

```
{"messages":[],"values":[]}
```

## The fix

The same three-line guard `pkg/actions/tools/mvn/goal.go:82` already uses:

```go
if err != nil {
    return err
}
```

applied to `pass/pass.go:51`, `golang/golang.go:31` and `golang/funcs.go:54`.

## Reproduced against the real binary, not a harness

All three panics, and all three now clean:

| site | trigger |
|---|---|
| `pass` | `PASSWORD_STORE_DIR` pointing at a nonexistent dir |
| `golang.ActionBuildTags` | cwd under an ancestor with mode 0600 |
| `golang.ActionFuncs` | same |

Worth noting for the two golang ones: a *deleted* cwd doesn't reach them, because carapace's own `os.Getwd` fails first and returns a clean error. The reachable trigger is an unreadable ancestor, where `Getwd` succeeds but `Lstat` returns EACCES.

Happy paths still work: build tags return `release` in a test project, and `go-carpet --func` returns the full function list.

## Audit

I checked every `filepath.Walk`/`WalkDir` callback in the repo — 8 total:

- the 3 above: fixed
- `mvn/goal.go:81`, `os/kernel.go:100`, `carapace-generate/pkg/completer/optimize.go:34`: already guarded
- `carapace-generate/cmd/conditions.go:56` and `completer/completers.go:59`: unguarded, but generator-only (`go:generate`, root is a required CLI argument), so not reachable at completion time. Left alone rather than churning them.

`go build ./...` clean, `gofmt -l` clean on all three files.
