### PR TITLE
fix(nushell): fallback to default completions when completion is not found by carapace

### DIFF
--- a/cmd/carapace/cmd/snippet/nushell.go
+++ b/cmd/carapace/cmd/snippet/nushell.go
@@ -24,19 +24,16 @@ let carapace_completer = {|spans|
     $spans | skip 1 | prepend ($spans.0%v)
   })
 
-  if ($spans | length) == 1 {
-    null
-  } else {
-    with-env {
-      CARAPACE_SHELL: 'nushell'
-      CARAPACE_SHELL_ALIASES: (scope aliases | get name | uniq | str join "\n")
-      CARAPACE_SHELL_BUILTINS: (help commands | where category != "" | get name | each { split row " " | first } | uniq  | str join "\n")
-      CARAPACE_SHELL_FUNCTIONS: (help commands | where category == "" | get name | each { split row " " | first } | uniq  | str join "\n")
-      CARAPACE_SHELL_VARIABLES: (scope variables | get name | uniq | str join "\n")
-    } {
-      carapace $spans.0 nushell ...$spans | from json
-    }
+  let result = with-env {
+    CARAPACE_SHELL: 'nushell'
+    CARAPACE_SHELL_ALIASES: (scope aliases | get name | uniq | str join "\n")
+    CARAPACE_SHELL_BUILTINS: (help commands | where category != "" | get name | each { split row " " | first } | uniq  | str join "\n")
+    CARAPACE_SHELL_FUNCTIONS: (help commands | where category == "" | get name | each { split row " " | first } | uniq  | str join "\n")
+    CARAPACE_SHELL_VARIABLES: (scope variables | get name | uniq | str join "\n")
+  } {
+    carapace $spans.0 nushell ...$spans | from json
   }
+  if ($result | is-empty) { null } else { $out }
 }
 
 mut current = (($env | default {} config).config | default {} completions)


### PR DESCRIPTION
The initial proposed solution #3613, only solves cases where carapace is fed one command at a time.

Consider this:
```sh
zig run main.zig -- ~/Some/Pat<TAB>
```

Currently, with the above, `carapace` gives nushell an empty list, which leads to `NO RECORDS FOUND`, stopping the path from autocompleting.

The solution I'm proposing takes a look at what `carapace` returns, instead of what intput we give it. And based on the return, we either result in `null` or an empty list fed to nushell. Hopefully this covers all scenarions.

At least it fixes the issue I have above with the `zig` example, plus one-word completions like `tmux<TAB>`, like in PR I'm referencing.