### PR TITLE
Parse runnable shim specs as YAML

### DIFF
--- a/cmd/carapace/cmd/shim/shim.go
+++ b/cmd/carapace/cmd/shim/shim.go
@@ -1,16 +1,15 @@
 package shim
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace/pkg/xdg"
+	"gopkg.in/yaml.v3"
 )
 
 func Update() error {
@@ -102,18 +101,24 @@ func (s shim) NeedsUpdate() bool {
 }
 
 func (s shim) IsRunnable() bool {
-	file, err := os.Open(s.Target)
+	content, err := os.ReadFile(s.Target)
 	if err != nil {
 		return false
 	}
-	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
+	var document yaml.Node
+	if err := yaml.Unmarshal(content, &document); err != nil || len(document.Content) != 1 {
+		return false
+	}
 
-	r := regexp.MustCompile(`^ *run:`)
-	for scanner.Scan() {
-		if r.MatchString(scanner.Text()) {
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return false
+	}
+
+	for index := 0; index < len(root.Content); index += 2 {
+		key := root.Content[index]
+		if key.Kind == yaml.ScalarNode && key.Value == "run" {
 			return true
 		}
 	}

--- a/cmd/carapace/cmd/shim/shim_test.go
+++ b/cmd/carapace/cmd/shim/shim_test.go
@@ -1,0 +1,55 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsRunnable(t *testing.T) {
+	tests := map[string]struct {
+		content string
+		want    bool
+	}{
+		"plain root key":       {content: "name: demo\nrun: echo ok\n", want: true},
+		"quoted root key":      {content: "'run':\n  - echo ok\n", want: true},
+		"mapping value":        {content: "run:\n  shell: echo ok\n", want: true},
+		"literal text":         {content: "description: |\n  run: echo no\n", want: false},
+		"folded text":          {content: "description: >\n  run: echo no\n", want: false},
+		"nested key":           {content: "command:\n  run: echo no\n", want: false},
+		"comment":              {content: "name: demo\n# run: echo no\n", want: false},
+		"malformed":            {content: "run: [\n", want: false},
+		"empty":                {content: "", want: false},
+		"scalar root":          {content: "run echo no\n", want: false},
+		"sequence root":        {content: "- run: echo no\n", want: false},
+		"missing root run key": {content: "name: demo\n", want: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "spec.yaml")
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			candidate := shim{Target: path}
+			for attempt := 0; attempt < 2; attempt++ {
+				if got := candidate.IsRunnable(); got != test.want {
+					t.Fatalf("IsRunnable() = %v, want %v", got, test.want)
+				}
+			}
+
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(content) != test.content {
+				t.Fatal("IsRunnable modified the spec")
+			}
+		})
+	}
+
+	if (shim{Target: filepath.Join(t.TempDir(), "missing.yaml")}).IsRunnable() {
+		t.Fatal("IsRunnable() = true for a missing file")
+	}
+}


### PR DESCRIPTION
Fixes #2901

## Summary

- parse shim specs as YAML instead of scanning raw lines
- require a direct `run` key on the document's mapping root
- cover scalar text, nesting, malformed YAML, non-mapping roots, and read failures

## Validation

- `go test -count=1 -v ./cmd/carapace/cmd/shim`
- `go generate ./cmd/...`
- `go install -v -tags force_all ./cmd/carapace`
- `staticcheck ./cmd/carapace/cmd/shim`
- `gofmt -d -s cmd/carapace/cmd/shim/shim.go cmd/carapace/cmd/shim/shim_test.go`
- `git diff --check`

`go test -count=1 -v ./cmd/...` also ran. Its two existing invoke-completion tests fail because the sandbox's `carapace` resolves to `./carapace`; the same failures were reproduced from an exact-base `git archive` control. The shim package and all other reported command packages pass.
