### PR TITLE
feat: add agy completer

### DIFF
--- a/completers/common/agy_completer/cmd/agent.go
+++ b/completers/common/agy_completer/cmd/agent.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var agentCmd = &cobra.Command{
+	Use:     "agent",
+	GroupID: "engine",
+	Short:   "List available agents",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	Aliases: []string{"agents"},
+}
+
+func init() {
+	carapace.Gen(agentCmd).Standalone()
+	rootCmd.AddCommand(agentCmd)
+}

--- a/completers/common/agy_completer/cmd/agent.go
+++ b/completers/common/agy_completer/cmd/agent.go
@@ -15,5 +15,12 @@ var agentCmd = &cobra.Command{
 
 func init() {
 	carapace.Gen(agentCmd).Standalone()
+
+	agentCmd.Flags().String("output-format", "", "Output format (json, stream-json)")
+
 	rootCmd.AddCommand(agentCmd)
+
+	carapace.Gen(agentCmd).FlagCompletion(carapace.ActionMap{
+		"output-format": carapace.ActionValues("json", "stream-json"),
+	})
 }

--- a/completers/common/agy_completer/cmd/changelog.go
+++ b/completers/common/agy_completer/cmd/changelog.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var changelogCmd = &cobra.Command{
+	Use:     "changelog",
+	GroupID: "configuration",
+	Short:   "Show changelog and release notes",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(changelogCmd).Standalone()
+	rootCmd.AddCommand(changelogCmd)
+}

--- a/completers/common/agy_completer/cmd/help.go
+++ b/completers/common/agy_completer/cmd/help.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var helpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Show help for subcommands",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(helpCmd).Standalone()
+	rootCmd.AddCommand(helpCmd)
+}

--- a/completers/common/agy_completer/cmd/install.go
+++ b/completers/common/agy_completer/cmd/install.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var installCmd = &cobra.Command{
+	Use:     "install",
+	GroupID: "configuration",
+	Short:   "Configure environment paths and shell settings",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(installCmd).Standalone()
+	rootCmd.AddCommand(installCmd)
+}

--- a/completers/common/agy_completer/cmd/install.go
+++ b/completers/common/agy_completer/cmd/install.go
@@ -14,5 +14,14 @@ var installCmd = &cobra.Command{
 
 func init() {
 	carapace.Gen(installCmd).Standalone()
+
+	installCmd.Flags().String("dir", "", "Custom install directory")
+	installCmd.Flags().Bool("skip-aliases", false, "Preserve existing agy/antigravity aliases")
+	installCmd.Flags().Bool("skip-path", false, "Do not modify the shell profile PATH")
+
 	rootCmd.AddCommand(installCmd)
+
+	carapace.Gen(installCmd).FlagCompletion(carapace.ActionMap{
+		"dir": carapace.ActionDirectories(),
+	})
 }

--- a/completers/common/agy_completer/cmd/mcp.go
+++ b/completers/common/agy_completer/cmd/mcp.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/carapace-sh/carapace"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var mcpCmd = &cobra.Command{
@@ -13,86 +12,7 @@ var mcpCmd = &cobra.Command{
 	Run:     func(cmd *cobra.Command, args []string) {},
 }
 
-var mcpAddCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Add or update an MCP server configuration",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var mcpRemoveCmd = &cobra.Command{
-	Use:   "remove",
-	Short: "Remove an MCP server configuration",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var mcpListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all configured MCP servers",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var mcpEnableCmd = &cobra.Command{
-	Use:   "enable",
-	Short: "Enable an MCP server",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var mcpDisableCmd = &cobra.Command{
-	Use:   "disable",
-	Short: "Disable an MCP server",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
 func init() {
 	carapace.Gen(mcpCmd).Standalone()
-	carapace.Gen(mcpAddCmd).Standalone()
-	carapace.Gen(mcpRemoveCmd).Standalone()
-	carapace.Gen(mcpListCmd).Standalone()
-	carapace.Gen(mcpEnableCmd).Standalone()
-	carapace.Gen(mcpDisableCmd).Standalone()
-
-	mcpCmd.AddCommand(
-		mcpAddCmd,
-		mcpRemoveCmd,
-		mcpListCmd,
-		mcpEnableCmd,
-		mcpDisableCmd,
-	)
-
 	rootCmd.AddCommand(mcpCmd)
-
-	carapace.Gen(mcpAddCmd).PositionalCompletion(
-		carapace.ActionValues(),
-		carapace.ActionExecutables(),
-	)
-
-	carapace.Gen(mcpDisableCmd).PositionalCompletion(
-		ActionMcpServers(),
-	)
-
-	carapace.Gen(mcpEnableCmd).PositionalCompletion(
-		ActionMcpServers(),
-	)
-
-	carapace.Gen(mcpRemoveCmd).PositionalCompletion(
-		ActionMcpServers(),
-	)
-}
-
-func ActionMcpServers() carapace.Action {
-	return carapace.ActionExecCommand("agy", "mcp", "list")(func(output []byte) carapace.Action {
-		lines := strings.Split(string(output), "\n")
-		vals := make([]string, 0)
-		for _, line := range lines {
-			if line == "" || strings.Contains(line, "No MCP servers") || strings.HasPrefix(line, "NAME") {
-				continue
-			}
-
-			parts := strings.Fields(line)
-			if len(parts) > 0 {
-				vals = append(vals, parts[0])
-			}
-		}
-		return carapace.ActionValues(vals...)
-	})
 }

--- a/completers/common/agy_completer/cmd/mcp.go
+++ b/completers/common/agy_completer/cmd/mcp.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var mcpCmd = &cobra.Command{
+	Use:     "mcp",
+	GroupID: "integration",
+	Short:   "Manage MCP servers (add, remove, list, enable, disable)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+var mcpAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add or update an MCP server configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var mcpRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove an MCP server configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var mcpListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all configured MCP servers",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var mcpEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable an MCP server",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var mcpDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable an MCP server",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mcpCmd).Standalone()
+	carapace.Gen(mcpAddCmd).Standalone()
+	carapace.Gen(mcpRemoveCmd).Standalone()
+	carapace.Gen(mcpListCmd).Standalone()
+	carapace.Gen(mcpEnableCmd).Standalone()
+	carapace.Gen(mcpDisableCmd).Standalone()
+
+	mcpCmd.AddCommand(
+		mcpAddCmd,
+		mcpRemoveCmd,
+		mcpListCmd,
+		mcpEnableCmd,
+		mcpDisableCmd,
+	)
+
+	rootCmd.AddCommand(mcpCmd)
+
+	carapace.Gen(mcpAddCmd).PositionalCompletion(
+		carapace.ActionValues(),
+		carapace.ActionExecutables(),
+	)
+
+	carapace.Gen(mcpDisableCmd).PositionalCompletion(
+		ActionMcpServers(),
+	)
+
+	carapace.Gen(mcpEnableCmd).PositionalCompletion(
+		ActionMcpServers(),
+	)
+
+	carapace.Gen(mcpRemoveCmd).PositionalCompletion(
+		ActionMcpServers(),
+	)
+}
+
+func ActionMcpServers() carapace.Action {
+	return carapace.ActionExecCommand("agy", "mcp", "list")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if line == "" || strings.Contains(line, "No MCP servers") || strings.HasPrefix(line, "NAME") {
+				continue
+			}
+
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				vals = append(vals, parts[0])
+			}
+		}
+		return carapace.ActionValues(vals...)
+	})
+}

--- a/completers/common/agy_completer/cmd/mcp_add.go
+++ b/completers/common/agy_completer/cmd/mcp_add.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/env"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/net/http"
+	"github.com/spf13/cobra"
+)
+
+var mcpAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add or update an MCP server configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mcpAddCmd).Standalone()
+
+	mcpAddCmd.Flags().StringArray("env", []string{}, "Environment variable (KEY=VALUE)")
+	mcpAddCmd.Flags().StringArray("header", []string{}, "HTTP header (KEY=VALUE)")
+	mcpAddCmd.Flags().String("type", "", "Server type (stdio, http)")
+
+	mcpCmd.AddCommand(mcpAddCmd)
+
+	carapace.Gen(mcpAddCmd).PositionalCompletion(
+		carapace.ActionValues(),
+		carapace.ActionExecutables(),
+	)
+
+	carapace.Gen(mcpAddCmd).FlagCompletion(carapace.ActionMap{
+		"env":    env.ActionNameValues(false),
+		"header": http.ActionRequestHeaders(),
+		"type":   carapace.ActionValues("stdio", "http"),
+	})
+}

--- a/completers/common/agy_completer/cmd/mcp_disable.go
+++ b/completers/common/agy_completer/cmd/mcp_disable.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
+	"github.com/spf13/cobra"
+)
+
+var mcpDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable an MCP server",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mcpDisableCmd).Standalone()
+	mcpCmd.AddCommand(mcpDisableCmd)
+
+	carapace.Gen(mcpDisableCmd).PositionalCompletion(
+		agy.ActionMcpServers(),
+	)
+}

--- a/completers/common/agy_completer/cmd/mcp_enable.go
+++ b/completers/common/agy_completer/cmd/mcp_enable.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
+	"github.com/spf13/cobra"
+)
+
+var mcpEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable an MCP server",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mcpEnableCmd).Standalone()
+	mcpCmd.AddCommand(mcpEnableCmd)
+
+	carapace.Gen(mcpEnableCmd).PositionalCompletion(
+		agy.ActionMcpServers(),
+	)
+}

--- a/completers/common/agy_completer/cmd/mcp_list.go
+++ b/completers/common/agy_completer/cmd/mcp_list.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var mcpListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all configured MCP servers",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mcpListCmd).Standalone()
+	mcpCmd.AddCommand(mcpListCmd)
+}

--- a/completers/common/agy_completer/cmd/mcp_remove.go
+++ b/completers/common/agy_completer/cmd/mcp_remove.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
+	"github.com/spf13/cobra"
+)
+
+var mcpRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove an MCP server configuration",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(mcpRemoveCmd).Standalone()
+	mcpCmd.AddCommand(mcpRemoveCmd)
+
+	carapace.Gen(mcpRemoveCmd).PositionalCompletion(
+		agy.ActionMcpServers(),
+	)
+}

--- a/completers/common/agy_completer/cmd/micServe.go
+++ b/completers/common/agy_completer/cmd/micServe.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var micServeCmd = &cobra.Command{
+	Use:     "mic-serve",
+	GroupID: "integration",
+	Short:   "Serve this machine's microphone to a CLI on another host",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(micServeCmd).Standalone()
+	rootCmd.AddCommand(micServeCmd)
+}

--- a/completers/common/agy_completer/cmd/models.go
+++ b/completers/common/agy_completer/cmd/models.go
@@ -14,5 +14,12 @@ var modelsCmd = &cobra.Command{
 
 func init() {
 	carapace.Gen(modelsCmd).Standalone()
+
+	modelsCmd.Flags().String("output-format", "", "Output format (json, stream-json)")
+
 	rootCmd.AddCommand(modelsCmd)
+
+	carapace.Gen(modelsCmd).FlagCompletion(carapace.ActionMap{
+		"output-format": carapace.ActionValues("json", "stream-json"),
+	})
 }

--- a/completers/common/agy_completer/cmd/models.go
+++ b/completers/common/agy_completer/cmd/models.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var modelsCmd = &cobra.Command{
+	Use:     "models",
+	GroupID: "engine",
+	Short:   "List available models",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(modelsCmd).Standalone()
+	rootCmd.AddCommand(modelsCmd)
+}

--- a/completers/common/agy_completer/cmd/plugin.go
+++ b/completers/common/agy_completer/cmd/plugin.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/carapace-sh/carapace"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var pluginCmd = &cobra.Command{
@@ -14,131 +13,7 @@ var pluginCmd = &cobra.Command{
 	Aliases: []string{"plugins"},
 }
 
-var pluginListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List imported plugins",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginImportCmd = &cobra.Command{
-	Use:   "import",
-	Short: "Import plugins from gemini or claude",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginInstallCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install a plugin (supports plugin@marketplace)",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginUninstallCmd = &cobra.Command{
-	Use:   "uninstall",
-	Short: "Uninstall a plugin",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginEnableCmd = &cobra.Command{
-	Use:   "enable",
-	Short: "Enable a plugin",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginDisableCmd = &cobra.Command{
-	Use:   "disable",
-	Short: "Disable a plugin",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginValidateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Validate a plugin",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginLinkCmd = &cobra.Command{
-	Use:   "link",
-	Short: "Generate link to a marketplace",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
-var pluginHelpCmd = &cobra.Command{
-	Use:   "help",
-	Short: "Show the plugin command list",
-	Run:   func(cmd *cobra.Command, args []string) {},
-}
-
 func init() {
 	carapace.Gen(pluginCmd).Standalone()
-	carapace.Gen(pluginListCmd).Standalone()
-	carapace.Gen(pluginImportCmd).Standalone()
-	carapace.Gen(pluginInstallCmd).Standalone()
-	carapace.Gen(pluginUninstallCmd).Standalone()
-	carapace.Gen(pluginEnableCmd).Standalone()
-	carapace.Gen(pluginDisableCmd).Standalone()
-	carapace.Gen(pluginValidateCmd).Standalone()
-	carapace.Gen(pluginLinkCmd).Standalone()
-	carapace.Gen(pluginHelpCmd).Standalone()
-
-	pluginCmd.AddCommand(
-		pluginListCmd,
-		pluginImportCmd,
-		pluginInstallCmd,
-		pluginUninstallCmd,
-		pluginEnableCmd,
-		pluginDisableCmd,
-		pluginValidateCmd,
-		pluginLinkCmd,
-		pluginHelpCmd,
-	)
-
 	rootCmd.AddCommand(pluginCmd)
-
-	carapace.Gen(pluginDisableCmd).PositionalCompletion(
-		ActionPlugins(),
-	)
-
-	carapace.Gen(pluginEnableCmd).PositionalCompletion(
-		ActionPlugins(),
-	)
-
-	carapace.Gen(pluginImportCmd).PositionalCompletion(
-		carapace.ActionValues("gemini", "claude"),
-	)
-
-	carapace.Gen(pluginInstallCmd).PositionalCompletion(
-		carapace.ActionDirectories(),
-	)
-
-	carapace.Gen(pluginLinkCmd).PositionalCompletion(
-		// TODO: update positional completion once documentation for agy plugin link is available
-		carapace.ActionValues().Usage("marketplace name"),
-		carapace.ActionValues().Usage("target"),
-	)
-
-	carapace.Gen(pluginUninstallCmd).PositionalCompletion(
-		ActionPlugins(),
-	)
-
-	carapace.Gen(pluginValidateCmd).PositionalCompletion(
-		carapace.ActionDirectories(),
-	)
-}
-
-func ActionPlugins() carapace.Action {
-	return carapace.ActionExecCommand("agy", "plugin", "list")(func(output []byte) carapace.Action {
-		lines := strings.Split(string(output), "\n")
-		vals := make([]string, 0)
-		for _, line := range lines {
-			if line == "" || strings.Contains(line, "No imported plugins") || strings.HasPrefix(line, "NAME") {
-				continue
-			}
-
-			parts := strings.Fields(line)
-			if len(parts) > 0 {
-				vals = append(vals, parts[0])
-			}
-		}
-		return carapace.ActionValues(vals...)
-	})
 }

--- a/completers/common/agy_completer/cmd/plugin.go
+++ b/completers/common/agy_completer/cmd/plugin.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var pluginCmd = &cobra.Command{
+	Use:     "plugin",
+	GroupID: "integration",
+	Short:   "Manage plugins (install, uninstall, list, enable, disable)",
+	Run:     func(cmd *cobra.Command, args []string) {},
+	Aliases: []string{"plugins"},
+}
+
+var pluginListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List imported plugins",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginImportCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import plugins from gemini or claude",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install a plugin (supports plugin@marketplace)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginLinkCmd = &cobra.Command{
+	Use:   "link",
+	Short: "Generate link to a marketplace",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+var pluginHelpCmd = &cobra.Command{
+	Use:   "help",
+	Short: "Show the plugin command list",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginCmd).Standalone()
+	carapace.Gen(pluginListCmd).Standalone()
+	carapace.Gen(pluginImportCmd).Standalone()
+	carapace.Gen(pluginInstallCmd).Standalone()
+	carapace.Gen(pluginUninstallCmd).Standalone()
+	carapace.Gen(pluginEnableCmd).Standalone()
+	carapace.Gen(pluginDisableCmd).Standalone()
+	carapace.Gen(pluginValidateCmd).Standalone()
+	carapace.Gen(pluginLinkCmd).Standalone()
+	carapace.Gen(pluginHelpCmd).Standalone()
+
+	pluginCmd.AddCommand(
+		pluginListCmd,
+		pluginImportCmd,
+		pluginInstallCmd,
+		pluginUninstallCmd,
+		pluginEnableCmd,
+		pluginDisableCmd,
+		pluginValidateCmd,
+		pluginLinkCmd,
+		pluginHelpCmd,
+	)
+
+	rootCmd.AddCommand(pluginCmd)
+
+	carapace.Gen(pluginDisableCmd).PositionalCompletion(
+		ActionPlugins(),
+	)
+
+	carapace.Gen(pluginEnableCmd).PositionalCompletion(
+		ActionPlugins(),
+	)
+
+	carapace.Gen(pluginImportCmd).PositionalCompletion(
+		carapace.ActionValues("gemini", "claude"),
+	)
+
+	carapace.Gen(pluginInstallCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+
+	carapace.Gen(pluginLinkCmd).PositionalCompletion(
+		// TODO: update positional completion once documentation for agy plugin link is available
+		carapace.ActionValues().Usage("marketplace name"),
+		carapace.ActionValues().Usage("target"),
+	)
+
+	carapace.Gen(pluginUninstallCmd).PositionalCompletion(
+		ActionPlugins(),
+	)
+
+	carapace.Gen(pluginValidateCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}
+
+func ActionPlugins() carapace.Action {
+	return carapace.ActionExecCommand("agy", "plugin", "list")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if line == "" || strings.Contains(line, "No imported plugins") || strings.HasPrefix(line, "NAME") {
+				continue
+			}
+
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				vals = append(vals, parts[0])
+			}
+		}
+		return carapace.ActionValues(vals...)
+	})
+}

--- a/completers/common/agy_completer/cmd/plugin_disable.go
+++ b/completers/common/agy_completer/cmd/plugin_disable.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
+	"github.com/spf13/cobra"
+)
+
+var pluginDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginDisableCmd).Standalone()
+	pluginCmd.AddCommand(pluginDisableCmd)
+
+	carapace.Gen(pluginDisableCmd).PositionalCompletion(
+		agy.ActionPlugins(),
+	)
+}

--- a/completers/common/agy_completer/cmd/plugin_enable.go
+++ b/completers/common/agy_completer/cmd/plugin_enable.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
+	"github.com/spf13/cobra"
+)
+
+var pluginEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginEnableCmd).Standalone()
+	pluginCmd.AddCommand(pluginEnableCmd)
+
+	carapace.Gen(pluginEnableCmd).PositionalCompletion(
+		agy.ActionPlugins(),
+	)
+}

--- a/completers/common/agy_completer/cmd/plugin_import.go
+++ b/completers/common/agy_completer/cmd/plugin_import.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var pluginImportCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import plugins from gemini or claude",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginImportCmd).Standalone()
+	pluginCmd.AddCommand(pluginImportCmd)
+
+	carapace.Gen(pluginImportCmd).PositionalCompletion(
+		carapace.ActionValues("gemini", "claude"),
+	)
+}

--- a/completers/common/agy_completer/cmd/plugin_install.go
+++ b/completers/common/agy_completer/cmd/plugin_install.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var pluginInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install a plugin (supports plugin@marketplace)",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginInstallCmd).Standalone()
+	pluginCmd.AddCommand(pluginInstallCmd)
+
+	carapace.Gen(pluginInstallCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/common/agy_completer/cmd/plugin_link.go
+++ b/completers/common/agy_completer/cmd/plugin_link.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var pluginLinkCmd = &cobra.Command{
+	Use:   "link",
+	Short: "Generate link to a marketplace",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginLinkCmd).Standalone()
+	pluginCmd.AddCommand(pluginLinkCmd)
+
+	carapace.Gen(pluginLinkCmd).PositionalCompletion(
+		carapace.ActionValues().Usage("marketplace name"),
+		carapace.ActionValues().Usage("target"),
+	)
+}

--- a/completers/common/agy_completer/cmd/plugin_list.go
+++ b/completers/common/agy_completer/cmd/plugin_list.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var pluginListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List imported plugins",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginListCmd).Standalone()
+	pluginCmd.AddCommand(pluginListCmd)
+}

--- a/completers/common/agy_completer/cmd/plugin_uninstall.go
+++ b/completers/common/agy_completer/cmd/plugin_uninstall.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
+	"github.com/spf13/cobra"
+)
+
+var pluginUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginUninstallCmd).Standalone()
+	pluginCmd.AddCommand(pluginUninstallCmd)
+
+	carapace.Gen(pluginUninstallCmd).PositionalCompletion(
+		agy.ActionPlugins(),
+	)
+}

--- a/completers/common/agy_completer/cmd/plugin_validate.go
+++ b/completers/common/agy_completer/cmd/plugin_validate.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var pluginValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate a plugin",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(pluginValidateCmd).Standalone()
+	pluginCmd.AddCommand(pluginValidateCmd)
+
+	carapace.Gen(pluginValidateCmd).PositionalCompletion(
+		carapace.ActionDirectories(),
+	)
+}

--- a/completers/common/agy_completer/cmd/root.go
+++ b/completers/common/agy_completer/cmd/root.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"github.com/carapace-sh/carapace"
+	"github.com/carapace-sh/carapace-bin/pkg/actions/tools/agy"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var rootCmd = &cobra.Command{
@@ -27,6 +27,7 @@ func init() {
 	rootCmd.Flags().String("agent", "", "Agent for the current CLI session")
 	rootCmd.Flags().BoolP("continue", "c", false, "Continue the most recent conversation")
 	rootCmd.Flags().String("conversation", "", "Resume a previous conversation by ID")
+	rootCmd.Flags().String("cwd", "", "Working directory for the run")
 	rootCmd.Flags().Bool("dangerously-skip-permissions", false, "Auto-approve all tool permission requests without prompting")
 	rootCmd.Flags().Bool("disable-slash-commands", false, "Disable slash command and skill expansion in print mode")
 	rootCmd.Flags().String("effort", "", "Reasoning effort for the current CLI session (low|medium|high)")
@@ -35,51 +36,27 @@ func init() {
 	rootCmd.Flags().String("log-file", "", "Override CLI log file path")
 	rootCmd.Flags().String("mode", "", "Set the agent execution mode for this session (accept-edits, plan)")
 	rootCmd.Flags().String("model", "", "Model for the current CLI session")
-	rootCmd.Flags().Bool("new-project", false, "Create a new project for this session")
+	rootCmd.Flags().String("new-project", "", "Create a new project with the given name")
 	rootCmd.Flags().String("output-format", "text", "Output format for print mode (text, json, stream-json)")
 	rootCmd.Flags().StringP("print", "p", "", "Run a single prompt non-interactively")
 	rootCmd.Flags().String("print-timeout", "5m0s", "Timeout for print mode wait")
 	rootCmd.Flags().String("project", "", "Project ID or project name for the current CLI session")
 	rootCmd.Flags().String("prompt", "", "Alias for --print")
 	rootCmd.Flags().StringP("prompt-interactive", "i", "", "Run an initial prompt interactively and continue the session")
+	rootCmd.Flags().Bool("remote-control", false, "Start in remote control headless daemon mode")
 	rootCmd.Flags().Bool("sandbox", false, "Run in a sandbox with terminal restrictions enabled")
+	rootCmd.Flags().Bool("version", false, "Show version")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"add-dir": carapace.ActionDirectories(),
-		"agent": carapace.ActionExecCommand("agy", "agents")(func(output []byte) carapace.Action {
-			lines := strings.Split(string(output), "\n")
-			vals := make([]string, 0)
-			for _, line := range lines {
-				if line != "" {
-					parts := strings.Fields(line)
-					if len(parts) > 0 {
-						vals = append(vals, parts[0])
-					}
-				}
-			}
-			return carapace.ActionValues(vals...)
-		}),
-		"effort":       carapace.ActionValues("low", "medium", "high"),
-		"input-format": carapace.ActionValues("text", "stream-json"),
-		"json-schema":  carapace.ActionFiles(".json"),
-		"log-file":     carapace.ActionFiles(),
-		"mode":         carapace.ActionValues("accept-edits", "plan"),
-		"model": carapace.ActionExecCommand("agy", "models")(func(output []byte) carapace.Action {
-			lines := strings.Split(string(output), "\n")
-			vals := make([]string, 0)
-			for _, line := range lines {
-				if line == "" {
-					continue
-				}
-				parts := strings.SplitN(line, "\t", 2)
-				if len(parts) == 2 {
-					vals = append(vals, parts[0], parts[1])
-				} else {
-					vals = append(vals, parts[0], "")
-				}
-			}
-			return carapace.ActionValuesDescribed(vals...)
-		}),
+		"add-dir":       carapace.ActionDirectories(),
+		"agent":         agy.ActionAgents(),
+		"cwd":           carapace.ActionDirectories(),
+		"effort":        carapace.ActionValues("low", "medium", "high"),
+		"input-format":  carapace.ActionValues("text", "stream-json"),
+		"json-schema":   carapace.ActionFiles(".json"),
+		"log-file":      carapace.ActionFiles(),
+		"mode":          carapace.ActionValues("accept-edits", "plan"),
+		"model":         agy.ActionModels(),
 		"output-format": carapace.ActionValues("text", "json", "stream-json"),
 		"print-timeout": carapace.ActionValues("30s", "1m", "10m", "1h").Usage("duration (e.g., 5m, 1h30m)"),
 	})

--- a/completers/common/agy_completer/cmd/root.go
+++ b/completers/common/agy_completer/cmd/root.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "agy",
+	Short: "Google Antigravity AI Agent command-line interface",
+	Long:  "https://antigravity.google/docs/cli",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.AddGroup(&cobra.Group{ID: "engine", Title: "Engine"})
+	rootCmd.AddGroup(&cobra.Group{ID: "integration", Title: "Integration"})
+	rootCmd.AddGroup(&cobra.Group{ID: "configuration", Title: "Configuration"})
+
+	carapace.Gen(rootCmd).Standalone()
+	rootCmd.Flags().StringArray("add-dir", []string{}, "Add a directory to the workspace")
+	rootCmd.Flags().String("agent", "", "Agent for the current CLI session")
+	rootCmd.Flags().BoolP("continue", "c", false, "Continue the most recent conversation")
+	rootCmd.Flags().String("conversation", "", "Resume a previous conversation by ID")
+	rootCmd.Flags().Bool("dangerously-skip-permissions", false, "Auto-approve all tool permission requests without prompting")
+	rootCmd.Flags().Bool("disable-slash-commands", false, "Disable slash command and skill expansion in print mode")
+	rootCmd.Flags().String("effort", "", "Reasoning effort for the current CLI session (low|medium|high)")
+	rootCmd.Flags().String("input-format", "text", "Input format for print mode (text, stream-json). stream-json reads one NDJSON message per line from stdin and runs a turn for each; it requires --output-format stream-json")
+	rootCmd.Flags().String("json-schema", "", "Optional JSON schema string or path to a schema file to enforce structured output (for stream-json, only applicable to the final result)")
+	rootCmd.Flags().String("log-file", "", "Override CLI log file path")
+	rootCmd.Flags().String("mode", "", "Set the agent execution mode for this session (accept-edits, plan)")
+	rootCmd.Flags().String("model", "", "Model for the current CLI session")
+	rootCmd.Flags().Bool("new-project", false, "Create a new project for this session")
+	rootCmd.Flags().String("output-format", "text", "Output format for print mode (text, json, stream-json)")
+	rootCmd.Flags().StringP("print", "p", "", "Run a single prompt non-interactively")
+	rootCmd.Flags().String("print-timeout", "5m0s", "Timeout for print mode wait")
+	rootCmd.Flags().String("project", "", "Project ID or project name for the current CLI session")
+	rootCmd.Flags().String("prompt", "", "Alias for --print")
+	rootCmd.Flags().StringP("prompt-interactive", "i", "", "Run an initial prompt interactively and continue the session")
+	rootCmd.Flags().Bool("sandbox", false, "Run in a sandbox with terminal restrictions enabled")
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"add-dir": carapace.ActionDirectories(),
+		"agent": carapace.ActionExecCommand("agy", "agents")(func(output []byte) carapace.Action {
+			lines := strings.Split(string(output), "\n")
+			vals := make([]string, 0)
+			for _, line := range lines {
+				if line != "" {
+					parts := strings.Fields(line)
+					if len(parts) > 0 {
+						vals = append(vals, parts[0])
+					}
+				}
+			}
+			return carapace.ActionValues(vals...)
+		}),
+		"effort":       carapace.ActionValues("low", "medium", "high"),
+		"input-format": carapace.ActionValues("text", "stream-json"),
+		"json-schema":  carapace.ActionFiles(".json"),
+		"log-file":     carapace.ActionFiles(),
+		"mode":         carapace.ActionValues("accept-edits", "plan"),
+		"model": carapace.ActionExecCommand("agy", "models")(func(output []byte) carapace.Action {
+			lines := strings.Split(string(output), "\n")
+			vals := make([]string, 0)
+			for _, line := range lines {
+				if line == "" {
+					continue
+				}
+				parts := strings.SplitN(line, "\t", 2)
+				if len(parts) == 2 {
+					vals = append(vals, parts[0], parts[1])
+				} else {
+					vals = append(vals, parts[0], "")
+				}
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		}),
+		"output-format": carapace.ActionValues("text", "json", "stream-json"),
+		"print-timeout": carapace.ActionValues("30s", "1m", "10m", "1h").Usage("duration (e.g., 5m, 1h30m)"),
+	})
+}

--- a/completers/common/agy_completer/cmd/run.go
+++ b/completers/common/agy_completer/cmd/run.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:     "run",
+	GroupID: "engine",
+	Short:   "Run the agent via the run subcommand",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(runCmd).Standalone()
+
+	runCmd.Flags().String("cwd", "", "Working directory for the run")
+	rootCmd.AddCommand(runCmd)
+
+	carapace.Gen(runCmd).FlagCompletion(carapace.ActionMap{
+		"cwd": carapace.ActionDirectories(),
+	})
+}

--- a/completers/common/agy_completer/cmd/update.go
+++ b/completers/common/agy_completer/cmd/update.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+var updateCmd = &cobra.Command{
+	Use:     "update",
+	GroupID: "configuration",
+	Short:   "Update CLI",
+	Run:     func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	carapace.Gen(updateCmd).Standalone()
+	rootCmd.AddCommand(updateCmd)
+}

--- a/completers/common/agy_completer/main.go
+++ b/completers/common/agy_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/carapace-sh/carapace-bin/completers/common/agy_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/actions/tools/agy/agy.go
+++ b/pkg/actions/tools/agy/agy.go
@@ -1,0 +1,92 @@
+package agy
+
+import (
+	"strings"
+
+	"github.com/carapace-sh/carapace"
+)
+
+// ActionAgents completes agents
+//
+//	my-agent
+//	default
+func ActionAgents() carapace.Action {
+	return carapace.ActionExecCommand("agy", "agents")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if line != "" {
+				parts := strings.Fields(line)
+				if len(parts) > 0 {
+					vals = append(vals, parts[0])
+				}
+			}
+		}
+		return carapace.ActionValues(vals...)
+	}).Tag("agents")
+}
+
+// ActionModels completes models
+//
+//	gemini-3.5-flash-medium	Gemini 3.5 Flash (Medium)
+//	claude-sonnet-4-6	Claude Sonnet 4.6 (Thinking)
+func ActionModels() carapace.Action {
+	return carapace.ActionExecCommand("agy", "models")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+			parts := strings.SplitN(line, "\t", 2)
+			if len(parts) == 2 {
+				vals = append(vals, parts[0], parts[1])
+			} else {
+				vals = append(vals, parts[0], "")
+			}
+		}
+		return carapace.ActionValuesDescribed(vals...)
+	}).Tag("models")
+}
+
+// ActionPlugins completes installed plugins
+//
+//	my-plugin
+//	example-plugin
+func ActionPlugins() carapace.Action {
+	return carapace.ActionExecCommand("agy", "plugin", "list")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if line == "" || strings.Contains(line, "No imported plugins") || strings.HasPrefix(line, "NAME") {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				vals = append(vals, parts[0])
+			}
+		}
+		return carapace.ActionValues(vals...)
+	}).Tag("plugins")
+}
+
+// ActionMcpServers completes configured MCP servers
+//
+//	my-server
+//	example-server
+func ActionMcpServers() carapace.Action {
+	return carapace.ActionExecCommand("agy", "mcp", "list")(func(output []byte) carapace.Action {
+		lines := strings.Split(string(output), "\n")
+		vals := make([]string, 0)
+		for _, line := range lines {
+			if line == "" || strings.Contains(line, "No MCP servers") || strings.HasPrefix(line, "NAME") {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				vals = append(vals, parts[0])
+			}
+		}
+		return carapace.ActionValues(vals...)
+	}).Tag("mcp servers")
+}


### PR DESCRIPTION
adds completions for the agy cli agent (google antigravity): base commands, all 9 subcommands and all the flags.

grouped the subcommands into engine, integration, and config categories to make the dropdown a bit cleaner.

i left a TODO for the `agy plugin link` arguments since the upstream docs for that aren't out yet, but everything else is working perfectly.