### PR TITLE
docs: list experimental Cmd support on landing page

### DIFF
--- a/docs/src/carapace-bin.md
+++ b/docs/src/carapace-bin.md
@@ -6,6 +6,7 @@
 
 Supported shells:
 - [Bash](https://www.gnu.org/software/bash/)
+- [Cmd](https://en.wikipedia.org/wiki/Cmd.exe) ([experimental](https://github.com/carapace-sh/carapace/issues/1107))
 - [Elvish](https://elv.sh/)
 - [Fish](https://fishshell.com/)
 - [Ion](https://doc.redox-os.org/ion-manual/) ([experimental](https://github.com/carapace-sh/carapace/issues/88))


### PR DESCRIPTION
## Summary

Add the missing experimental Cmd/Clink entry to the documentation landing page's supported-shell list.

## Why

Cmd support is already documented in the README and setup guide, but the published landing page lists only the other ten shells. This uses the same wording and links as the README.

## Validation

- confirmed the landing-page list now matches the README's 11 supported shells
- verified both added links return HTTP 200
- `git diff --check`
