### PR TITLE
brew: added services and bundle

### DIFF
--- a/completers/common/brew_completer/cmd/action/bundle.go
+++ b/completers/common/brew_completer/cmd/action/bundle.go
@@ -1,0 +1,51 @@
+package action
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var bundleTypes = []string{"cargo", "cask", "flatpak", "formula", "go", "krew", "mas", "npm", "tap", "uv", "vscode", "winget"}
+
+// ActionBundleEntries completes entries of the Brewfile
+func ActionBundleEntries(cmd *cobra.Command) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		args := []string{"bundle", "list"}
+		if flag := cmd.Flag("file"); flag != nil && flag.Changed {
+			args = append(args, "--file", flag.Value.String())
+		}
+		if flag := cmd.Flag("global"); flag != nil && flag.Changed {
+			args = append(args, "--global")
+		}
+		for _, t := range bundleTypes {
+			if flag := cmd.Flag(t); flag != nil && flag.Changed {
+				args = append(args, "--"+t)
+			}
+		}
+
+		c.Setenv("HOMEBREW_NO_AUTO_UPDATE", "1")
+		return carapace.ActionExecCommand("brew", args...)(func(output []byte) carapace.Action {
+			lines := strings.Split(string(output), "\n")
+			return carapace.ActionValues(lines[:len(lines)-1]...)
+		}).Tag("bundle entries")
+	})
+}
+
+// ActionBundlePackages completes packages of the Brewfile entry type selected by flag
+func ActionBundlePackages(cmd *cobra.Command) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if flag := cmd.Flag("tap"); flag != nil && flag.Changed {
+			return brew.ActionInstalledTaps()
+		}
+
+		for _, t := range []string{"cargo", "flatpak", "go", "krew", "npm", "uv", "vscode"} {
+			if flag := cmd.Flag(t); flag != nil && flag.Changed {
+				return carapace.ActionValues()
+			}
+		}
+		return ActionSearch(cmd)
+	})
+}

--- a/completers/common/brew_completer/cmd/bundle.go
+++ b/completers/common/brew_completer/cmd/bundle.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundleCmd = &cobra.Command{
+	Use:     "bundle",
+	Short:   "Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store, Visual Studio Code and more",
+	GroupID: "main",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundleCmd).Standalone()
+
+	bundleCmd.PersistentFlags().String("file", "", "Read from or write to the `Brewfile` from this location. Use `--file=-` to pipe to stdin/stdout.")
+	bundleCmd.PersistentFlags().BoolP("global", "g", false, "Read from or write to the `Brewfile` from `$HOMEBREW_BUNDLE_FILE_GLOBAL` (if set), `${XDG_CONFIG_HOME}/homebrew/Brewfile` (if `$XDG_CONFIG_HOME` is set), `~/.homebrew/Brewfile` or `~/.Brewfile` otherwise.")
+
+	bundleCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundleCmd.Flags().Bool("help", false, "Show this message.")
+	bundleCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundleCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	rootCmd.AddCommand(bundleCmd)
+
+	carapace.Gen(bundleCmd).FlagCompletion(carapace.ActionMap{
+		"file": carapace.ActionFiles(),
+	})
+}

--- a/completers/common/brew_completer/cmd/bundle_add.go
+++ b/completers/common/brew_completer/cmd/bundle_add.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/brew_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var bundle_addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add entries to your `Brewfile`",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_addCmd).Standalone()
+
+	bundle_addCmd.Flags().Bool("cargo", false, "Add entries for Cargo packages.")
+	bundle_addCmd.Flags().Bool("cask", false, "Add Homebrew cask entries.")
+	bundle_addCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_addCmd.Flags().Bool("flatpak", false, "Add entries for Flatpak packages. Note: Linux only.")
+	bundle_addCmd.Flags().Bool("formula", false, "Add Homebrew formula entries.")
+	bundle_addCmd.Flags().Bool("go", false, "Add entries for Go packages.")
+	bundle_addCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_addCmd.Flags().Bool("install", false, "Run `install` before adding entries.")
+	bundle_addCmd.Flags().Bool("krew", false, "Add entries for Krew plugins.")
+	bundle_addCmd.Flags().Bool("no-describe", false, "Do not add description comments above each line. Description comments are the default. Enabled by default if `$HOMEBREW_BUNDLE_NO_DESCRIBE` is set.")
+	bundle_addCmd.Flags().Bool("npm", false, "Add entries for npm packages.")
+	bundle_addCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_addCmd.Flags().Bool("tap", false, "Add Homebrew tap entries.")
+	bundle_addCmd.Flags().Bool("uv", false, "Add entries for uv tools.")
+	bundle_addCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundle_addCmd.Flags().Bool("vscode", false, "Add entries for VSCode (and forks/variants) extensions.")
+	bundleCmd.AddCommand(bundle_addCmd)
+
+	carapace.Gen(bundle_addCmd).PositionalAnyCompletion(
+		action.ActionBundlePackages(bundle_addCmd).FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/bundle_check.go
+++ b/completers/common/brew_completer/cmd/bundle_check.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check if all dependencies present in the `Brewfile` are installed",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_checkCmd).Standalone()
+
+	bundle_checkCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_checkCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_checkCmd.Flags().Bool("install", false, "Run `install` before checking dependencies.")
+	bundle_checkCmd.Flags().Bool("no-upgrade", false, "Do not check for outdated dependencies. Note they may still be upgraded by `brew install` if needed. Enabled by default if `$HOMEBREW_BUNDLE_NO_UPGRADE` is set.")
+	bundle_checkCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_checkCmd.Flags().BoolP("verbose", "v", false, "List all missing dependencies.")
+	bundleCmd.AddCommand(bundle_checkCmd)
+}

--- a/completers/common/brew_completer/cmd/bundle_cleanup.go
+++ b/completers/common/brew_completer/cmd/bundle_cleanup.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_cleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Uninstall all dependencies not present in the `Brewfile`",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_cleanupCmd).Standalone()
+
+	bundle_cleanupCmd.Flags().Bool("all", false, "Clean up all supported dependencies.")
+	bundle_cleanupCmd.Flags().Bool("cargo", false, "Clean up Cargo packages.")
+	bundle_cleanupCmd.Flags().Bool("cask", false, "Clean up Homebrew cask dependencies.")
+	bundle_cleanupCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_cleanupCmd.Flags().Bool("flatpak", false, "Clean up Flatpak packages. Note: Linux only.")
+	bundle_cleanupCmd.Flags().BoolP("force", "f", false, "Actually perform cleanup operations and reset Homebrew's global trust store to the `Brewfile` values.")
+	bundle_cleanupCmd.Flags().Bool("formula", false, "Clean up Homebrew formula dependencies.")
+	bundle_cleanupCmd.Flags().Bool("go", false, "Clean up Go packages.")
+	bundle_cleanupCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_cleanupCmd.Flags().Bool("install", false, "Run `install` before cleaning up dependencies.")
+	bundle_cleanupCmd.Flags().Bool("krew", false, "Clean up Krew plugins.")
+	bundle_cleanupCmd.Flags().Bool("mas", false, "Clean up Mac App Store dependencies.")
+	bundle_cleanupCmd.Flags().Bool("no-cargo", false, "`cleanup` without Cargo packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_CARGO` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cask", false, "Clean up without Homebrew cask dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_CASK` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-brew", false, "Clean up without Homebrew formula dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_BREW` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-cargo", false, "`cleanup` without Cargo packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_CARGO` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-cask", false, "Clean up without Homebrew cask dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_CASK` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-flatpak", false, "`cleanup` without Flatpak packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_FLATPAK` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-go", false, "`cleanup` without Go packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_GO` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-krew", false, "`cleanup` without Krew plugins. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_KREW` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-mas", false, "`cleanup` without Mac App Store dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_MAS` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-npm", false, "`cleanup` without npm packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_NPM` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-tap", false, "Clean up without Homebrew tap dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_TAP` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-uv", false, "`cleanup` without uv tools. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_UV` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-vscode", false, "`cleanup` without VSCode (and forks/variants) extensions. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_VSCODE` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-cleanup-winget", false, "`cleanup` without WinGet packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_WINGET` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-flatpak", false, "`cleanup` without Flatpak packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_FLATPAK` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-formula", false, "Clean up without Homebrew formula dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_BREW` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-go", false, "`cleanup` without Go packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_GO` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-krew", false, "`cleanup` without Krew plugins. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_KREW` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-mas", false, "`cleanup` without Mac App Store dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_MAS` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-npm", false, "`cleanup` without npm packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_NPM` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-tap", false, "Clean up without Homebrew tap dependencies. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_TAP` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-uv", false, "`cleanup` without uv tools. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_UV` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-vscode", false, "`cleanup` without VSCode (and forks/variants) extensions. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_VSCODE` is set.")
+	bundle_cleanupCmd.Flags().Bool("no-winget", false, "`cleanup` without WinGet packages. Enabled by default if `$HOMEBREW_BUNDLE_CLEANUP_NO_WINGET` is set.")
+	bundle_cleanupCmd.Flags().Bool("npm", false, "Clean up npm packages.")
+	bundle_cleanupCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_cleanupCmd.Flags().Bool("tap", false, "Clean up Homebrew tap dependencies.")
+	bundle_cleanupCmd.Flags().Bool("uv", false, "Clean up uv tools.")
+	bundle_cleanupCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundle_cleanupCmd.Flags().Bool("vscode", false, "Clean up VSCode (and forks/variants) extensions.")
+	bundle_cleanupCmd.Flags().Bool("winget", false, "Clean up WinGet packages. Note: WSL only.")
+	bundle_cleanupCmd.Flags().Bool("zap", false, "Clean up casks using the `zap` command instead of `uninstall`.")
+	bundleCmd.AddCommand(bundle_cleanupCmd)
+}

--- a/completers/common/brew_completer/cmd/bundle_dump.go
+++ b/completers/common/brew_completer/cmd/bundle_dump.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_dumpCmd = &cobra.Command{
+	Use:   "dump",
+	Short: "Write all installed casks/formulae/images/taps into a `Brewfile`",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_dumpCmd).Standalone()
+
+	bundle_dumpCmd.Flags().Bool("cargo", false, "Dump Cargo packages.")
+	bundle_dumpCmd.Flags().Bool("cask", false, "Dump Homebrew cask dependencies.")
+	bundle_dumpCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_dumpCmd.Flags().Bool("flatpak", false, "Dump Flatpak packages. Note: Linux only.")
+	bundle_dumpCmd.Flags().BoolP("force", "f", false, "Overwrite an existing `Brewfile`.")
+	bundle_dumpCmd.Flags().Bool("formula", false, "Dump Homebrew formula dependencies.")
+	bundle_dumpCmd.Flags().Bool("go", false, "Dump Go packages.")
+	bundle_dumpCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_dumpCmd.Flags().Bool("install", false, "Run `install` before dumping dependencies.")
+	bundle_dumpCmd.Flags().Bool("krew", false, "Dump Krew plugins.")
+	bundle_dumpCmd.Flags().Bool("mas", false, "Dump Mac App Store dependencies.")
+	bundle_dumpCmd.Flags().Bool("no-cargo", false, "`dump` without Cargo packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_CARGO` is set.")
+	bundle_dumpCmd.Flags().Bool("no-cask", false, "Dump without Homebrew cask dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_CASK` is set.")
+	bundle_dumpCmd.Flags().Bool("no-describe", false, "Do not add description comments above each line. Description comments are the default. Enabled by default if `$HOMEBREW_BUNDLE_NO_DESCRIBE` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-brew", false, "Dump without Homebrew formula dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_BREW` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-cargo", false, "`dump` without Cargo packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_CARGO` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-cask", false, "Dump without Homebrew cask dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_CASK` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-flatpak", false, "`dump` without Flatpak packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_FLATPAK` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-go", false, "`dump` without Go packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_GO` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-krew", false, "`dump` without Krew plugins. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_KREW` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-mas", false, "`dump` without Mac App Store dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_MAS` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-npm", false, "`dump` without npm packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_NPM` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-tap", false, "Dump without Homebrew tap dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_TAP` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-uv", false, "`dump` without uv tools. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_UV` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-vscode", false, "`dump` without VSCode (and forks/variants) extensions. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_VSCODE` is set.")
+	bundle_dumpCmd.Flags().Bool("no-dump-winget", false, "`dump` without WinGet packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_WINGET` is set.")
+	bundle_dumpCmd.Flags().Bool("no-flatpak", false, "`dump` without Flatpak packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_FLATPAK` is set.")
+	bundle_dumpCmd.Flags().Bool("no-formula", false, "Dump without Homebrew formula dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_BREW` is set.")
+	bundle_dumpCmd.Flags().Bool("no-go", false, "`dump` without Go packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_GO` is set.")
+	bundle_dumpCmd.Flags().Bool("no-krew", false, "`dump` without Krew plugins. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_KREW` is set.")
+	bundle_dumpCmd.Flags().Bool("no-mas", false, "`dump` without Mac App Store dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_MAS` is set.")
+	bundle_dumpCmd.Flags().Bool("no-npm", false, "`dump` without npm packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_NPM` is set.")
+	bundle_dumpCmd.Flags().Bool("no-restart", false, "Do not add `restart_service` to formula lines.")
+	bundle_dumpCmd.Flags().Bool("no-tap", false, "Dump without Homebrew tap dependencies. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_TAP` is set.")
+	bundle_dumpCmd.Flags().Bool("no-uv", false, "`dump` without uv tools. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_UV` is set.")
+	bundle_dumpCmd.Flags().Bool("no-vscode", false, "`dump` without VSCode (and forks/variants) extensions. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_VSCODE` is set.")
+	bundle_dumpCmd.Flags().Bool("no-winget", false, "`dump` without WinGet packages. Enabled by default if `$HOMEBREW_BUNDLE_DUMP_NO_WINGET` is set.")
+	bundle_dumpCmd.Flags().Bool("npm", false, "Dump npm packages.")
+	bundle_dumpCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_dumpCmd.Flags().Bool("tap", false, "Dump Homebrew tap dependencies.")
+	bundle_dumpCmd.Flags().Bool("uv", false, "Dump uv tools.")
+	bundle_dumpCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundle_dumpCmd.Flags().Bool("vscode", false, "Dump VSCode (and forks/variants) extensions.")
+	bundle_dumpCmd.Flags().Bool("winget", false, "Dump WinGet packages. Note: WSL only.")
+	bundleCmd.AddCommand(bundle_dumpCmd)
+}

--- a/completers/common/brew_completer/cmd/bundle_edit.go
+++ b/completers/common/brew_completer/cmd/bundle_edit.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_editCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Edit the `Brewfile` in your editor",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_editCmd).Standalone()
+
+	bundle_editCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_editCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_editCmd.Flags().Bool("install", false, "Run `install` before editing the `Brewfile`.")
+	bundle_editCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_editCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundleCmd.AddCommand(bundle_editCmd)
+}

--- a/completers/common/brew_completer/cmd/bundle_env.go
+++ b/completers/common/brew_completer/cmd/bundle_env.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Print the environment variables that would be set in a `brew bundle exec` environment",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_envCmd).Standalone()
+
+	bundle_envCmd.Flags().Bool("check", false, "Check that all dependencies in the Brewfile are installed before printing the environment. Enabled by default if `$HOMEBREW_BUNDLE_CHECK` is set.")
+	bundle_envCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_envCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_envCmd.Flags().Bool("install", false, "Run `install` before printing the environment.")
+	bundle_envCmd.Flags().Bool("no-secrets", false, "Attempt to remove secrets from the environment before printing it.")
+	bundle_envCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_envCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundleCmd.AddCommand(bundle_envCmd)
+}

--- a/completers/common/brew_completer/cmd/bundle_exec.go
+++ b/completers/common/brew_completer/cmd/bundle_exec.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bridge/pkg/actions/bridge"
+	"github.com/spf13/cobra"
+)
+
+var bundle_execCmd = &cobra.Command{
+	Use:   "exec",
+	Short: "Run an external command in an isolated build environment based on the `Brewfile` dependencies",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_execCmd).Standalone()
+
+	bundle_execCmd.Flags().SetInterspersed(false)
+
+	bundle_execCmd.Flags().Bool("check", false, "Check that all dependencies in the Brewfile are installed before executing the command. Enabled by default if `$HOMEBREW_BUNDLE_CHECK` is set.")
+	bundle_execCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_execCmd.Flags().Bool("deny-network", false, "Deny network access from inside the sandbox.")
+	bundle_execCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_execCmd.Flags().Bool("install", false, "Run `install` before executing the command.")
+	bundle_execCmd.Flags().Bool("no-secrets", false, "Attempt to remove secrets from the environment before executing the command.")
+	bundle_execCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_execCmd.Flags().String("sandbox", "", "Run <command> in Homebrew's sandbox, allowing writes to <path> and Homebrew's temporary and cache directories.")
+	bundle_execCmd.Flags().Bool("services", false, "Temporarily start services while executing the command. Enabled by default if `$HOMEBREW_BUNDLE_SERVICES` is set.")
+	bundle_execCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundleCmd.AddCommand(bundle_execCmd)
+
+	carapace.Gen(bundle_execCmd).FlagCompletion(carapace.ActionMap{
+		"sandbox": carapace.ActionDirectories(),
+	})
+
+	carapace.Gen(bundle_execCmd).PositionalCompletion(
+		carapace.ActionExecutables(),
+	)
+
+	carapace.Gen(bundle_execCmd).PositionalAnyCompletion(
+		bridge.ActionCarapaceBin(),
+	)
+}

--- a/completers/common/brew_completer/cmd/bundle_install.go
+++ b/completers/common/brew_completer/cmd/bundle_install.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var bundle_installCmd = &cobra.Command{
+	Use:     "install",
+	Aliases: []string{"upgrade"},
+	Short:   "Install and upgrade (by default) all dependencies from the `Brewfile`",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_installCmd).Standalone()
+
+	bundle_installCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_installCmd.Flags().BoolP("force", "f", false, "Run with `--force`/`--overwrite`.")
+	bundle_installCmd.Flags().Bool("force-cleanup", false, "Perform cleanup after installing dependencies without asking. Enabled by default if `$HOMEBREW_BUNDLE_FORCE_INSTALL_CLEANUP` is set and `--global` is passed.")
+	bundle_installCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_installCmd.Flags().String("jobs", "", "Run up to this many formula installations in parallel. Defaults to 1 (sequential). Use `auto` for the number of CPU cores (max 4).")
+	bundle_installCmd.Flags().Bool("no-upgrade", false, "Do not run `brew upgrade` on outdated dependencies. Note they may still be upgraded by `brew install` if needed. Enabled by default if `$HOMEBREW_BUNDLE_NO_UPGRADE` is set.")
+	bundle_installCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_installCmd.Flags().Bool("upgrade", false, "Run `brew upgrade` on outdated dependencies, even if `$HOMEBREW_BUNDLE_NO_UPGRADE` is set.")
+	bundle_installCmd.Flags().String("upgrade-formulae", "", "Run `brew upgrade` on any of these comma-separated formulae, even if `$HOMEBREW_BUNDLE_NO_UPGRADE` is set.")
+	bundle_installCmd.Flags().BoolP("verbose", "v", false, "Print output from commands as they are run.")
+	bundle_installCmd.Flags().Bool("zap", false, "Use `zap` instead of `uninstall` when cleaning up casks after installing dependencies.")
+	bundleCmd.AddCommand(bundle_installCmd)
+
+	carapace.Gen(bundle_installCmd).FlagCompletion(carapace.ActionMap{
+		"jobs":             carapace.ActionValues("auto"),
+		"upgrade-formulae": brew.ActionAllFormulae().UniqueList(","),
+	})
+}

--- a/completers/common/brew_completer/cmd/bundle_list.go
+++ b/completers/common/brew_completer/cmd/bundle_list.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all dependencies present in the `Brewfile`",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_listCmd).Standalone()
+
+	bundle_listCmd.Flags().Bool("all", false, "List all dependencies.")
+	bundle_listCmd.Flags().Bool("cargo", false, "List Cargo packages.")
+	bundle_listCmd.Flags().Bool("cask", false, "List Homebrew cask dependencies.")
+	bundle_listCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_listCmd.Flags().Bool("flatpak", false, "List Flatpak packages. Note: Linux only.")
+	bundle_listCmd.Flags().Bool("formula", false, "List Homebrew formula dependencies.")
+	bundle_listCmd.Flags().Bool("go", false, "List Go packages.")
+	bundle_listCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_listCmd.Flags().Bool("install", false, "Run `install` before listing dependencies.")
+	bundle_listCmd.Flags().Bool("krew", false, "List Krew plugins.")
+	bundle_listCmd.Flags().Bool("mas", false, "List Mac App Store dependencies.")
+	bundle_listCmd.Flags().Bool("npm", false, "List npm packages.")
+	bundle_listCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_listCmd.Flags().Bool("tap", false, "List Homebrew tap dependencies.")
+	bundle_listCmd.Flags().Bool("uv", false, "List uv tools.")
+	bundle_listCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundle_listCmd.Flags().Bool("vscode", false, "List VSCode (and forks/variants) extensions.")
+	bundle_listCmd.Flags().Bool("winget", false, "List WinGet packages. Note: WSL only.")
+	bundleCmd.AddCommand(bundle_listCmd)
+}

--- a/completers/common/brew_completer/cmd/bundle_remove.go
+++ b/completers/common/brew_completer/cmd/bundle_remove.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/completers/common/brew_completer/cmd/action"
+	"github.com/spf13/cobra"
+)
+
+var bundle_removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove entries that match `name` from your `Brewfile`",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_removeCmd).Standalone()
+
+	bundle_removeCmd.Flags().Bool("cargo", false, "Remove entries for Cargo packages.")
+	bundle_removeCmd.Flags().Bool("cask", false, "Remove Homebrew cask entries.")
+	bundle_removeCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_removeCmd.Flags().Bool("flatpak", false, "Remove entries for Flatpak packages. Note: Linux only.")
+	bundle_removeCmd.Flags().Bool("formula", false, "Remove Homebrew formula entries, including matches against formula aliases and old names.")
+	bundle_removeCmd.Flags().Bool("go", false, "Remove entries for Go packages.")
+	bundle_removeCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_removeCmd.Flags().Bool("install", false, "Run `install` before removing entries.")
+	bundle_removeCmd.Flags().Bool("krew", false, "Remove entries for Krew plugins.")
+	bundle_removeCmd.Flags().Bool("mas", false, "Remove entries for Mac App Store dependencies.")
+	bundle_removeCmd.Flags().Bool("npm", false, "Remove entries for npm packages.")
+	bundle_removeCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_removeCmd.Flags().Bool("tap", false, "Remove Homebrew tap entries.")
+	bundle_removeCmd.Flags().Bool("uv", false, "Remove entries for uv tools.")
+	bundle_removeCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundle_removeCmd.Flags().Bool("vscode", false, "Remove entries for VSCode (and forks/variants) extensions.")
+	bundle_removeCmd.Flags().Bool("winget", false, "Remove entries for WinGet packages. Note: WSL only.")
+	bundleCmd.AddCommand(bundle_removeCmd)
+
+	carapace.Gen(bundle_removeCmd).PositionalAnyCompletion(
+		action.ActionBundleEntries(bundle_removeCmd).FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/bundle_sh.go
+++ b/completers/common/brew_completer/cmd/bundle_sh.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var bundle_shCmd = &cobra.Command{
+	Use:   "sh",
+	Short: "Run your shell in a `brew bundle exec` environment",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(bundle_shCmd).Standalone()
+
+	bundle_shCmd.Flags().Bool("check", false, "Check that all dependencies in the Brewfile are installed before starting the shell. Enabled by default if `$HOMEBREW_BUNDLE_CHECK` is set.")
+	bundle_shCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	bundle_shCmd.Flags().Bool("help", false, "Show this message.")
+	bundle_shCmd.Flags().Bool("install", false, "Run `install` before starting the shell.")
+	bundle_shCmd.Flags().Bool("no-secrets", false, "Attempt to remove secrets from the environment before starting the shell.")
+	bundle_shCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	bundle_shCmd.Flags().Bool("services", false, "Temporarily start services while running the shell. Enabled by default if `$HOMEBREW_BUNDLE_SERVICES` is set.")
+	bundle_shCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	bundleCmd.AddCommand(bundle_shCmd)
+}

--- a/completers/common/brew_completer/cmd/services.go
+++ b/completers/common/brew_completer/cmd/services.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/os"
+	"github.com/spf13/cobra"
+)
+
+var servicesCmd = &cobra.Command{
+	Use:     "services",
+	Short:   "Manage background services with macOS' `launchctl`(1) daemon manager or Linux's `systemctl`(1) service manager",
+	GroupID: "main",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(servicesCmd).Standalone()
+
+	servicesCmd.PersistentFlags().String("sudo-service-user", "", "When run as root on macOS, run the service(s) as this user.")
+
+	servicesCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	servicesCmd.Flags().Bool("help", false, "Show this message.")
+	servicesCmd.Flags().Bool("json", false, "Output as JSON.")
+	servicesCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	servicesCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	rootCmd.AddCommand(servicesCmd)
+
+	carapace.Gen(servicesCmd).FlagCompletion(carapace.ActionMap{
+		"sudo-service-user": os.ActionUsers(),
+	})
+}

--- a/completers/common/brew_completer/cmd/services_cleanup.go
+++ b/completers/common/brew_completer/cmd/services_cleanup.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var services_cleanupCmd = &cobra.Command{
+	Use:     "cleanup",
+	Aliases: []string{"clean", "cl", "rm"},
+	Short:   "Remove all unused services",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_cleanupCmd).Standalone()
+
+	services_cleanupCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_cleanupCmd.Flags().Bool("help", false, "Show this message.")
+	services_cleanupCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_cleanupCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_cleanupCmd)
+}

--- a/completers/common/brew_completer/cmd/services_info.go
+++ b/completers/common/brew_completer/cmd/services_info.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var services_infoCmd = &cobra.Command{
+	Use:     "info",
+	Aliases: []string{"i"},
+	Short:   "List all managed services for the current user (or root)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_infoCmd).Standalone()
+
+	services_infoCmd.Flags().Bool("all", false, "List all managed services.")
+	services_infoCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_infoCmd.Flags().Bool("help", false, "Show this message.")
+	services_infoCmd.Flags().Bool("json", false, "Output as JSON.")
+	services_infoCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_infoCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_infoCmd)
+
+	carapace.Gen(services_infoCmd).PositionalAnyCompletion(
+		brew.ActionServices().FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/services_kill.go
+++ b/completers/common/brew_completer/cmd/services_kill.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var services_killCmd = &cobra.Command{
+	Use:     "kill",
+	Aliases: []string{"k"},
+	Short:   "Stop the service <formula> immediately but keep it registered to launch at login (or boot)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_killCmd).Standalone()
+
+	services_killCmd.Flags().Bool("all", false, "Stop all services immediately but keep them registered to launch at login (or boot).")
+	services_killCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_killCmd.Flags().Bool("help", false, "Show this message.")
+	services_killCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_killCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_killCmd)
+
+	carapace.Gen(services_killCmd).PositionalAnyCompletion(
+		brew.ActionServices().FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/services_list.go
+++ b/completers/common/brew_completer/cmd/services_list.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var services_listCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List information about all managed services for the current user (or root)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_listCmd).Standalone()
+
+	services_listCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_listCmd.Flags().Bool("help", false, "Show this message.")
+	services_listCmd.Flags().Bool("json", false, "Output as JSON.")
+	services_listCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_listCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_listCmd)
+}

--- a/completers/common/brew_completer/cmd/services_restart.go
+++ b/completers/common/brew_completer/cmd/services_restart.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var services_restartCmd = &cobra.Command{
+	Use:     "restart",
+	Aliases: []string{"relaunch", "reload", "r"},
+	Short:   "Stop (if necessary) and start the service <formula> immediately and register it to launch at login (or boot)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_restartCmd).Standalone()
+
+	services_restartCmd.Flags().Bool("all", false, "Restart all services.")
+	services_restartCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_restartCmd.Flags().String("file", "", "Use the service file from this location to `start` the service.")
+	services_restartCmd.Flags().Bool("help", false, "Show this message.")
+	services_restartCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_restartCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_restartCmd)
+
+	carapace.Gen(services_restartCmd).FlagCompletion(carapace.ActionMap{
+		"file": carapace.ActionFiles(),
+	})
+
+	carapace.Gen(services_restartCmd).PositionalAnyCompletion(
+		brew.ActionServices().FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/services_run.go
+++ b/completers/common/brew_completer/cmd/services_run.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var services_runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the service <formula> without registering to launch at login (or boot)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_runCmd).Standalone()
+
+	services_runCmd.Flags().Bool("all", false, "Run all services without registering them to launch at login (or boot).")
+	services_runCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_runCmd.Flags().String("file", "", "Use the service file from this location to `run` the service.")
+	services_runCmd.Flags().Bool("help", false, "Show this message.")
+	services_runCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_runCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_runCmd)
+
+	carapace.Gen(services_runCmd).FlagCompletion(carapace.ActionMap{
+		"file": carapace.ActionFiles(),
+	})
+
+	carapace.Gen(services_runCmd).PositionalAnyCompletion(
+		brew.ActionServices().FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/services_start.go
+++ b/completers/common/brew_completer/cmd/services_start.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var services_startCmd = &cobra.Command{
+	Use:     "start",
+	Aliases: []string{"launch", "load", "s", "l"},
+	Short:   "Start the service <formula> immediately and register it to launch at login (or boot)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_startCmd).Standalone()
+
+	services_startCmd.Flags().Bool("all", false, "Start all services and register them to launch at login (or boot).")
+	services_startCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_startCmd.Flags().String("file", "", "Use the service file from this location to `start` the service.")
+	services_startCmd.Flags().Bool("help", false, "Show this message.")
+	services_startCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_startCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_startCmd)
+
+	carapace.Gen(services_startCmd).FlagCompletion(carapace.ActionMap{
+		"file": carapace.ActionFiles(),
+	})
+
+	carapace.Gen(services_startCmd).PositionalAnyCompletion(
+		brew.ActionServices().FilterArgs(),
+	)
+}

--- a/completers/common/brew_completer/cmd/services_stop.go
+++ b/completers/common/brew_completer/cmd/services_stop.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/brew"
+	"github.com/spf13/cobra"
+)
+
+var services_stopCmd = &cobra.Command{
+	Use:     "stop",
+	Aliases: []string{"unload", "terminate", "term", "t", "u"},
+	Short:   "Stop the service <formula> immediately and unregister it from launching at login (or boot)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(services_stopCmd).Standalone()
+
+	services_stopCmd.Flags().Bool("all", false, "Stop all services and unregister them from launching at login (or boot), unless `--keep` is specified.")
+	services_stopCmd.Flags().Bool("debug", false, "Display any debugging information.")
+	services_stopCmd.Flags().Bool("help", false, "Show this message.")
+	services_stopCmd.Flags().Bool("keep", false, "When stopped, don't unregister the service from launching at login (or boot).")
+	services_stopCmd.Flags().String("max-wait", "", "Wait at most this many seconds for `stop` to finish stopping a service. Defaults to 60. Set this to zero (0) seconds to wait indefinitely.")
+	services_stopCmd.Flags().Bool("no-wait", false, "Don't wait for `stop` to finish stopping the service.")
+	services_stopCmd.Flags().Bool("quiet", false, "Make some output more quiet.")
+	services_stopCmd.Flags().Bool("verbose", false, "Make some output more verbose.")
+	servicesCmd.AddCommand(services_stopCmd)
+
+	carapace.Gen(services_stopCmd).PositionalAnyCompletion(
+		brew.ActionServices().FilterArgs(),
+	)
+}

--- a/pkg/actions/tools/brew/service.go
+++ b/pkg/actions/tools/brew/service.go
@@ -1,0 +1,35 @@
+package brew
+
+import (
+	"encoding/json"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace/pkg/style"
+)
+
+type service struct {
+	Name   string
+	Status string
+}
+
+// ActionServices completes services
+//
+//	postgresql@17 (started)
+//	unbound (none)
+func ActionServices() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		c.Setenv("HOMEBREW_NO_AUTO_UPDATE", "1")
+		return carapace.ActionExecCommand("brew", "services", "list", "--json")(func(output []byte) carapace.Action {
+			var services []service
+			if err := json.Unmarshal(output, &services); err != nil {
+				return carapace.ActionMessage(err.Error())
+			}
+
+			vals := make([]string, 0)
+			for _, service := range services {
+				vals = append(vals, service.Name, service.Status, style.ForKeyword(service.Status, c))
+			}
+			return carapace.ActionStyledValuesDescribed(vals...)
+		}).Tag("services")
+	})
+}


### PR DESCRIPTION
Both were external commands when the completer was written and are now built into Homebrew, so #2228 never listed them.

- `services` with its eight subcommands and their aliases
- `bundle` with its eleven subcommands
- `tools.brew.Services` completing service names with their status
- Brewfile entries for `bundle remove`, packages for `bundle add`
- `bundle exec` bridges to the completer of the given command

Flags and descriptions follow brew(1) as of Homebrew 6.0.16. Both actions that shell out set `HOMEBREW_NO_AUTO_UPDATE=1`, otherwise `brew bundle list` takes 15s and prints the auto-update banner into the values.
