### PR TITLE
fix: remove obsolete Windows shims by actual filename

### DIFF
--- a/cmd/carapace/cmd/shim/clean.go
+++ b/cmd/carapace/cmd/shim/clean.go
@@ -1,9 +1,8 @@
 package shim
 
 import (
-	"fmt"
 	"os"
-	"runtime"
+	"path/filepath"
 	"strings"
 
 	"github.com/carapace-sh/carapace"
@@ -15,8 +14,11 @@ func removeObsolete() error {
 	if err != nil {
 		return err
 	}
+	return removeObsoleteIn(configDir)
+}
 
-	entries, err := os.ReadDir(configDir + "/carapace/bin")
+func removeObsoleteIn(configDir string) error {
+	entries, err := os.ReadDir(filepath.Join(configDir, "carapace", "bin"))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -25,12 +27,9 @@ func removeObsolete() error {
 	}
 
 	for _, entry := range entries {
-		specPath := fmt.Sprintf("%v/carapace/specs/%v.yaml", configDir, strings.TrimSuffix(entry.Name(), ".exe"))
+		specPath := filepath.Join(configDir, "carapace", "specs", strings.TrimSuffix(entry.Name(), ".exe")+".yaml")
 		if _, err := os.Stat(specPath); os.IsNotExist(err) {
-			shimPath := fmt.Sprintf("%v/carapace/bin/%v", configDir, entry.Name())
-			if runtime.GOOS == "windows" {
-				shimPath += ".exe"
-			}
+			shimPath := filepath.Join(configDir, "carapace", "bin", entry.Name())
 
 			carapace.LOG.Printf("removing shim %#v", shimPath)
 			if err := os.Remove(shimPath); err != nil {

--- a/cmd/carapace/cmd/shim/clean_test.go
+++ b/cmd/carapace/cmd/shim/clean_test.go
@@ -1,0 +1,44 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestRemoveObsolete(t *testing.T) {
+	configDir := t.TempDir()
+	binDir := filepath.Join(configDir, "carapace", "bin")
+	specDir := filepath.Join(configDir, "carapace", "specs")
+	for _, dir := range []string{binDir, specDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	extension := ""
+	if runtime.GOOS == "windows" {
+		extension = ".exe"
+	}
+	staleShim := filepath.Join(binDir, "stale"+extension)
+	currentShim := filepath.Join(binDir, "current"+extension)
+	for _, path := range []string{staleShim, currentShim} {
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(specDir, "current.yaml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeObsoleteIn(configDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(staleShim); !os.IsNotExist(err) {
+		t.Fatalf("obsolete shim still exists: %v", err)
+	}
+	if _, err := os.Stat(currentShim); err != nil {
+		t.Fatalf("current shim was removed: %v", err)
+	}
+}


### PR DESCRIPTION
On Windows, obsolete-shim cleanup tries to remove `stale.exe.exe` when the actual directory entry is `stale.exe`. Use the entry's actual filename so cleanup removes stale shims successfully. A temporary-directory regression test verifies removal and retention of a shim whose spec still exists.

Fixes #3784.

## Validation

- `go generate ./cmd/...`
- `go test -v ./cmd/carapace/cmd/shim`
- `go vet ./cmd/carapace/cmd/shim`
- `gofmt` and `git diff --check`

The complete `go test -v ./cmd/...` run passes the shim, MCP, and main package checks, but four command-invocation tests encounter Windows executable-resolution errors (`carapace resolves to executable in current directory`). No generated binaries are included in this change.
